### PR TITLE
add press 'esc' to cancel agent

### DIFF
--- a/src/hooks/use-input-handler.ts
+++ b/src/hooks/use-input-handler.ts
@@ -327,6 +327,7 @@ Available models: ${modelNames.join(", ")}`,
         return;
       }
       if (isProcessing || isStreaming) {
+        agent.abortCurrentOperation();
         setIsProcessing(false);
         setIsStreaming(false);
         setTokenCount(0);


### PR DESCRIPTION
## What does this PR do?

This pull request introduces functionality to cancel ongoing operations in the `GrokAgent` and integrates it into the user input handling flow. The changes ensure that operations can be aborted cleanly, improving responsiveness and user control.

### New cancellation functionality in `GrokAgent`:

* Added an `AbortController` to the `GrokAgent` class to manage operation cancellation (`src/agent/grok-agent.ts`, [src/agent/grok-agent.tsR37](diffhunk://#diff-61a2c527a6ad36f6898593155c2e1413b65bc671f3cb2b91eb0bd5c5777c4da4R37)).
* Incorporated checks for cancellation at key points in the `processUserMessageStream` method, including during the agent loop, streaming, and tool execution. If an operation is cancelled, a cancellation message is yielded, and the process exits gracefully (`src/agent/grok-agent.ts`, [[1]](diffhunk://#diff-61a2c527a6ad36f6898593155c2e1413b65bc671f3cb2b91eb0bd5c5777c4da4R271-R273) [[2]](diffhunk://#diff-61a2c527a6ad36f6898593155c2e1413b65bc671f3cb2b91eb0bd5c5777c4da4R299-R325) [[3]](diffhunk://#diff-61a2c527a6ad36f6898593155c2e1413b65bc671f3cb2b91eb0bd5c5777c4da4R398-R407) [[4]](diffhunk://#diff-61a2c527a6ad36f6898593155c2e1413b65bc671f3cb2b91eb0bd5c5777c4da4R454-R463).
* Added a `finally` block to reset the `AbortController` after the operation completes or is cancelled (`src/agent/grok-agent.ts`, [src/agent/grok-agent.tsR475-R477](diffhunk://#diff-61a2c527a6ad36f6898593155c2e1413b65bc671f3cb2b91eb0bd5c5777c4da4R475-R477)).
* Introduced a new `abortCurrentOperation` method to trigger the cancellation (`src/agent/grok-agent.ts`, [src/agent/grok-agent.tsR548-R553](diffhunk://#diff-61a2c527a6ad36f6898593155c2e1413b65bc671f3cb2b91eb0bd5c5777c4da4R548-R553)).

### Integration with user input handling:

* Updated the `use-input-handler` hook to call `abortCurrentOperation` when a new user input is received while processing or streaming is active (`src/hooks/use-input-handler.ts`, [src/hooks/use-input-handler.tsR330](diffhunk://#diff-8fdb6362b40b21a0b32d7cf12cb9ea401f968e231a45a40b71af8bd6e8b26bf8R330)).

## Checklist

- [x] I tested my changes
- [x] I reviewed my own code