### PR TITLE
Added filterCommandSuggestions utility to improve command suggestion

### DIFF
--- a/src/ui/components/command-suggestions.tsx
+++ b/src/ui/components/command-suggestions.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { Box, Text } from "ink";
 
 interface CommandSuggestion {
@@ -13,6 +13,18 @@ interface CommandSuggestionsProps {
   isVisible: boolean;
 }
 
+export const MAX_SUGGESTIONS = 8;
+
+export function filterCommandSuggestions<T extends { command: string }>(
+  suggestions: T[],
+  input: string
+): T[] {
+  const lowerInput = input.toLowerCase();
+  return suggestions
+    .filter((s) => s.command.toLowerCase().startsWith(lowerInput))
+    .slice(0, MAX_SUGGESTIONS);
+}
+
 export function CommandSuggestions({
   suggestions,
   input,
@@ -21,13 +33,10 @@ export function CommandSuggestions({
 }: CommandSuggestionsProps) {
   if (!isVisible) return null;
 
-  const filteredSuggestions = suggestions
-    .filter((suggestion) =>
-      input.startsWith("/")
-        ? suggestion.command.startsWith("/")
-        : suggestion.command.toLowerCase().startsWith(input.toLowerCase())
-    )
-    .slice(0, 8);
+  const filteredSuggestions = useMemo(
+    () => filterCommandSuggestions(suggestions, input),
+    [suggestions, input]
+  );
 
   return (
     <Box marginTop={1} flexDirection="column">


### PR DESCRIPTION
 ## What does this PR do?

Fixed filtering logic in CommandSuggestions component to properly filter based on the entire input string
Updated input handler to show suggestions while typing slash commands (not just on exact /)
Synchronized arrow key navigation and Enter/Tab selection to operate on the same filtered list shown to users

Before: Typing /cl  din't filter out the relevant commands
After: Typing /cl shows only /clear and pressing Enter correctly selects /clear
Fixes #42

## Checklist

- [x] I tested my changes
- [x] I reviewed my own code