### PR TITLE
add a max tool round options

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Process a single prompt and exit (useful for scripting and automation):
 grok --prompt "show me the package.json file"
 grok -p "create a new file called example.js with a hello world function"
 grok --prompt "run npm test and show me the results" --directory /path/to/project
+grok --prompt "complex task" --max-tool-rounds 50  # Limit tool usage for faster execution
 ```
 
 This mode is particularly useful for:
@@ -198,6 +199,27 @@ This mode is particularly useful for:
 - **Scripting**: Integrate AI assistance into shell scripts
 - **Terminal benchmarks**: Perfect for tools like Terminal Bench that need non-interactive execution
 - **Batch processing**: Process multiple prompts programmatically
+
+### Tool Execution Control
+
+By default, Grok CLI allows up to 400 tool execution rounds to handle complex multi-step tasks. You can control this behavior:
+
+```bash
+# Limit tool rounds for faster execution on simple tasks
+grok --max-tool-rounds 10 --prompt "show me the current directory"
+
+# Increase limit for very complex tasks (use with caution)
+grok --max-tool-rounds 1000 --prompt "comprehensive code refactoring"
+
+# Works with all modes
+grok --max-tool-rounds 20  # Interactive mode
+grok git commit-and-push --max-tool-rounds 30  # Git commands
+```
+
+**Use Cases**:
+- **Fast responses**: Lower limits (10-50) for simple queries
+- **Complex automation**: Higher limits (500+) for comprehensive tasks
+- **Resource control**: Prevent runaway executions in automated environments
 
 ### Model Selection
 
@@ -244,6 +266,7 @@ Options:
   -u, --base-url <url>   Grok API base URL (or set GROK_BASE_URL env var)
   -m, --model <model>    AI model to use (e.g., grok-4-latest, grok-3-latest) (or set GROK_MODEL env var)
   -p, --prompt <prompt>  process a single prompt and exit (headless mode)
+  --max-tool-rounds <rounds>  maximum number of tool execution rounds (default: 400)
   -h, --help             display help for command
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-kit/grok-cli",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "An open-source AI agent that brings the power of Grok directly into your terminal.",
   "main": "dist/index.js",
   "bin": {

--- a/src/agent/grok-agent.ts
+++ b/src/agent/grok-agent.ts
@@ -51,12 +51,14 @@ export class GrokAgent extends EventEmitter {
   private tokenCounter: TokenCounter;
   private abortController: AbortController | null = null;
   private mcpInitialized: boolean = false;
+  private maxToolRounds: number;
 
-  constructor(apiKey: string, baseURL?: string, model?: string) {
+  constructor(apiKey: string, baseURL?: string, model?: string, maxToolRounds?: number) {
     super();
     const manager = getSettingsManager();
     const savedModel = manager.getCurrentModel();
     const modelToUse = model || savedModel || "grok-4-latest";
+    this.maxToolRounds = maxToolRounds || 400;
     this.grokClient = new GrokClient(apiKey, modelToUse, baseURL);
     this.textEditor = new TextEditorTool();
     this.bash = new BashTool();
@@ -179,7 +181,7 @@ Current working directory: ${process.cwd()}`,
     this.messages.push({ role: "user", content: message });
 
     const newEntries: ChatEntry[] = [userEntry];
