### PR TITLE
fix issue with node build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-kit/grok-cli",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "description": "An open-source AI agent that brings the power of Grok directly into your terminal.",
   "type": "module",
   "main": "dist/index.js",
@@ -14,9 +14,12 @@
     "grok": "dist/index.js"
   },
   "scripts": {
-    "build": "bun run tsc",
+    "build": "tsc",
+    "build:bun": "bun run tsc",
     "dev": "bun run src/index.ts",
-    "start": "bun run dist/index.js",
+    "dev:node": "tsx src/index.ts",
+    "start": "node dist/index.js",
+    "start:bun": "bun run dist/index.js",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "typecheck": "tsc --noEmit",
     "install:bun": "bun install"
@@ -58,9 +61,7 @@
     "typescript": "^5.3.3"
   },
   "engines": {
-    "node": ">=18.0.0",
-    "bun": ">=1.0.0"
+    "node": ">=18.0.0"
   },
-  "packageManager": "bun@1.1.0",
   "preferGlobal": true
 }


### PR DESCRIPTION
## What does this PR do?

This pull request updates the build and start scripts in the `package.json` to improve compatibility with both Node.js and Bun, and removes Bun as a required package manager. The changes make it easier to develop and run the CLI in different environments.

Build and runtime improvements:

* Updated the `build`, `dev`, and `start` scripts to support both Node.js and Bun, adding new script variants for each environment (`build:bun`, `dev:node`, `start:bun`).
* Changed the default `build` and `start` scripts to use Node.js instead of Bun for broader compatibility.

Package management and dependencies:

* Removed Bun from the required package managers and engine requirements, making Node.js the only mandatory runtime.

Version update:

* Bumped the package version from `0.0.31` to `0.0.32` to reflect these changes.

Fixes #90 

## Checklist

- [x] I tested my changes
- [x] I reviewed my own code