### PR TITLE
Add the "apiKey" field name to the "No API key" error message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -354,7 +354,7 @@ program
 
       if (!apiKey) {
         console.error(
-          "❌ Error: API key required. Set GROK_API_KEY environment variable, use --api-key flag, or save to ~/.grok/user-settings.json"
+          "❌ Error: API key required. Set GROK_API_KEY environment variable, use --api-key flag, or set \"apiKey\" field in ~/.grok/user-settings.json"
         );
         process.exit(1);
       }


### PR DESCRIPTION
## What does this PR do?

I was confused how to set the API key I tried a bunch of different key names like: `APIKey`, `grokApiKey`, etc.

Fixes #
This just tells the user the key name to set to make it a bit easier.

## Checklist

- [X] I tested my changes
- [X] I reviewed my own code