### PR TITLE
fix: use package.json version instead of hardcoded "1.0.0"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 import { program } from "commander";
 import * as dotenv from "dotenv";
+import packageJson from "../package.json";
 import { Agent } from "./agent/agent";
 import { completeDelegation, failDelegation, loadDelegation } from "./agent/delegations";
 import { MODELS } from "./grok/models";
@@ -175,7 +176,7 @@ function requireApiKey(apiKey: string | undefined): string {
 program
   .name("grok")
   .description("AI coding agent powered by Grok — built with Bun and OpenTUI")
-  .version("1.0.0")
+  .version(packageJson.version)
   .argument("[message...]", "Initial message to send")
   .option("-k, --api-key <key>", "Grok API key")
   .option("-u, --base-url <url>", "API base URL")


### PR DESCRIPTION
## Problem

The CLI was displaying version `"1.0.0"` (hardcoded in `src/index.ts`) while `package.json` shows the actual version as `"1.0.0-rc2"`.

This causes confusion when users run `grok --version` and see a version that doesn't match the published package.

## Solution

- Import `package.json` in `src/index.ts`
- Use `packageJson.version` in `program.version()` instead of hardcoded string
- Ensures `--version` always shows the correct version from `package.json`

## Changes

```diff
+import packageJson from "../package.json";
...
program
  .name("grok")
  .description("AI coding agent powered by Grok — built with Bun and OpenTUI")
-  .version("1.0.0")
+  .version(packageJson.version)
```

## Testing

✅ TypeScript build passes (`npm run build`)
✅ Version now correctly shows `1.0.0-rc2` instead of `1.0.0`
✅ No breaking changes (internal refactor only)
✅ `tsconfig.json` already has `resolveJsonModule: true`

## Type

Bug fix

## Impact

Low risk, high value:
- Fixes user-facing version mismatch
- Single-line change
- Backward compatible
- Future-proof (auto-updates when package.json version changes)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only CLI version reporting by reading `package.json`, with no impact to runtime agent logic or external APIs.
> 
> **Overview**
> Updates the CLI `--version` output to reflect the real package version by importing `package.json` and passing `packageJson.version` into Commander’s `.version()` instead of a hardcoded string.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1742332c021e3635d90bc039925d64498122c876. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->