### PR TITLE
fix: remove deprecated search_parameters (Live Search API returns 410)

### DIFF
--- a/src/agent/grok-agent.ts
+++ b/src/agent/grok-agent.ts
@@ -103,7 +103,7 @@ You have access to these tools:
 - update_todo_list: Update existing todos in your todo list
 
 REAL-TIME INFORMATION:
-You have access to real-time web search and X (Twitter) data. When users ask for current information, latest news, or recent events, you automatically have access to up-to-date information from the web and social media.
+Web search and X (Twitter) search are available via MCP tools (e.g., grok_web_search, grok_x_search) if configured. Use these MCP tools when users ask for current information, latest news, or recent events.
 
 IMPORTANT TOOL USAGE RULES:
 - NEVER use create_file on files that already exist - this will overwrite them completely
@@ -167,39 +167,6 @@ Current working directory: ${process.cwd()}`,
     });
   }
 
-  private isGrokModel(): boolean {
-    const currentModel = this.grokClient.getCurrentModel();
-    return currentModel.toLowerCase().includes("grok");
-  }
-
-  // Heuristic: enable web search only when likely needed
-  private shouldUseSearchFor(message: string): boolean {
-    const q = message.toLowerCase();
-    const keywords = [
-      "today",
-      "latest",
-      "news",
-      "trending",
-      "breaking",
-      "current",
-      "now",
-      "recent",
-      "x.com",
-      "twitter",
-      "tweet",
-      "what happened",
-      "as of",
-      "update on",
-      "release notes",
-      "changelog",
-      "price",
-    ];
-    if (keywords.some((k) => q.includes(k))) return true;
-    // crude date pattern (e.g., 2024/2025) may imply recency
-    if (/(20\d{2})/.test(q)) return true;
-    return false;
-  }
-
   async processUserMessage(message: string): Promise<ChatEntry[]> {
     // Add user message to conversation
     const userEntry: ChatEntry = {
@@ -218,11 +185,7 @@ Current working directory: ${process.cwd()}`,
       const tools = await getAllGrokTools();
       let currentResponse = await this.grokClient.chat(
         this.messages,
-        tools,
-        undefined,
-        this.isGrokModel() && this.shouldUseSearchFor(message)
-          ? { search_parameters: { mode: "auto" } }
-          : { search_parameters: { mode: "off" } }
+        tools
       );
 
       // Agent loop - continue until no more tool calls or max rounds reached
@@ -314,11 +277,7 @@ Current working directory: ${process.cwd()}`,
           // Get next response - this might contain more tool calls
           currentResponse = await this.grokClient.chat(
             this.messages,
-            tools,
-            undefined,
-            this.isGrokModel() && this.shouldUseSearchFor(message)
-              ? { search_parameters: { mode: "auto" } }
-              : { search_parameters: { mode: "off" } }
+            tools
           );
         } else {
           // No more tool calls, add final response
@@ -438,11 +397,7 @@ Current working directory: ${process.cwd()}`,
         const tools = await getAllGrokTools();
         const stream = this.grokClient.chatStream(
           this.messages,
-          tools,
-          undefined,
-          this.isGrokModel() && this.shouldUseSearchFor(message)
-            ? { search_parameters: { mode: "auto" } }
-            : { search_parameters: { mode: "off" } }
+          tools
         );
         let accumulatedMessage: any = {};
         let accumulatedContent = "";

--- a/src/grok/client.ts
+++ b/src/grok/client.ts
@@ -25,11 +25,12 @@ export interface GrokToolCall {
   };
 }
 
+/** @deprecated Live Search API deprecated Jan 2026 — use MCP tools (web_search, x_search) instead */
 export interface SearchParameters {
   mode?: "auto" | "on" | "off";
-  // sources removed - let API use default sources to avoid format issues
 }
 
+/** @deprecated Live Search API deprecated Jan 2026 — use MCP tools (web_search, x_search) instead */
 export interface SearchOptions {
   search_parameters?: SearchParameters;
 }
@@ -75,7 +76,7 @@ export class GrokClient {
     messages: GrokMessage[],
     tools?: GrokTool[],
     model?: string,
-    searchOptions?: SearchOptions
+    _searchOptions?: SearchOptions
   ): Promise<GrokResponse> {
     try {
       const requestPayload: any = {
@@ -87,10 +88,8 @@ export class GrokClient {
         max_tokens: this.defaultMaxTokens,
       };
 
-      // Add search parameters if specified
-      if (searchOptions?.search_parameters) {
-        requestPayload.search_parameters = searchOptions.search_parameters;
-      }
+      // Note: search_parameters removed — Live Search API deprecated (410) since Jan 2026.
+      // Web/X search now available via MCP tools (web_search, x_search) using the Responses API.
 
       const response =
         await this.client.chat.completions.create(requestPayload);
@@ -105,7 +104,7 @@ export class GrokClient {
     messages: GrokMessage[],
     tools?: GrokTool[],
     model?: string,
-    searchOptions?: SearchOptions
+    _searchOptions?: SearchOptions
   ): AsyncGenerator<any, void, unknown> {
     try {
       const requestPayload: any = {
@@ -118,10 +117,7 @@ export class GrokClient {
         stream: true,
       };
 
-      // Add search parameters if specified
-      if (searchOptions?.search_parameters) {
-        requestPayload.search_parameters = searchOptions.search_parameters;
-      }
+      // Note: search_parameters removed — Live Search API deprecated (410) since Jan 2026.
 
       const stream = (await this.client.chat.completions.create(
         requestPayload
@@ -137,17 +133,14 @@ export class GrokClient {
 
   async search(
     query: string,
-    searchParameters?: SearchParameters
+    _searchParameters?: SearchParameters
   ): Promise<GrokResponse> {
     const searchMessage: GrokMessage = {
       role: "user",
       content: query,
     };
 
-    const searchOptions: SearchOptions = {
-      search_parameters: searchParameters || { mode: "on" },
-    };
-
-    return this.chat([searchMessage], [], undefined, searchOptions);
+    // Note: search_parameters removed — Live Search API deprecated (410) since Jan 2026.
+    return this.chat([searchMessage], [], undefined);
   }
 }


### PR DESCRIPTION
## Summary

- xAI deprecated the Live Search API (`search_parameters`) in Jan 2026, returning HTTP 410 for all requests
- Every grok-cli session fails with `Grok API error: 410` when the search heuristic triggers (keywords like "today", "latest", "news", date patterns, etc.)
- This removes `search_parameters` from all `chat`/`chatStream` request payloads
- Removes the `isGrokModel()` and `shouldUseSearchFor()` heuristics that triggered the deprecated API
- Updates the system prompt to reference MCP-based search tools instead
- Marks `SearchParameters`/`SearchOptions` interfaces as `@deprecated` while keeping method signatures backwards-compatible

## Context

xAI's migration path is from the Chat Completions Live Search API to the new [Responses API with server-side tools](https://docs.x.ai/docs/guides/tools/search-tools) (`web_search`, `x_search`). These are best exposed via MCP servers rather than baked into the chat completions flow.

## Test plan

- [x] Verify `bun run build` compiles cleanly
- [x] Confirm no `search_parameters` sent in API requests
- [x] Sessions no longer hit 410 errors
- [x] MCP-based search tools work as replacement

🤖 Generated with [Claude Code](https://claude.com/claude-code)