-    const maxToolRounds = 10; // Prevent infinite loops
+    const maxToolRounds = this.maxToolRounds; // Prevent infinite loops
     let toolRounds = 0;
 
     try {
@@ -382,7 +384,7 @@ Current working directory: ${process.cwd()}`,
       tokenCount: inputTokens,
     };
 
-    const maxToolRounds = 30; // Prevent infinite loops
+    const maxToolRounds = this.maxToolRounds; // Prevent infinite loops
     let toolRounds = 0;
     let totalOutputTokens = 0;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,10 +108,11 @@ function loadModel(): string | undefined {
 async function handleCommitAndPushHeadless(
   apiKey: string,
   baseURL?: string,
-  model?: string
+  model?: string,
+  maxToolRounds?: number
 ): Promise<void> {
   try {
-    const agent = new GrokAgent(apiKey, baseURL, model);
+    const agent = new GrokAgent(apiKey, baseURL, model, maxToolRounds);
 
     // Configure confirmation service for headless mode (auto-approve all operations)
     const confirmationService = ConfirmationService.getInstance();
@@ -229,10 +230,11 @@ async function processPromptHeadless(
   prompt: string,
   apiKey: string,
   baseURL?: string,
-  model?: string
+  model?: string,
+  maxToolRounds?: number
 ): Promise<void> {
   try {
-    const agent = new GrokAgent(apiKey, baseURL, model);
+    const agent = new GrokAgent(apiKey, baseURL, model, maxToolRounds);
 
     // Configure confirmation service for headless mode (auto-approve all operations)
     const confirmationService = ConfirmationService.getInstance();
@@ -322,6 +324,11 @@ program
     "-p, --prompt <prompt>",
     "process a single prompt and exit (headless mode)"
   )
+  .option(
+    "--max-tool-rounds <rounds>",
+    "maximum number of tool execution rounds (default: 400)",
+    "400"
+  )
   .action(async (options) => {
     if (options.directory) {
       try {
@@ -340,6 +347,7 @@ program
       const apiKey = options.apiKey || loadApiKey();
       const baseURL = options.baseUrl || loadBaseURL();
       const model = options.model || loadModel();
+      const maxToolRounds = parseInt(options.maxToolRounds) || 400;
 
       if (!apiKey) {
         console.error(
@@ -355,12 +363,12 @@ program
 
       // Headless mode: process prompt and exit
       if (options.prompt) {
-        await processPromptHeadless(options.prompt, apiKey, baseURL, model);
+        await processPromptHeadless(options.prompt, apiKey, baseURL, model, maxToolRounds);
         return;
       }
 
       // Interactive mode: launch UI
-      const agent = new GrokAgent(apiKey, baseURL, model);
+      const agent = new GrokAgent(apiKey, baseURL, model, maxToolRounds);
       console.log("🤖 Starting Grok CLI Conversational Assistant...\n");
 
       ensureUserSettingsDirectory();
@@ -390,6 +398,11 @@ gitCommand
     "-m, --model <model>",
     "AI model to use (e.g., gemini-2.5-pro, grok-4-latest) (or set GROK_MODEL env var)"
   )
+  .option(
+    "--max-tool-rounds <rounds>",
+    "maximum number of tool execution rounds (default: 400)",
+    "400"
+  )
   .action(async (options) => {
     if (options.directory) {
       try {
@@ -408,6 +421,7 @@ gitCommand
       const apiKey = options.apiKey || loadApiKey();
       const baseURL = options.baseUrl || loadBaseURL();
       const model = options.model || loadModel();
+      const maxToolRounds = parseInt(options.maxToolRounds) || 400;
 
       if (!apiKey) {
         console.error(
@@ -421,7 +435,7 @@ gitCommand
         await saveCommandLineSettings(options.apiKey, options.baseUrl);
       }
 
-      await handleCommitAndPushHeadless(apiKey, baseURL, model);
+      await handleCommitAndPushHeadless(apiKey, baseURL, model, maxToolRounds);
     } catch (error: any) {
       console.error("❌ Error during git commit-and-push:", error.message);
       process.exit(1);


### PR DESCRIPTION
## What does this PR do?

This pull request introduces a new feature to control the maximum number of tool execution rounds in the Grok CLI, enhancing flexibility for handling tasks of varying complexity. It includes updates to the CLI, internal logic, and documentation to support this feature.

### New Feature: Tool Execution Control
* [`src/agent/grok-agent.ts`](diffhunk://#diff-61a2c527a6ad36f6898593155c2e1413b65bc671f3cb2b91eb0bd5c5777c4da4R54-R61): Added a `maxToolRounds` parameter to the `GrokAgent` class, defaulting to 400, and replaced hardcoded limits with this configurable value. [[1]](diffhunk://#diff-61a2c527a6ad36f6898593155c2e1413b65bc671f3cb2b91eb0bd5c5777c4da4R54-R61) [[2]](diffhunk://#diff-61a2c527a6ad36f6898593155c2e1413b65bc671f3cb2b91eb0bd5c5777c4da4L182-R184) [[3]](diffhunk://#diff-61a2c527a6ad36f6898593155c2e1413b65bc671f3cb2b91eb0bd5c5777c4da4L385-R387)
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L111-R115): Updated CLI options and internal logic to accept and pass the `--max-tool-rounds` parameter, allowing users to specify the limit for tool execution rounds. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L111-R115) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L232-R237) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R327-R331) [[4]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R350) [[5]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L358-R371) [[6]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R401-R405) [[7]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R424) [[8]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L424-R438)

### Documentation Updates
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R194): Documented the new `--max-tool-rounds` option, including examples and use cases for controlling tool execution limits in different scenarios. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R194) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R203-R223) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R269)

### Version Update
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Bumped the version from `0.0.18` to `0.0.19` to reflect the new feature addition.

Fixes #62 

## Checklist

- [x] I tested my changes
- [x] I reviewed my own code