### PR TITLE
feat: add configurable sandbox settings (network, resources, ports, secrets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,26 @@ Project file: **`.grok/settings.json`** — e.g. the current model for this proj
 
 ---
 
+## Sandbox
+
+Grok CLI can run shell commands inside a [Shuru](https://github.com/superhq-ai/shuru) microVM sandbox so the agent can't touch your host filesystem or network.
+
+**Requires macOS 14+ on Apple Silicon.**
+
+Enable it with `--sandbox` on the CLI, or toggle it from the TUI with `/sandbox`.
+
+When sandbox mode is active you can configure:
+
+- **Network** — off by default; enable with `--allow-net`, restrict with `--allow-host`
+- **Port forwards** — `--port 8080:80`
+- **Resource limits** — CPUs, memory, disk size (via settings or `/sandbox` panel)
+- **Checkpoints** — start from a saved environment snapshot
+- **Secrets** — inject API keys without exposing them inside the VM
+
+All settings are saved in `~/.grok/user-settings.json` (user) and `.grok/settings.json` (project).
+
+---
+
 ## Development
 
 From a clone:

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -32,7 +32,13 @@ import type {
   WorkspaceInfo,
 } from "../types/index";
 import { loadCustomInstructions } from "../utils/instructions";
-import { type CustomSubagentConfig, loadMcpServers, loadValidSubAgents, type SandboxMode } from "../utils/settings";
+import {
+  type CustomSubagentConfig,
+  loadMcpServers,
+  loadValidSubAgents,
+  type SandboxMode,
+  type SandboxSettings,
+} from "../utils/settings";
 import { discoverSkills, formatSkillsForPrompt } from "../utils/skills";
 import {
   type CompactionSettings,
@@ -56,6 +62,7 @@ interface AgentOptions {
   persistSession?: boolean;
   session?: string;
   sandboxMode?: SandboxMode;
+  sandboxSettings?: SandboxSettings;
 }
 
 type ProcessMessageFinishReason = "stop" | "length" | "content-filter" | "tool-calls" | "error" | "other";
@@ -247,6 +254,7 @@ function buildSystemPrompt(
   sandboxMode: SandboxMode,
   planContext?: string | null,
   subagents?: CustomSubagentConfig[],
+  sandboxSettings?: SandboxSettings,
 ): string {
   const custom = loadCustomInstructions(cwd);
   const customSection = custom
@@ -256,7 +264,7 @@ function buildSystemPrompt(
   const skillsText = formatSkillsForPrompt(discoverSkills(cwd));
   const skillsSection = skillsText ? `\n\n${skillsText}\n` : "";
   const subagentsSection = formatCustomSubagentsPromptSection(subagents ?? loadValidSubAgents());
-  const sandboxSection = formatSandboxPromptSection(sandboxMode);
+  const sandboxSection = formatSandboxPromptSection(sandboxMode, sandboxSettings);
 
   const planSection = planContext
     ? `\n\nAPPROVED PLAN:\nThe following plan has been approved by the user. Execute it now.\n${planContext}\n`
@@ -273,6 +281,7 @@ function buildSubagentPrompt(
   custom: CustomSubagentConfig | null,
   sandboxMode: SandboxMode,
   subagents?: CustomSubagentConfig[],
+  sandboxSettings?: SandboxSettings,
 ): string {
   const isExplore = request.agent === "explore";
   const isVision = request.agent === "vision";
@@ -312,22 +321,42 @@ function buildSubagentPrompt(
     "",
     `Delegated task: ${request.description}`,
     "",
-    buildSystemPrompt(cwd, mode, sandboxMode, undefined, subagents),
+    buildSystemPrompt(cwd, mode, sandboxMode, undefined, subagents, sandboxSettings),
   ].join("\n");
 }
 
-function formatSandboxPromptSection(sandboxMode: SandboxMode): string {
+function formatSandboxPromptSection(sandboxMode: SandboxMode, settings?: SandboxSettings): string {
   if (sandboxMode === "off") return "";
-  return [
+
+  const s = settings ?? {};
+  let networkLine: string;
+  if (s.allowNet) {
+    networkLine = s.allowedHosts?.length
+      ? `- Network access is restricted to: ${s.allowedHosts.join(", ")}.`
+      : "- Network access is enabled.";
+  } else {
+    networkLine = "- Network is disabled.";
+  }
+
+  const lines = [
     "",
     "SANDBOX MODE:",
     "- Bash commands run inside a Shuru sandbox.",
-    "- Network is disabled by default unless the current workspace config allows it.",
+    networkLine,
     "- The current workspace is mounted inside the sandbox at `/workspace`.",
     "- Shell-side workspace file changes do not persist back to the host in this version.",
     "- Use `read_file`, `edit_file`, and `write_file` for durable source edits.",
     "- If a task needs a host-persistent shell mutation, explain that sandbox mode blocks that workflow and ask whether to disable sandbox mode.",
-  ].join("\n");
+  ];
+
+  if (s.ports?.length) {
+    lines.push(`- Port forwards: ${s.ports.join(", ")}.`);
+  }
+  if (s.from) {
+    lines.push(`- Starting from checkpoint: ${s.from}.`);
+  }
+
+  return lines.join("\n");
 }
 
 function applyModelConstraints(system: string, modelId: string): string {
@@ -378,7 +407,10 @@ export class Agent {
     if (apiKey) {
       this.setApiKey(apiKey, baseURL);
     }
-    this.bash = new BashTool(process.cwd(), { sandboxMode: options.sandboxMode ?? "off" });
+    this.bash = new BashTool(process.cwd(), {
+      sandboxMode: options.sandboxMode ?? "off",
+      sandboxSettings: options.sandboxSettings,
+    });
     this.delegations = new DelegationManager(() => this.bash.getCwd());
     this.modelId = normalizeModelId(model || DEFAULT_MODEL);
     this.schedules = new ScheduleManager(
@@ -423,6 +455,14 @@ export class Agent {
 
   setSandboxMode(mode: SandboxMode): void {
     this.bash.setSandboxMode(mode);
+  }
+
+  getSandboxSettings(): SandboxSettings {
+    return this.bash.getSandboxSettings();
+  }
+
+  setSandboxSettings(settings: SandboxSettings): void {
+    this.bash.setSandboxSettings(settings);
   }
 
   setMode(mode: AgentMode): void {
@@ -480,7 +520,14 @@ export class Agent {
     ratioUsed: number;
     ratioRemaining: number;
   } {
-    const system = buildSystemPrompt(this.bash.getCwd(), this.mode, this.bash.getSandboxMode(), this.planContext);
+    const system = buildSystemPrompt(
+      this.bash.getCwd(),
+      this.mode,
+      this.bash.getSandboxMode(),
+      this.planContext,
+      undefined,
+      this.bash.getSandboxSettings(),
+    );
     const usedTokens = Math.min(contextWindow, estimateConversationTokens(system, this.messages, inFlightText));
     const remainingTokens = Math.max(0, contextWindow - usedTokens);
 
@@ -637,7 +684,10 @@ export class Agent {
     }
 
     const childMode: AgentMode = isExplore ? "ask" : "agent";
-    const childBash = new BashTool(this.bash.getCwd(), { sandboxMode: this.bash.getSandboxMode() });
+    const childBash = new BashTool(this.bash.getCwd(), {
+      sandboxMode: this.bash.getSandboxMode(),
+      sandboxSettings: this.bash.getSandboxSettings(),
+    });
     const childBaseTools = createTools(childBash, provider, childMode);
     const initialDetail = isExplore ? "Scanning the codebase" : "Planning delegated work";
     let assistantText = "";
@@ -651,7 +701,14 @@ export class Agent {
       ? { ...resolveModelRuntime(provider, childModelId), model: provider.responses(childModelId) }
       : resolveModelRuntime(provider, childModelId);
     const childSystem = applyModelConstraints(
-      buildSubagentPrompt(request, childBash.getCwd(), custom ?? null, childBash.getSandboxMode(), subagents),
+      buildSubagentPrompt(
+        request,
+        childBash.getCwd(),
+        custom ?? null,
+        childBash.getSandboxMode(),
+        subagents,
+        childBash.getSandboxSettings(),
+      ),
       childRuntime.modelId,
     );
 
@@ -770,6 +827,7 @@ export class Agent {
       return await this.delegations.start(request, {
         model: this.modelId,
         sandboxMode: this.bash.getSandboxMode(),
+        sandboxSettings: this.bash.getSandboxSettings(),
         maxToolRounds: this.maxToolRounds,
         maxTokens: this.maxTokens,
       });
@@ -898,7 +956,14 @@ export class Agent {
     const provider = this.requireProvider();
     const subagents = loadValidSubAgents();
     const system = applyModelConstraints(
-      buildSystemPrompt(this.bash.getCwd(), this.mode, this.bash.getSandboxMode(), this.planContext, subagents),
+      buildSystemPrompt(
+        this.bash.getCwd(),
+        this.mode,
+        this.bash.getSandboxMode(),
+        this.planContext,
+        subagents,
+        this.bash.getSandboxSettings(),
+      ),
       this.modelId,
     );
     const runtime = resolveModelRuntime(provider, this.modelId);

--- a/src/agent/delegations.test.ts
+++ b/src/agent/delegations.test.ts
@@ -91,4 +91,52 @@ describe("DelegationManager sandbox propagation", () => {
     expect(record.sandboxMode).toBe("shuru");
     expect(record.pid).toBe(2468);
   });
+
+  it("persists sandbox settings in background delegation records", async () => {
+    const home = makeTempDir("grok-delegation-home-");
+    const cwd = makeTempDir("grok-delegation-cwd-");
+    const spawnMock = vi.fn(() => ({
+      pid: 3579,
+      unref: vi.fn(),
+    }));
+    const mod = await importDelegationsModule({ home, spawnMock });
+    const manager = new mod.DelegationManager(() => cwd);
+
+    const sandboxSettings = {
+      allowNet: true,
+      allowedHosts: ["api.openai.com"],
+      cpus: 4,
+      memory: 4096,
+    };
+
+    await manager.start(
+      {
+        agent: "explore",
+        description: "Inspect",
+        prompt: "Look around",
+      },
+      {
+        model: "grok-test-model",
+        sandboxMode: "shuru",
+        sandboxSettings,
+        maxToolRounds: 25,
+        maxTokens: 2048,
+      },
+    );
+
+    const cliArgs = (spawnMock.mock.calls[0] as unknown[])?.[1] as string[];
+    const jobPath = cliArgs[cliArgs.indexOf("--background-task-file") + 1] as string;
+    const record = JSON.parse(fs.readFileSync(jobPath, "utf8")) as {
+      sandboxMode: string;
+      sandboxSettings?: {
+        allowNet: boolean;
+        allowedHosts: string[];
+        cpus: number;
+        memory: number;
+      };
+    };
+
+    expect(record.sandboxMode).toBe("shuru");
+    expect(record.sandboxSettings).toEqual(sandboxSettings);
+  });
 });

--- a/src/agent/delegations.ts
+++ b/src/agent/delegations.ts
@@ -4,7 +4,7 @@ import { promises as fs } from "fs";
 import os from "os";
 import path from "path";
 import type { DelegationRun, DelegationStatus, TaskRequest, ToolResult } from "../types/index";
-import type { SandboxMode } from "../utils/settings";
+import type { SandboxMode, SandboxSettings } from "../utils/settings";
 
 const ID_ADJECTIVES = ["brisk", "calm", "clever", "eager", "gentle", "keen", "lively", "nimble", "quiet", "steady"];
 
@@ -20,6 +20,7 @@ export interface StoredDelegation {
   cwd: string;
   model: string;
   sandboxMode: SandboxMode;
+  sandboxSettings?: SandboxSettings;
   maxToolRounds: number;
   maxTokens: number;
   status: DelegationStatus;
@@ -41,6 +42,7 @@ export interface DelegationNotification {
 interface StartDelegationOptions {
   model: string;
   sandboxMode: SandboxMode;
+  sandboxSettings?: SandboxSettings;
   maxToolRounds: number;
   maxTokens: number;
 }
@@ -78,6 +80,7 @@ export class DelegationManager {
       cwd,
       model: options.model,
       sandboxMode: options.sandboxMode,
+      sandboxSettings: options.sandboxSettings,
       maxToolRounds: options.maxToolRounds,
       maxTokens: options.maxTokens,
       status: "running",

--- a/src/agent/sandbox.test.ts
+++ b/src/agent/sandbox.test.ts
@@ -75,4 +75,41 @@ describe("Agent sandbox mode", () => {
       expect.objectContaining({ sandboxMode: "shuru" }),
     );
   });
+
+  it("can get and set sandbox settings", async () => {
+    const { Agent } = await importAgentModule();
+    const agent = new Agent(undefined, undefined, undefined, undefined, {
+      persistSession: false,
+      sandboxMode: "shuru",
+      sandboxSettings: { allowNet: true, cpus: 4 },
+    });
+
+    expect(agent.getSandboxSettings()).toEqual({ allowNet: true, cpus: 4 });
+
+    agent.setSandboxSettings({ allowNet: false, memory: 2048 });
+    expect(agent.getSandboxSettings()).toEqual({ allowNet: false, memory: 2048 });
+  });
+
+  it("passes sandbox settings into background delegations", async () => {
+    const { Agent } = await importAgentModule();
+    const settings = { allowNet: true, allowedHosts: ["api.openai.com"] };
+    const agent = new Agent(undefined, undefined, undefined, undefined, {
+      persistSession: false,
+      sandboxMode: "shuru",
+      sandboxSettings: settings,
+    });
+    const startMock = vi.fn(async () => ({ success: true, output: "ok" }));
+    (agent as unknown as { delegations: { start: typeof startMock } }).delegations.start = startMock;
+
+    await (agent as unknown as { runDelegation: (request: unknown) => Promise<unknown> }).runDelegation({
+      agent: "explore",
+      description: "Inspect",
+      prompt: "Look around",
+    });
+
+    expect(startMock).toHaveBeenCalledWith(
+      expect.objectContaining({ agent: "explore" }),
+      expect.objectContaining({ sandboxSettings: settings }),
+    );
+  });
 });

--- a/src/grok/tools.test.ts
+++ b/src/grok/tools.test.ts
@@ -44,6 +44,29 @@ describe("schedule daemon tools", () => {
     expect(bashTool.description).toContain("do not persist back to the host");
   });
 
+  it("reflects network enabled in sandbox tool description", () => {
+    const tools = createTools(
+      new BashTool("/tmp", { sandboxMode: "shuru", sandboxSettings: { allowNet: true } }),
+      {} as never,
+      "agent",
+    );
+    const bashTool = tools.bash as { description?: string };
+    expect(bashTool.description).toContain("network access is enabled");
+  });
+
+  it("reflects restricted hosts in sandbox tool description", () => {
+    const tools = createTools(
+      new BashTool("/tmp", {
+        sandboxMode: "shuru",
+        sandboxSettings: { allowNet: true, allowedHosts: ["api.openai.com"] },
+      }),
+      {} as never,
+      "agent",
+    );
+    const bashTool = tools.bash as { description?: string };
+    expect(bashTool.description).toContain("network is restricted to: api.openai.com");
+  });
+
   it("reports daemon status", async () => {
     const { tools } = createScheduleToolSet({
       getDaemonStatus: async () => ({ running: true, pid: 4321 }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,10 @@ import {
   getBaseURL,
   getCurrentModel,
   getCurrentSandboxMode,
+  getCurrentSandboxSettings,
+  mergeSandboxSettings,
   type SandboxMode,
+  type SandboxSettings,
   saveUserSettings,
 } from "./utils/settings";
 
@@ -47,10 +50,11 @@ async function startInteractive(
   model: string,
   maxToolRounds: number,
   sandboxMode: SandboxMode,
+  sandboxSettings: SandboxSettings,
   session?: string,
   initialMessage?: string,
 ) {
-  const agent = new Agent(apiKey, baseURL, model, maxToolRounds, { session, sandboxMode });
+  const agent = new Agent(apiKey, baseURL, model, maxToolRounds, { session, sandboxMode, sandboxSettings });
   const { createCliRenderer } = await import("@opentui/core");
   const { createRoot } = await import("@opentui/react");
   const { createElement } = await import("react");
@@ -79,6 +83,7 @@ async function startInteractive(
         model,
         maxToolRounds,
         sandboxMode,
+        sandboxSettings,
       },
       initialMessage,
       onExit,
@@ -93,10 +98,11 @@ async function runHeadless(
   model: string,
   maxToolRounds: number,
   sandboxMode: SandboxMode,
+  sandboxSettings: SandboxSettings,
   format: HeadlessOutputFormat,
   session?: string,
 ) {
-  const agent = new Agent(apiKey, baseURL, model, maxToolRounds, { session, sandboxMode });
+  const agent = new Agent(apiKey, baseURL, model, maxToolRounds, { session, sandboxMode, sandboxSettings });
   const prelude = renderHeadlessPrelude(format, agent.getSessionId() || undefined);
   if (prelude.stdout) process.stdout.write(prelude.stdout);
   if (prelude.stderr) process.stderr.write(prelude.stderr);
@@ -141,6 +147,10 @@ function stringOption(value: string | boolean | undefined): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
 
+function collect(value: string, prev: string[]): string[] {
+  return [...prev, value];
+}
+
 function resolveCliSandboxMode(value: string | boolean | undefined): SandboxMode | undefined {
   if (value === true) return "shuru";
   if (value === false) return "off";
@@ -162,7 +172,12 @@ async function runBackgroundDelegation(jobPath: string, options: CliOptions) {
     const maxToolRounds =
       parseInt(stringOption(options.maxToolRounds) || String(delegation.maxToolRounds), 10) || delegation.maxToolRounds;
     const sandboxMode = resolveCliSandboxMode(options.sandbox) || delegation.sandboxMode || getCurrentSandboxMode();
-    const agent = new Agent(apiKey, baseURL, model, maxToolRounds, { persistSession: false, sandboxMode });
+    const sandboxSettings = mergeSandboxSettings(getCurrentSandboxSettings(), delegation.sandboxSettings);
+    const agent = new Agent(apiKey, baseURL, model, maxToolRounds, {
+      persistSession: false,
+      sandboxMode,
+      sandboxSettings,
+    });
     const result = await agent.runTaskRequest({
       agent: delegation.agent,
       description: delegation.description,
@@ -195,10 +210,23 @@ function resolveConfig(options: CliOptions) {
   const maxToolRounds = parseInt(stringOption(options.maxToolRounds) || "400", 10) || 400;
   const sandboxMode = resolveCliSandboxMode(options.sandbox) || getCurrentSandboxMode();
 
+  const cliOverrides: SandboxSettings = {};
+  if (options.allowNet === true) cliOverrides.allowNet = true;
+  const allowHostValue = options.allowHost;
+  if (Array.isArray(allowHostValue) && allowHostValue.length > 0) {
+    cliOverrides.allowedHosts = allowHostValue as string[];
+    if (!cliOverrides.allowNet) cliOverrides.allowNet = true;
+  }
+  const portValue = options.port;
+  if (Array.isArray(portValue) && portValue.length > 0) {
+    cliOverrides.ports = portValue as string[];
+  }
+  const sandboxSettings = mergeSandboxSettings(getCurrentSandboxSettings(), cliOverrides);
+
   if (typeof options.apiKey === "string") saveUserSettings({ apiKey: options.apiKey });
   if (typeof options.model === "string") saveUserSettings({ defaultModel: normalizeModelId(options.model) });
 
-  return { apiKey, baseURL, model, maxToolRounds, sandboxMode };
+  return { apiKey, baseURL, model, maxToolRounds, sandboxMode, sandboxSettings };
 }
 
 function requireApiKey(apiKey: string | undefined): string {
@@ -233,6 +261,9 @@ program
   .option("--format <format>", "Headless output format: text or json", parseHeadlessOutputFormat, "text")
   .option("--sandbox", "Run agent shell commands inside a Shuru sandbox")
   .option("--no-sandbox", "Run agent shell commands directly on the host")
+  .option("--allow-net", "Enable network access inside the Shuru sandbox")
+  .option("--allow-host <pattern>", "Restrict sandbox network to specific hosts (repeatable)", collect, [])
+  .option("--port <mapping>", "Forward a host port to sandbox guest (HOST:GUEST, repeatable)", collect, [])
   .option("-s, --session <id>", "Continue a saved session by id, or use 'latest'")
   .option("--background-task-file <path>", "Run a persisted background delegation")
   .option("--max-tool-rounds <n>", "Max tool execution rounds", "400")
@@ -254,6 +285,7 @@ program
         config.model,
         config.maxToolRounds,
         config.sandboxMode,
+        config.sandboxSettings,
         options.format,
         options.session,
       );
@@ -267,6 +299,7 @@ program
       config.model,
       config.maxToolRounds,
       config.sandboxMode,
+      config.sandboxSettings,
       options.session,
       initialMessage,
     );
@@ -296,6 +329,7 @@ program
         model: config.model,
         maxToolRounds: config.maxToolRounds,
         sandboxMode: config.sandboxMode,
+        sandboxSettings: config.sandboxSettings,
         logFile: options.logFile,
         pairCodeFile: options.pairCodeFile,
       });

--- a/src/telegram/headless-bridge.ts
+++ b/src/telegram/headless-bridge.ts
@@ -7,9 +7,11 @@ import {
   getBaseURL,
   getCurrentModel,
   getCurrentSandboxMode,
+  getCurrentSandboxSettings,
   getTelegramBotToken,
   loadUserSettings,
   type SandboxMode,
+  type SandboxSettings,
   saveApprovedTelegramUserId,
   saveUserSettings,
 } from "../utils/settings";
@@ -27,6 +29,7 @@ export interface TelegramHeadlessBridgeOptions {
   baseURL?: string;
   model?: string;
   sandboxMode?: SandboxMode;
+  sandboxSettings?: SandboxSettings;
   maxToolRounds?: number;
   logFile?: string;
   pairCodeFile?: string;
@@ -37,6 +40,7 @@ interface TelegramHeadlessStartupConfig {
   baseURL: string;
   model: string;
   sandboxMode: SandboxMode;
+  sandboxSettings: SandboxSettings;
   maxToolRounds: number;
 }
 
@@ -76,7 +80,7 @@ function buildTelegramAgentFactory(startupConfig: TelegramHeadlessStartupConfig)
       startupConfig.baseURL,
       startupConfig.model,
       startupConfig.maxToolRounds,
-      { session: sessionId, sandboxMode: startupConfig.sandboxMode },
+      { session: sessionId, sandboxMode: startupConfig.sandboxMode, sandboxSettings: startupConfig.sandboxSettings },
     );
 
     const nextSessionId = agent.getSessionId();
@@ -126,6 +130,7 @@ export async function runTelegramHeadlessBridge(options: TelegramHeadlessBridgeO
     baseURL: options.baseURL ?? getBaseURL(),
     model: options.model ?? getCurrentModel(),
     sandboxMode: options.sandboxMode ?? getCurrentSandboxMode(),
+    sandboxSettings: options.sandboxSettings ?? getCurrentSandboxSettings(),
     maxToolRounds: options.maxToolRounds ?? 400,
   };
   const pathOptions: TelegramHeadlessBridgePathOptions = {

--- a/src/tools/bash.test.ts
+++ b/src/tools/bash.test.ts
@@ -33,6 +33,63 @@ describe("wrapCommandForShuru", () => {
     const result = wrapCommandForShuru("/repo", "echo 'hello world'");
     expect(result).toContain("'\\''hello world'\\''");
   });
+
+  it("includes --allow-net when allowNet is true", () => {
+    const result = wrapCommandForShuru("/repo", "curl example.com", { allowNet: true });
+    expect(result).toContain("--allow-net");
+    expect(result).toContain("--mount '/repo:/workspace'");
+  });
+
+  it("includes --allow-host flags for each allowed host", () => {
+    const result = wrapCommandForShuru("/repo", "curl api.openai.com", {
+      allowNet: true,
+      allowedHosts: ["api.openai.com", "registry.npmjs.org"],
+    });
+    expect(result).toContain("--allow-net");
+    expect(result).toContain("--allow-host api.openai.com");
+    expect(result).toContain("--allow-host registry.npmjs.org");
+  });
+
+  it("includes port forwards", () => {
+    const result = wrapCommandForShuru("/repo", "python -m http.server", { ports: ["8080:8000", "8443:443"] });
+    expect(result).toContain("-p 8080:8000");
+    expect(result).toContain("-p 8443:443");
+  });
+
+  it("includes resource limits", () => {
+    const result = wrapCommandForShuru("/repo", "make -j4", { cpus: 4, memory: 4096, diskSize: 8192 });
+    expect(result).toContain("--cpus 4");
+    expect(result).toContain("--memory 4096");
+    expect(result).toContain("--disk-size 8192");
+  });
+
+  it("includes --from checkpoint flag", () => {
+    const result = wrapCommandForShuru("/repo", "python script.py", { from: "py-env" });
+    expect(result).toContain("--from py-env");
+  });
+
+  it("includes --secret flags", () => {
+    const result = wrapCommandForShuru("/repo", "curl https://api.openai.com", {
+      allowNet: true,
+      secrets: [{ name: "API_KEY", fromEnv: "OPENAI_API_KEY", hosts: ["api.openai.com"] }],
+    });
+    expect(result).toContain("--secret API_KEY=OPENAI_API_KEY@api.openai.com");
+  });
+
+  it("combines multiple settings correctly", () => {
+    const result = wrapCommandForShuru("/repo", "echo hi", {
+      allowNet: true,
+      allowedHosts: ["example.com"],
+      cpus: 2,
+      from: "base",
+    });
+    expect(result).toMatch(/^shuru run --cpus 2 --allow-net --allow-host example\.com --from base --mount/);
+  });
+
+  it("uses default empty settings when none provided", () => {
+    const result = wrapCommandForShuru("/repo", "echo hi", {});
+    expect(result).toBe("shuru run --mount '/repo:/workspace' -- sh -lc 'cd /workspace && echo hi'");
+  });
 });
 
 describe("getSandboxMutationBlockReason", () => {
@@ -124,5 +181,44 @@ describe("BashTool sandbox state", () => {
     expect(off.getToolDescription()).not.toContain("Shuru");
     expect(on.getToolDescription()).toContain("Shuru sandbox");
     expect(on.getToolDescription()).toContain("do not persist back to the host");
+  });
+
+  it("stores and returns sandbox settings", () => {
+    const bash = new BashTool("/repo", {
+      sandboxMode: "shuru",
+      sandboxSettings: { allowNet: true, cpus: 4 },
+    });
+
+    expect(bash.getSandboxSettings()).toEqual({ allowNet: true, cpus: 4 });
+  });
+
+  it("can update sandbox settings at runtime", () => {
+    const bash = new BashTool("/repo", { sandboxMode: "shuru" });
+
+    expect(bash.getSandboxSettings()).toEqual({});
+
+    bash.setSandboxSettings({ allowNet: true, allowedHosts: ["api.openai.com"] });
+
+    expect(bash.getSandboxSettings()).toEqual({ allowNet: true, allowedHosts: ["api.openai.com"] });
+  });
+
+  it("includes network status in tool description when allowNet is set", () => {
+    const netOn = new BashTool("/repo", {
+      sandboxMode: "shuru",
+      sandboxSettings: { allowNet: true },
+    });
+    expect(netOn.getToolDescription()).toContain("network access is enabled");
+
+    const netRestricted = new BashTool("/repo", {
+      sandboxMode: "shuru",
+      sandboxSettings: { allowNet: true, allowedHosts: ["api.openai.com"] },
+    });
+    expect(netRestricted.getToolDescription()).toContain("network is restricted to: api.openai.com");
+
+    const netOff = new BashTool("/repo", {
+      sandboxMode: "shuru",
+      sandboxSettings: { allowNet: false },
+    });
+    expect(netOff.getToolDescription()).toContain("network is disabled");
   });
 });

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -4,7 +4,7 @@ import { mkdtemp, rm, stat, unlink } from "fs/promises";
 import os from "os";
 import path from "path";
 import type { ToolResult } from "../types/index";
-import type { SandboxMode } from "../utils/settings";
+import type { SandboxMode, SandboxSettings } from "../utils/settings";
 
 const MAX_TAIL_BYTES = 8_192;
 const MAX_BACKGROUND_PROCESSES = 8;
@@ -23,6 +23,7 @@ export interface BackgroundProcess {
 
 interface BashToolOptions {
   sandboxMode?: SandboxMode;
+  sandboxSettings?: SandboxSettings;
 }
 
 let nextBgId = 1;
@@ -32,10 +33,12 @@ export class BashTool {
   private bgProcesses = new Map<number, BackgroundProcess>();
   private tmpDir: string | null = null;
   private sandboxMode: SandboxMode;
+  private sandboxSettings: SandboxSettings;
 
   constructor(initialCwd = process.cwd(), options: BashToolOptions = {}) {
     this.cwd = initialCwd;
     this.sandboxMode = options.sandboxMode ?? "off";
+    this.sandboxSettings = options.sandboxSettings ?? {};
   }
 
   private async ensureTmpDir(): Promise<string> {
@@ -362,9 +365,23 @@ export class BashTool {
     this.sandboxMode = mode;
   }
 
+  getSandboxSettings(): SandboxSettings {
+    return this.sandboxSettings;
+  }
+
+  setSandboxSettings(settings: SandboxSettings): void {
+    this.sandboxSettings = settings;
+  }
+
   getToolDescription(): string {
     if (this.sandboxMode === "shuru") {
-      return "Execute a bash command inside a Shuru sandbox. Use for searching (grep, rg, find), git inspection, build tools, test runners, and other shell commands that should stay isolated. The current workspace is mounted inside the sandbox at /workspace, network is disabled by default unless configured, and shell-side workspace file changes do not persist back to the host in this version, so prefer the dedicated file tools for durable edits. Set background=true for long-running processes like dev servers or watchers.";
+      const s = this.sandboxSettings;
+      const netStatus = s.allowNet
+        ? s.allowedHosts?.length
+          ? `network is restricted to: ${s.allowedHosts.join(", ")}`
+          : "network access is enabled"
+        : "network is disabled";
+      return `Execute a bash command inside a Shuru sandbox. Use for searching (grep, rg, find), git inspection, build tools, test runners, and other shell commands that should stay isolated. The current workspace is mounted inside the sandbox at /workspace, ${netStatus}, and shell-side workspace file changes do not persist back to the host in this version, so prefer the dedicated file tools for durable edits. Set background=true for long-running processes like dev servers or watchers.`;
     }
     return "Execute a bash command. Use for searching (grep, rg, find), git, build tools, package managers, running tests, and any other shell command. Set background=true for long-running processes like dev servers, watchers, or anything that should keep running while you continue working. For file read/write/edit, prefer the dedicated file tools instead.";
   }
@@ -381,7 +398,7 @@ export class BashTool {
     if (blockedReason) {
       return { ok: false, error: blockedReason };
     }
-    return { ok: true, command: wrapCommandForShuru(this.cwd, command) };
+    return { ok: true, command: wrapCommandForShuru(this.cwd, command, this.sandboxSettings) };
   }
 
   private formatSandboxRuntimeError(output: string, fallbackMessage: string): string | null {
@@ -412,10 +429,30 @@ function formatAge(start: Date): string {
   return `${hr}h${min % 60}m`;
 }
 
-export function wrapCommandForShuru(cwd: string, command: string): string {
+export function wrapCommandForShuru(cwd: string, command: string, settings: SandboxSettings = {}): string {
+  const parts: string[] = ["shuru", "run"];
+
+  if (settings.cpus) parts.push("--cpus", String(settings.cpus));
+  if (settings.memory) parts.push("--memory", String(settings.memory));
+  if (settings.diskSize) parts.push("--disk-size", String(settings.diskSize));
+  if (settings.allowNet) parts.push("--allow-net");
+  if (settings.allowedHosts) {
+    for (const host of settings.allowedHosts) parts.push("--allow-host", host);
+  }
+  if (settings.ports) {
+    for (const port of settings.ports) parts.push("-p", port);
+  }
+  if (settings.secrets) {
+    for (const s of settings.secrets) {
+      parts.push("--secret", `${s.name}=${s.fromEnv}@${s.hosts.join(",")}`);
+    }
+  }
+  if (settings.from) parts.push("--from", settings.from);
+
   const mountArg = `${cwd}:/workspace`;
-  const innerCommand = `cd /workspace && ${command}`;
-  return `shuru run --mount ${shellQuote(mountArg)} -- sh -lc ${shellQuote(innerCommand)}`;
+  parts.push("--mount", shellQuote(mountArg));
+  parts.push("--", "sh", "-lc", shellQuote(`cd /workspace && ${command}`));
+  return parts.join(" ");
 }
 
 function shellQuote(value: string): string {

--- a/src/ui/app.tsx
+++ b/src/ui/app.tsx
@@ -45,6 +45,7 @@ import {
   type McpRemoteTransport,
   type McpServerConfig,
   type SandboxMode,
+  type SandboxSettings,
   saveApprovedTelegramUserId,
   saveMcpServers,
   saveProjectSettings,
@@ -348,10 +349,104 @@ const BUILTIN_TYPED_SLASH_COMMANDS = new Set([
   "/commit-pr",
 ]);
 
-const SANDBOX_OPTIONS: Array<{ id: SandboxMode; label: string; description: string }> = [
-  { id: "off", label: "Off", description: "Run shell commands directly on the host" },
-  { id: "shuru", label: "Shuru", description: "Run shell commands inside a Shuru sandbox" },
+interface SandboxRow {
+  key: string;
+  label: string;
+  type: "toggle" | "text";
+  placeholder?: string;
+  getDisplay: (mode: SandboxMode, s: SandboxSettings) => string;
+  getOptions?: () => string[];
+  apply: (mode: SandboxMode, s: SandboxSettings, value: string) => { mode?: SandboxMode; settings?: SandboxSettings };
+}
+
+const SANDBOX_ROWS: SandboxRow[] = [
+  {
+    key: "mode",
+    label: "Mode",
+    type: "toggle",
+    getDisplay: (mode) => (mode === "shuru" ? "Shuru" : "Off"),
+    getOptions: () => ["Off", "Shuru"],
+    apply: (_mode, _s, value) => ({ mode: value === "Shuru" ? "shuru" : "off" }),
+  },
+  {
+    key: "allowNet",
+    label: "Network",
+    type: "toggle",
+    getDisplay: (_m, s) => (s.allowNet ? "On" : "Off"),
+    getOptions: () => ["Off", "On"],
+    apply: (_m, _s, value) => ({ settings: { allowNet: value === "On" } }),
+  },
+  {
+    key: "allowedHosts",
+    label: "Allowed hosts",
+    type: "text",
+    placeholder: "api.openai.com, registry.npmjs.org",
+    getDisplay: (_m, s) => s.allowedHosts?.join(", ") || "(unrestricted)",
+    apply: (_m, _s, value) => ({
+      settings: {
+        allowedHosts: value
+          ? value
+              .split(",")
+              .map((h) => h.trim())
+              .filter(Boolean)
+          : undefined,
+      },
+    }),
+  },
+  {
+    key: "ports",
+    label: "Port forwards",
+    type: "text",
+    placeholder: "8080:80, 8443:443",
+    getDisplay: (_m, s) => s.ports?.join(", ") || "(none)",
+    apply: (_m, _s, value) => ({
+      settings: {
+        ports: value
+          ? value
+              .split(",")
+              .map((p) => p.trim())
+              .filter(Boolean)
+          : undefined,
+      },
+    }),
+  },
+  {
+    key: "cpus",
+    label: "CPUs",
+    type: "text",
+    placeholder: "e.g. 4",
+    getDisplay: (_m, s) => (s.cpus ? String(s.cpus) : "(default)"),
+    apply: (_m, _s, value) => ({ settings: { cpus: value ? parseInt(value, 10) || undefined : undefined } }),
+  },
+  {
+    key: "memory",
+    label: "Memory (MB)",
+    type: "text",
+    placeholder: "e.g. 4096",
+    getDisplay: (_m, s) => (s.memory ? String(s.memory) : "(default)"),
+    apply: (_m, _s, value) => ({ settings: { memory: value ? parseInt(value, 10) || undefined : undefined } }),
+  },
+  {
+    key: "diskSize",
+    label: "Disk size (MB)",
+    type: "text",
+    placeholder: "e.g. 8192",
+    getDisplay: (_m, s) => (s.diskSize ? String(s.diskSize) : "(default)"),
+    apply: (_m, _s, value) => ({ settings: { diskSize: value ? parseInt(value, 10) || undefined : undefined } }),
+  },
+  {
+    key: "from",
+    label: "Checkpoint",
+    type: "text",
+    placeholder: "checkpoint name",
+    getDisplay: (_m, s) => s.from || "(none)",
+    apply: (_m, _s, value) => ({ settings: { from: value || undefined } }),
+  },
 ];
+
+function getSandboxVisibleRows(mode: SandboxMode): SandboxRow[] {
+  return mode === "shuru" ? SANDBOX_ROWS : SANDBOX_ROWS.slice(0, 1);
+}
 
 function parseCustomSubagentSlashCommand(
   cmd: string,
@@ -406,6 +501,7 @@ export interface AppStartupConfig {
   baseURL: string;
   model: string;
   sandboxMode: SandboxMode;
+  sandboxSettings: SandboxSettings;
   maxToolRounds: number;
 }
 
@@ -444,7 +540,10 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
   const [modelPickerIndex, setModelPickerIndex] = useState(0);
   const [modelSearchQuery, setModelSearchQuery] = useState("");
   const [showSandboxPicker, setShowSandboxPicker] = useState(false);
-  const [sandboxPickerIndex, setSandboxPickerIndex] = useState(0);
+  const [sandboxSettings, setSandboxSettingsState] = useState<SandboxSettings>(() => agent.getSandboxSettings());
+  const [sandboxSettingsFocusIndex, setSandboxSettingsFocusIndex] = useState(0);
+  const [sandboxSettingsEditing, setSandboxSettingsEditing] = useState<string | null>(null);
+  const [sandboxSettingsEditBuffer, setSandboxSettingsEditBuffer] = useState("");
   const [activeToolCalls, setActiveToolCalls] = useState<ToolCall[]>([]);
   const [sessionTitle, setSessionTitle] = useState<string | null>(() => agent.getSessionTitle());
   const [sessionId, setSessionId] = useState<string | null>(() => agent.getSessionId());
@@ -584,7 +683,6 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
       )
     : MODELS;
   const filteredModelIds = filteredModels.map((m) => m.id);
-  const currentSandboxIndex = SANDBOX_OPTIONS.findIndex((option) => option.id === sandboxMode);
   const filteredSlashItems = slashSearchQuery
     ? SLASH_MENU_ITEMS.filter(
         (item) =>
@@ -621,10 +719,25 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
     [agent],
   );
 
+  const applySandboxSettings = useCallback(
+    (next: SandboxSettings) => {
+      agent.setSandboxSettings(next);
+      for (const telegramAgent of telegramAgentsRef.current.values()) {
+        telegramAgent.setSandboxSettings(next);
+      }
+      setSandboxSettingsState(next);
+      saveProjectSettings({ sandbox: next });
+      saveUserSettings({ sandbox: next });
+    },
+    [agent],
+  );
+
   const openSandboxPicker = useCallback(() => {
-    setSandboxPickerIndex(Math.max(0, currentSandboxIndex));
+    setSandboxSettingsFocusIndex(0);
+    setSandboxSettingsEditing(null);
+    setSandboxSettingsEditBuffer("");
     setShowSandboxPicker(true);
-  }, [currentSandboxIndex]);
+  }, []);
 
   const setReasoningEfforts = useCallback((next: Record<string, ReasoningEffort>) => {
     setReasoningEffortByModel(next);
@@ -1307,6 +1420,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
       const a = new Agent(apiKey, startupConfig.baseURL, startupConfig.model, startupConfig.maxToolRounds, {
         session: sid,
         sandboxMode,
+        sandboxSettings,
       });
       if (!sid && a.getSessionId()) {
         saveUserSettings({
@@ -1323,7 +1437,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
       map.set(userId, a);
       return a;
     },
-    [sandboxMode, startupConfig, wireTelegramAgentUi],
+    [sandboxMode, sandboxSettings, startupConfig, wireTelegramAgentUi],
   );
 
   const appendTelegramUserMessage = useCallback(
@@ -2526,24 +2640,82 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
         return;
       }
       if (showSandboxPicker) {
+        const visibleRows = getSandboxVisibleRows(sandboxMode);
+
+        if (sandboxSettingsEditing) {
+          if (isEscapeKey(key)) {
+            setSandboxSettingsEditing(null);
+            setSandboxSettingsEditBuffer("");
+            return;
+          }
+          if (key.name === "return") {
+            const row = visibleRows.find((r) => r.key === sandboxSettingsEditing);
+            if (row) {
+              const result = row.apply(sandboxMode, sandboxSettings, sandboxSettingsEditBuffer.trim());
+              if (result.mode !== undefined) applySandboxMode(result.mode);
+              if (result.settings) applySandboxSettings({ ...sandboxSettings, ...result.settings });
+            }
+            setSandboxSettingsEditing(null);
+            setSandboxSettingsEditBuffer("");
+            return;
+          }
+          if (key.name === "backspace") {
+            setSandboxSettingsEditBuffer((b) => b.slice(0, -1));
+            return;
+          }
+          if (key.sequence && key.sequence.length === 1 && !key.ctrl && !key.meta) {
+            setSandboxSettingsEditBuffer((b) => b + key.sequence);
+            return;
+          }
+          return;
+        }
+
         if (isEscapeKey(key)) {
           setShowSandboxPicker(false);
           return;
         }
         if (key.name === "up") {
-          setSandboxPickerIndex((i) => Math.max(0, i - 1));
+          setSandboxSettingsFocusIndex((i) => Math.max(0, i - 1));
           return;
         }
         if (key.name === "down") {
-          setSandboxPickerIndex((i) => Math.min(SANDBOX_OPTIONS.length - 1, i + 1));
+          setSandboxSettingsFocusIndex((i) => Math.min(visibleRows.length - 1, i + 1));
           return;
         }
-        if (key.name === "return") {
-          const selected = SANDBOX_OPTIONS[sandboxPickerIndex];
-          if (selected) {
-            applySandboxMode(selected.id);
+
+        const focusedRow = visibleRows[sandboxSettingsFocusIndex];
+        if (!focusedRow) return;
+
+        if (focusedRow.type === "toggle" && (key.name === "left" || key.name === "right")) {
+          const options = focusedRow.getOptions!();
+          const current = focusedRow.getDisplay(sandboxMode, sandboxSettings);
+          const idx = options.indexOf(current);
+          const next =
+            key.name === "right" ? options[Math.min(options.length - 1, idx + 1)] : options[Math.max(0, idx - 1)];
+          if (next && next !== current) {
+            const result = focusedRow.apply(sandboxMode, sandboxSettings, next);
+            if (result.mode !== undefined) applySandboxMode(result.mode);
+            if (result.settings) applySandboxSettings({ ...sandboxSettings, ...result.settings });
           }
-          setShowSandboxPicker(false);
+          return;
+        }
+
+        if (key.name === "return") {
+          if (focusedRow.type === "toggle") {
+            const options = focusedRow.getOptions!();
+            const current = focusedRow.getDisplay(sandboxMode, sandboxSettings);
+            const idx = options.indexOf(current);
+            const next = options[(idx + 1) % options.length];
+            const result = focusedRow.apply(sandboxMode, sandboxSettings, next);
+            if (result.mode !== undefined) applySandboxMode(result.mode);
+            if (result.settings) applySandboxSettings({ ...sandboxSettings, ...result.settings });
+          } else {
+            setSandboxSettingsEditing(focusedRow.key);
+            const current = sandboxSettings[focusedRow.key as keyof SandboxSettings];
+            setSandboxSettingsEditBuffer(
+              Array.isArray(current) ? current.join(", ") : current != null ? String(current) : "",
+            );
+          }
           return;
         }
         return;
@@ -2654,7 +2826,12 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
       pqs,
       removeEditingSubagent,
       applySandboxMode,
-      sandboxPickerIndex,
+      applySandboxSettings,
+      sandboxSettings,
+      sandboxSettingsEditing,
+      sandboxSettingsEditBuffer,
+      sandboxSettingsFocusIndex,
+      sandboxMode,
       showModelPicker,
       showPlanPanel,
       showSandboxPicker,
@@ -2972,7 +3149,10 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
         <SandboxPickerModal
           t={t}
           currentMode={sandboxMode}
-          selectedIndex={sandboxPickerIndex}
+          settings={sandboxSettings}
+          focusIndex={sandboxSettingsFocusIndex}
+          editing={sandboxSettingsEditing}
+          editBuffer={sandboxSettingsEditBuffer}
           width={width}
           height={height}
         />
@@ -4400,19 +4580,27 @@ function ModelPickerModal({
 function SandboxPickerModal({
   t,
   currentMode,
-  selectedIndex,
+  settings,
+  focusIndex,
+  editing,
+  editBuffer,
   width,
   height,
 }: {
   t: Theme;
   currentMode: SandboxMode;
-  selectedIndex: number;
+  settings: SandboxSettings;
+  focusIndex: number;
+  editing: string | null;
+  editBuffer: string;
   width: number;
   height: number;
 }) {
-  const panelHeight = Math.min(SANDBOX_OPTIONS.length + 5, Math.floor(height * 0.4));
+  const visibleRows = getSandboxVisibleRows(currentMode);
+  const panelHeight = Math.min(visibleRows.length + 6, Math.floor(height * 0.6));
   const top = bottomAlignedModalTop(height, panelHeight);
   const overlayBg = "#000000cc" as string;
+
   return (
     <box
       position="absolute"
@@ -4434,32 +4622,50 @@ function SandboxPickerModal({
       >
         <box flexShrink={0} flexDirection="row" justifyContent="space-between" paddingLeft={2} paddingRight={2}>
           <text fg={t.primary}>
-            <b>{"Select sandbox mode"}</b>
+            <b>{"Sandbox settings"}</b>
           </text>
           <text fg={t.textMuted}>{"esc"}</text>
         </box>
         <scrollbox flexGrow={1} minHeight={0}>
-          {SANDBOX_OPTIONS.map((option, idx) => {
-            const selected = idx === selectedIndex;
-            const current = option.id === currentMode;
+          {visibleRows.map((row, idx) => {
+            const focused = idx === focusIndex;
+            const isEditing = editing === row.key;
+            const display = row.getDisplay(currentMode, settings);
             return (
               <box
-                key={option.id}
-                backgroundColor={selected ? t.selectedBg : undefined}
+                key={row.key}
+                backgroundColor={focused ? t.selectedBg : undefined}
                 paddingLeft={2}
                 paddingRight={2}
                 width="100%"
               >
                 <box width="100%" flexDirection="row" justifyContent="space-between">
-                  <text fg={current ? t.accent : selected ? t.selected : t.text}>{option.label}</text>
-                  <text fg={selected ? t.primary : t.textMuted}>{option.description}</text>
+                  <text fg={focused ? t.selected : t.text}>{row.label}</text>
+                  {isEditing ? (
+                    <text fg={t.accent}>
+                      {editBuffer || row.placeholder || ""}
+                      {"_"}
+                    </text>
+                  ) : row.type === "toggle" ? (
+                    <text fg={focused ? t.primary : t.textMuted}>
+                      {"< "}
+                      {display}
+                      {" >"}
+                    </text>
+                  ) : (
+                    <text fg={focused ? t.primary : t.textMuted}>{display}</text>
+                  )}
                 </box>
               </box>
             );
           })}
         </scrollbox>
         <box flexShrink={0} paddingLeft={2} paddingRight={2} paddingTop={1}>
-          <text fg={t.textMuted}>{"enter select  esc close"}</text>
+          <text fg={t.textMuted}>
+            {editing
+              ? "type value  enter confirm  esc cancel"
+              : "arrows navigate  left/right toggle  enter edit  esc close"}
+          </text>
         </box>
       </box>
     </box>

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -8,6 +8,23 @@ export type TelegramStreamingMode = "off" | "partial";
 export type TelegramAudioInputEngine = "whisper.cpp";
 export type SandboxMode = "off" | "shuru";
 
+export interface SandboxSecretConfig {
+  name: string;
+  fromEnv: string;
+  hosts: string[];
+}
+
+export interface SandboxSettings {
+  allowNet?: boolean;
+  allowedHosts?: string[];
+  ports?: string[];
+  cpus?: number;
+  memory?: number;
+  diskSize?: number;
+  secrets?: SandboxSecretConfig[];
+  from?: string;
+}
+
 export const DEFAULT_TELEGRAM_AUDIO_INPUT_BINARY = "whisper-cli";
 export const DEFAULT_TELEGRAM_AUDIO_INPUT_MODEL = "tiny.en";
 
@@ -109,6 +126,7 @@ export interface UserSettings {
   apiKey?: string;
   defaultModel?: string;
   sandboxMode?: SandboxMode;
+  sandbox?: SandboxSettings;
   reasoningEffortByModel?: Record<string, ReasoningEffort>;
   telegram?: TelegramSettings;
   mcp?: McpSettings;
@@ -118,6 +136,7 @@ export interface UserSettings {
 export interface ProjectSettings {
   model?: string;
   sandboxMode?: SandboxMode;
+  sandbox?: SandboxSettings;
 }
 
 const USER_DIR = path.join(os.homedir(), ".grok");
@@ -198,6 +217,9 @@ export function saveUserSettings(partial: Partial<UserSettings>): void {
           })),
         }
       : {}),
+    ...(partial.sandbox !== undefined
+      ? { sandbox: normalizeSandboxSettings({ ...current.sandbox, ...partial.sandbox }) }
+      : {}),
   };
 
   writeJson(USER_SETTINGS_PATH, next);
@@ -216,6 +238,9 @@ export function saveProjectSettings(partial: Partial<ProjectSettings>): void {
     ...partial,
     ...(partial.model !== undefined ? { model: normalizeModelId(partial.model) } : {}),
     ...(partial.sandboxMode !== undefined ? { sandboxMode: normalizeSandboxMode(partial.sandboxMode) } : {}),
+    ...(partial.sandbox !== undefined
+      ? { sandbox: normalizeSandboxSettings({ ...current.sandbox, ...partial.sandbox }) }
+      : {}),
   });
 }
 
@@ -239,12 +264,77 @@ export function normalizeSandboxMode(value: unknown): SandboxMode {
   return value === "shuru" ? "shuru" : "off";
 }
 
+function isNonNullObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function normalizeSecretConfig(raw: unknown): SandboxSecretConfig | null {
+  if (!isNonNullObject(raw)) return null;
+  const name = typeof raw.name === "string" ? raw.name.trim() : "";
+  const fromEnv = typeof raw.fromEnv === "string" ? raw.fromEnv.trim() : "";
+  const hosts = Array.isArray(raw.hosts)
+    ? raw.hosts.filter((h): h is string => typeof h === "string" && h.trim() !== "")
+    : [];
+  if (!name || !fromEnv) return null;
+  return { name, fromEnv, hosts };
+}
+
+export function normalizeSandboxSettings(raw: unknown): SandboxSettings {
+  if (!isNonNullObject(raw)) return {};
+  const result: SandboxSettings = {};
+
+  if (typeof raw.allowNet === "boolean") result.allowNet = raw.allowNet;
+  if (Array.isArray(raw.allowedHosts)) {
+    const hosts = raw.allowedHosts.filter((h): h is string => typeof h === "string" && h.trim() !== "");
+    if (hosts.length > 0) result.allowedHosts = hosts;
+  }
+  if (Array.isArray(raw.ports)) {
+    const ports = raw.ports.filter((p): p is string => typeof p === "string" && /^\d+:\d+$/.test(p.trim()));
+    if (ports.length > 0) result.ports = ports;
+  }
+  if (typeof raw.cpus === "number" && raw.cpus > 0) result.cpus = raw.cpus;
+  if (typeof raw.memory === "number" && raw.memory > 0) result.memory = raw.memory;
+  if (typeof raw.diskSize === "number" && raw.diskSize > 0) result.diskSize = raw.diskSize;
+  if (Array.isArray(raw.secrets)) {
+    const secrets = raw.secrets.map(normalizeSecretConfig).filter((s): s is SandboxSecretConfig => s !== null);
+    if (secrets.length > 0) result.secrets = secrets;
+  }
+  if (typeof raw.from === "string" && raw.from.trim()) result.from = raw.from.trim();
+
+  return result;
+}
+
+export function mergeSandboxSettings(
+  base: SandboxSettings | undefined,
+  override: SandboxSettings | undefined,
+): SandboxSettings {
+  if (!base && !override) return {};
+  if (!base) return { ...override };
+  if (!override) return { ...base };
+  return {
+    allowNet: override.allowNet ?? base.allowNet,
+    allowedHosts: override.allowedHosts ?? base.allowedHosts,
+    ports: override.ports ?? base.ports,
+    cpus: override.cpus ?? base.cpus,
+    memory: override.memory ?? base.memory,
+    diskSize: override.diskSize ?? base.diskSize,
+    secrets: override.secrets ?? base.secrets,
+    from: override.from ?? base.from,
+  };
+}
+
 export function getCurrentSandboxMode(): SandboxMode {
   const project = loadProjectSettings();
   if (project.sandboxMode) return normalizeSandboxMode(project.sandboxMode);
   const user = loadUserSettings();
   if (user.sandboxMode) return normalizeSandboxMode(user.sandboxMode);
   return "off";
+}
+
+export function getCurrentSandboxSettings(): SandboxSettings {
+  const user = loadUserSettings();
+  const project = loadProjectSettings();
+  return mergeSandboxSettings(user.sandbox, project.sandbox);
 }
 
 export function getReasoningEffortForModel(modelId: string): ReasoningEffort | undefined {


### PR DESCRIPTION
## What does this PR do?

Expose Shuru sandbox configuration beyond the simple on/off toggle. Settings (allowNet, allowedHosts, ports, cpus, memory, diskSize, secrets, checkpoint) flow from CLI flags / saved settings through Agent, sub-agents, and background delegations into wrapCommandForShuru. The TUI /sandbox panel is replaced with a unified settings modal using arrow left/right for toggles and inline editing for text fields. Adds --allow-net, --allow-host, and --port CLI flags and a README section on sandbox support.

Fixes #216 

## Checklist

- [x] I tested my changes
- [x] I reviewed my own code