### PR TITLE
feat: add model parameter support for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,21 @@ Or specify a working directory:
 grok -d /path/to/project
 ```
 
+### Model Selection
+
+You can specify which AI model to use with the `--model` parameter:
+
+```bash
+# Use Grok models
+grok --model grok-4-latest
+grok --model grok-3-latest
+grok --model grok-3-fast
+
+# Use other models (with appropriate API endpoint)
+grok --model gemini-2.5-pro --base-url https://api-endpoint.com/v1
+grok --model claude-sonnet-4-20250514 --base-url https://api-endpoint.com/v1
+```
+
 ### Custom Instructions
 
 You can provide custom instructions to tailor Grok's behavior to your project by creating a `.grok/GROK.md` file in your project directory:

--- a/src/agent/grok-agent.ts
+++ b/src/agent/grok-agent.ts
@@ -36,9 +36,9 @@ export class GrokAgent extends EventEmitter {
   private tokenCounter: TokenCounter;
   private abortController: AbortController | null = null;
 
-  constructor(apiKey: string, baseURL?: string) {
+  constructor(apiKey: string, baseURL?: string, model?: string) {
     super();
-    this.grokClient = new GrokClient(apiKey, undefined, baseURL);
+    this.grokClient = new GrokClient(apiKey, model, baseURL);
     this.textEditor = new TextEditorTool();
     this.bash = new BashTool();
     this.todoTool = new TodoTool();

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,7 @@ program
   .option("-d, --directory <dir>", "set working directory", process.cwd())
   .option("-k, --api-key <key>", "Grok API key (or set GROK_API_KEY env var)")
   .option("-u, --base-url <url>", "Grok API base URL (or set GROK_BASE_URL env var)")
+  .option("-m, --model <model>", "AI model to use (e.g., gemini-2.5-pro, grok-4-latest)")
   .action((options) => {
     if (options.directory) {
       try {
@@ -85,7 +86,8 @@ program
       // Get API key from options, environment, or user settings
       const apiKey = options.apiKey || loadApiKey();
       const baseURL = options.baseUrl || loadBaseURL();
-      const agent = apiKey ? new GrokAgent(apiKey, baseURL) : undefined;
+      const model = options.model;
+      const agent = apiKey ? new GrokAgent(apiKey, baseURL, model) : undefined;
 
       console.log("🤖 Starting Grok CLI Conversational Assistant...\n");
 


### PR DESCRIPTION
- Add --model/-m CLI option to specify AI model
- Update GrokAgent constructor to accept model parameter
- Pass model parameter to GrokClient for initialization
- Add model selection documentation to README
- Enable support for multiple AI models (Grok, Gemini, Claude, etc.)