### PR TITLE
feat: git commands

### DIFF
--- a/src/hooks/use-input-handler.ts
+++ b/src/hooks/use-input-handler.ts
@@ -57,6 +57,7 @@ export function useInputHandler({
     { command: "/help", description: "Show help information" },
     { command: "/clear", description: "Clear chat history" },
     { command: "/models", description: "Switch Grok Model" },
+    { command: "/commit-and-push", description: "AI commit & push to remote" },
     { command: "/exit", description: "Exit the application" },
   ];
 
@@ -103,6 +104,9 @@ Built-in Commands:
   /models     - Switch Grok models
   /exit       - Exit application
   exit, quit  - Exit application
+  
+Git Commands:
+  /commit-and-push - AI-generated commit + push to remote
   
 Keyboard Shortcuts:
   Shift+Tab   - Toggle auto-edit mode (bypass confirmations)
@@ -158,6 +162,146 @@ Available models: ${modelNames.join(", ")}`,
         setChatHistory((prev) => [...prev, errorEntry]);
       }
 
+      setInput("");
+      return true;
+    }
+
+    if (trimmedInput === "/commit-and-push") {
+      const userEntry: ChatEntry = {
+        type: "user",
+        content: "/commit-and-push",
+        timestamp: new Date(),
+      };
+      setChatHistory((prev) => [...prev, userEntry]);
+
+      setIsProcessing(true);
+      setIsStreaming(true);
+
+      try {
+        // Get git status and diff first
+        const statusResult = await agent.executeBashCommand("git status --porcelain");
+        const diffResult = await agent.executeBashCommand("git diff --cached");
+        
+        if (!statusResult.success || !statusResult.output?.trim()) {
+          const noChangesEntry: ChatEntry = {
+            type: "assistant",
+            content: "No changes to commit. Stage your changes first with `git add`.",
+            timestamp: new Date(),
+          };
+          setChatHistory((prev) => [...prev, noChangesEntry]);
+          setIsProcessing(false);
+          setIsStreaming(false);
+          setInput("");
+          return true;
+        }
+
+        // Generate commit message using AI
+        const commitPrompt = `Generate a concise, professional git commit message for these changes:
+
+Git Status:
+${statusResult.output}
+
+Git Diff (staged changes):
+${diffResult.output || "No staged changes shown"}
+
+Follow conventional commit format (feat:, fix:, docs:, etc.) and keep it under 72 characters.
+Respond with ONLY the commit message, no additional text.`;
+
+        let commitMessage = "";
+        let streamingEntry: ChatEntry | null = null;
+
+        for await (const chunk of agent.processUserMessageStream(commitPrompt)) {
+          if (chunk.type === "content" && chunk.content) {
+            if (!streamingEntry) {
+              const newEntry = {
+                type: "assistant" as const,
+                content: `Generating commit message...\n\n${chunk.content}`,
+                timestamp: new Date(),
+                isStreaming: true,
+              };
+              setChatHistory((prev) => [...prev, newEntry]);
+              streamingEntry = newEntry;
+              commitMessage = chunk.content;
+            } else {
+              commitMessage += chunk.content;
+              setChatHistory((prev) =>
+                prev.map((entry, idx) =>
+                  idx === prev.length - 1 && entry.isStreaming
+                    ? { ...entry, content: `Generating commit message...\n\n${commitMessage}` }
+                    : entry
+                )
+              );
+            }
+          } else if (chunk.type === "done") {
+            if (streamingEntry) {
+              setChatHistory((prev) =>
+                prev.map((entry) =>
+                  entry.isStreaming 
+                    ? { ...entry, content: `Generated commit message: "${commitMessage.trim()}"`, isStreaming: false }
+                    : entry
+                )
+              );
+            }
+            break;
+          }
+        }
+
+        // Execute the commit
+        const cleanCommitMessage = commitMessage.trim().replace(/^["']|["']$/g, '');
+        const commitCommand = `git commit -m "${cleanCommitMessage}"`;
+        const commitResult = await agent.executeBashCommand(commitCommand);
+
+        const commitEntry: ChatEntry = {
+          type: "tool_result",
+          content: commitResult.success
+            ? commitResult.output || "Commit successful"
+            : commitResult.error || "Commit failed",
+          timestamp: new Date(),
+          toolCall: {
+            id: `git_commit_${Date.now()}`,
+            type: "function",
+            function: {
+              name: "bash",
+              arguments: JSON.stringify({ command: commitCommand }),
+            },
+          },
+          toolResult: commitResult,
+        };
+        setChatHistory((prev) => [...prev, commitEntry]);
+
+        // If commit was successful, push to remote
+        if (commitResult.success) {
+          const pushResult = await agent.executeBashCommand("git push");
+          const pushEntry: ChatEntry = {
+            type: "tool_result",
+            content: pushResult.success
+              ? pushResult.output || "Push successful"
+              : pushResult.error || "Push failed",
+            timestamp: new Date(),
+            toolCall: {
+              id: `git_push_${Date.now()}`,
+              type: "function",
+              function: {
+                name: "bash",
+                arguments: JSON.stringify({ command: "git push" }),
+              },
+            },
+            toolResult: pushResult,
+          };
+          setChatHistory((prev) => [...prev, pushEntry]);
+        }
+
+      } catch (error: any) {
+        const errorEntry: ChatEntry = {
+          type: "assistant",
+          content: `Error during commit and push: ${error.message}`,
+          timestamp: new Date(),
+        };
+        setChatHistory((prev) => [...prev, errorEntry]);
+      }
+
+      setIsProcessing(false);
+      setIsStreaming(false);
       setInput("");
       return true;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,7 +157,13 @@ Respond with ONLY the commit message, no additional text.`;
       console.log(`✅ git commit: ${commitResult.output?.split('\n')[0] || 'Commit successful'}`);
       
       // If commit was successful, push to remote
-      const pushResult = await agent.executeBashCommand("git push");
+      // First try regular push, if it fails try with upstream setup
+      let pushResult = await agent.executeBashCommand("git push");
+      
+      if (!pushResult.success && pushResult.error?.includes("no upstream branch")) {
+        console.log("🔄 Setting upstream and pushing...");
+        pushResult = await agent.executeBashCommand("git push -u origin HEAD");
+      }
       
       if (pushResult.success) {
         console.log(`✅ git push: ${pushResult.output?.split('\n')[0] || 'Push successful'}`);


### PR DESCRIPTION
## What does this PR do?

This pull request introduces a new feature that enables AI-assisted Git operations, specifically for generating commit messages and pushing changes to a remote repository. The changes include updates to both interactive and headless modes, as well as enhancements to the CLI interface. Below is a summary of the most important changes:

### New Feature: AI-Assisted Git Operations
* Added a new `/commit-and-push` command to the `useInputHandler` hook, allowing users to generate AI-driven commit messages and push changes to a remote repository interactively. This includes handling Git status, generating commit messages using AI, executing the commit, and pushing changes. [[1]](diffhunk://#diff-8fdb6362b40b21a0b32d7cf12cb9ea401f968e231a45a40b71af8bd6e8b26bf8R60) [[2]](diffhunk://#diff-8fdb6362b40b21a0b32d7cf12cb9ea401f968e231a45a40b71af8bd6e8b26bf8R169-R316)
* Introduced a corresponding `commit-and-push` subcommand in the CLI for headless mode, enabling the same functionality via command-line options. This includes support for specifying the working directory, API key, base URL, and AI model. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R91-R184) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R314-R364)

### CLI Enhancements
* Added a new `git` subcommand to the CLI, with a `commit-and-push` operation for AI-assisted Git workflows. This improves usability for developers who prefer headless operations.
* Updated the CLI description to reflect the broader capabilities of the tool beyond text editing.

### User Experience Improvements
* Expanded the list of built-in commands in the interactive mode to include `/commit-and-push`, with a clear description of its functionality.

These changes significantly enhance the tool's functionality by integrating AI into Git workflows, streamlining commit and push operations for both interactive and headless modes.

Fixes #37 

## Checklist

- [x] I tested my changes
- [x] I reviewed my own code