### PR TITLE
test: add helper coverage for rewrite utilities

### DIFF
--- a/src/mcp/parse-headers.test.ts
+++ b/src/mcp/parse-headers.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { parseEnvLines, parseHeaderLines } from "./parse-headers";
+
+describe("parseHeaderLines", () => {
+  it("parses colon-separated headers and trims whitespace", () => {
+    expect(
+      parseHeaderLines(`
+        Authorization: Bearer token
+        X-Trace-Id:  abc123
+      `),
+    ).toEqual({
+      Authorization: "Bearer token",
+      "X-Trace-Id": "abc123",
+    });
+  });
+
+  it("ignores blank and malformed lines while preserving later colons in values", () => {
+    expect(
+      parseHeaderLines(`
+        invalid
+        : missing-name
+        Host: example.com:443
+      `),
+    ).toEqual({
+      Host: "example.com:443",
+    });
+  });
+});
+
+describe("parseEnvLines", () => {
+  it("parses equals-separated env assignments and trims whitespace", () => {
+    expect(
+      parseEnvLines(`
+        API_KEY = secret
+        MODE= production
+      `),
+    ).toEqual({
+      API_KEY: "secret",
+      MODE: "production",
+    });
+  });
+
+  it("ignores blank and malformed lines while preserving later equals in values", () => {
+    expect(
+      parseEnvLines(`
+        missing
+        = no-name
+        URL=https://example.com?a=b
+      `),
+    ).toEqual({
+      URL: "https://example.com?a=b",
+    });
+  });
+});

--- a/src/telegram/limits.test.ts
+++ b/src/telegram/limits.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { splitTelegramMessage, TELEGRAM_MAX_MESSAGE } from "./limits";
+
+describe("splitTelegramMessage", () => {
+  it("returns no chunks for empty input", () => {
+    expect(splitTelegramMessage("")).toEqual([]);
+  });
+
+  it("keeps short input in a single chunk", () => {
+    const text = "hello world";
+
+    expect(splitTelegramMessage(text)).toEqual([text]);
+  });
+
+  it("keeps exact-limit input in a single chunk", () => {
+    const text = "x".repeat(TELEGRAM_MAX_MESSAGE);
+
+    expect(splitTelegramMessage(text)).toEqual([text]);
+  });
+
+  it("splits oversized input into limit-bounded chunks", () => {
+    const text = "x".repeat(TELEGRAM_MAX_MESSAGE * 2 + 17);
+    const chunks = splitTelegramMessage(text);
+
+    expect(chunks).toHaveLength(3);
+    expect(chunks[0]).toHaveLength(TELEGRAM_MAX_MESSAGE);
+    expect(chunks[1]).toHaveLength(TELEGRAM_MAX_MESSAGE);
+    expect(chunks[2]).toHaveLength(17);
+    expect(chunks.join("")).toBe(text);
+  });
+});

--- a/src/utils/instructions.test.ts
+++ b/src/utils/instructions.test.ts
@@ -1,0 +1,80 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+function makeTempDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function writeFile(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+async function importLoadCustomInstructions(mockedHome?: string) {
+  vi.resetModules();
+  vi.doUnmock("os");
+
+  if (mockedHome) {
+    vi.doMock("os", async () => {
+      const actual = await vi.importActual<typeof import("os")>("os");
+      return {
+        ...actual,
+        homedir: () => mockedHome,
+      };
+    });
+  }
+
+  const mod = await import("./instructions");
+  return mod.loadCustomInstructions;
+}
+
+describe("loadCustomInstructions", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    vi.doUnmock("os");
+  });
+
+  it("returns null when no instruction files exist", async () => {
+    const home = makeTempDir("grok-home-");
+    const cwd = makeTempDir("grok-cwd-");
+    const loadCustomInstructions = await importLoadCustomInstructions(home);
+
+    expect(loadCustomInstructions(cwd)).toBeNull();
+  });
+
+  it("loads global plus repo-chain AGENTS files in order", async () => {
+    const home = makeTempDir("grok-home-");
+    const repoRoot = makeTempDir("grok-repo-");
+    const cwd = path.join(repoRoot, "pkg", "feature");
+    fs.mkdirSync(path.join(repoRoot, ".git"));
+    fs.mkdirSync(cwd, { recursive: true });
+
+    writeFile(path.join(home, ".grok", "AGENTS.md"), "global instructions");
+    writeFile(path.join(repoRoot, "AGENTS.md"), "root instructions");
+    writeFile(path.join(repoRoot, "pkg", "AGENTS.md"), "pkg instructions");
+    writeFile(path.join(repoRoot, "pkg", "feature", "AGENTS.md"), "feature instructions");
+    const loadCustomInstructions = await importLoadCustomInstructions(home);
+
+    expect(loadCustomInstructions(cwd)).toBe(
+      ["global instructions", "root instructions", "pkg instructions", "feature instructions"].join("\n\n"),
+    );
+  });
+
+  it("prefers AGENTS.override.md over AGENTS.md in the same directory", async () => {
+    const home = makeTempDir("grok-home-");
+    const repoRoot = makeTempDir("grok-repo-");
+    const cwd = path.join(repoRoot, "nested");
+    fs.mkdirSync(path.join(repoRoot, ".git"));
+    fs.mkdirSync(cwd, { recursive: true });
+
+    writeFile(path.join(repoRoot, "AGENTS.md"), "root instructions");
+    writeFile(path.join(repoRoot, "nested", "AGENTS.md"), "nested base instructions");
+    writeFile(path.join(repoRoot, "nested", "AGENTS.override.md"), "nested override instructions");
+    const loadCustomInstructions = await importLoadCustomInstructions(home);
+
+    expect(loadCustomInstructions(cwd)).toBe(["root instructions", "nested override instructions"].join("\n\n"));
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Adds a first narrow rewrite-era helper test tranche:
- coverage for header/env parsing helpers
- coverage for Telegram message chunking
- coverage for custom instruction loading and `AGENTS.override.md` precedence

Part of #153

## Checklist

- [x] I tested my changes
- [x] I reviewed my own code