### PR TITLE
fix: improve diff generation and multi-line string replacement for la…

### DIFF
--- a/src/agent/grok-agent.ts
+++ b/src/agent/grok-agent.ts
@@ -509,7 +509,8 @@ Current working directory: ${process.cwd()}`,
           return await this.textEditor.strReplace(
             args.path,
             args.old_str,
-            args.new_str
+            args.new_str,
+            args.replace_all
           );
 
         case "bash":

--- a/src/grok/tools.ts
+++ b/src/grok/tools.ts
@@ -62,11 +62,15 @@ export const GROK_TOOLS: GrokTool[] = [
           },
           old_str: {
             type: "string",
-            description: "Text to replace (must match exactly)",
+            description: "Text to replace (must match exactly, or will use fuzzy matching for multi-line strings)",
           },
           new_str: {
             type: "string",
             description: "Text to replace with",
+          },
+          replace_all: {
+            type: "boolean",
+            description: "Replace all occurrences (default: false, only replaces first occurrence)",
           },
         },
         required: ["path", "old_str", "new_str"],

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,6 +19,7 @@ export interface EditorCommand {
   content?: string;
   insert_line?: number;
   view_range?: [number, number];
+  replace_all?: boolean;
 }
 
 export interface AgentState {


### PR DESCRIPTION
## Summary

This PR fixes critical issues with the text editor tool's diff generation and string replacement functionality, particularly for large files. The changes significantly improve the user experience by showing only relevant context in diffs and enabling robust multi-line string replacements.

## Problem

Users reported that "the edit tool doesn't apply diffs correctly for larger files" (#[issue-number]). Investigation revealed two major issues:

1. **Excessive diff output**: For a single line change in a 336-line file, the tool displayed all 336 lines in the confirmation dialog, making it impossible to review changes effectively
2. **Failed multi-line replacements**: Multi-line string replacements failed due to formatting differences (quotes, whitespace, indentation)

### Before
- Single line change showed entire file: `@@ -1,336 +1,336 @@`
- Incorrect change count: "272 additions and 272 removals" for a 1-line change
- Multi-line replacements failed with "String not found in file"

### After
- Single line change shows only context: `@@ -62,7 +62,7 @@`
- Accurate change count: "1 addition and 1 removal"
- Multi-line replacements work with intelligent fuzzy matching

## Changes

### 1. Rewrote `generateDiff` method with proper unified diff algorithm
- Implements two-pass algorithm: first finds changes, then generates contextual hunks
- Shows only 3 lines of context before/after changes (configurable via `CONTEXT_LINES`)
- Merges nearby changes into single hunks for better readability
- Correctly calculates line numbers and change counts

### 2. Added fuzzy matching for multi-line string replacements
- New `findFuzzyMatch` method intelligently matches code blocks (especially functions)
- Uses structural matching based on brace counting and token analysis
- Handles differences in quotes, whitespace, and formatting
- Returns the actual content from the file for accurate replacement

### 3. Additional improvements
- Added `replaceAll` parameter to replace all occurrences (not just first)
- Added `replaceLines` method for line-based editing when string matching isn't suitable
- Improved user feedback with occurrence counts
- Better error messages guiding users to appropriate tools

## Testing

Tested with:
- Large files (300+ lines) with single line changes
- Multi-line function replacements with formatting differences
- Multiple scattered changes throughout a file
- Adjacent changes that should merge into single hunks

## Breaking Changes

None. The changes are backward compatible and improve existing functionality.

## Screenshots

### Before
<img width="1172" height="912" alt="Screenshot 2025-07-22 at 15 31 39" src="https://github.com/user-attachments/assets/ff33fd79-4a60-4ad3-a333-608a81cb0b0e" />


### After  
<img width="1172" height="889" alt="Screenshot 2025-07-22 at 15 50 48" src="https://github.com/user-attachments/assets/fa86c990-81ff-49dc-970d-bac69e352de4" />



## Checklist

- [x] Self-review completed
- [x] No new warnings introduced
- [x] Documentation updated if needed

## Related Issues

Fixes #12  - Edit tool doesn't apply diffs correctly for larger files