### PR TITLE
feat: add LSP support with server catalog and diagnostics

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "@ai-sdk/xai": "^3.0.67",
         "@coinbase/agentkit": "^0.10.4",
         "@modelcontextprotocol/sdk": "^1.27.1",
+        "@npmcli/arborist": "^9.4.2",
         "@opentui/core": "^0.1.88",
         "@opentui/react": "^0.1.88",
         "agent-desktop": "^0.1.11",
@@ -20,12 +21,15 @@
         "grammy": "^1.41.1",
         "react": "^19.2.4",
         "semver": "^7.7.4",
+        "vscode-jsonrpc": "^8.2.1",
+        "vscode-languageserver-types": "^3.17.5",
         "zod": "^4.3.6",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.8",
         "@types/diff": "^8.0.0",
         "@types/node": "^22.19.15",
+        "@types/npmcli__arborist": "^6.3.3",
         "@types/react": "^19.2.14",
         "@types/semver": "^7.7.1",
         "husky": "^9.1.7",
@@ -166,6 +170,8 @@
 
     "@ethersproject/wordlists": ["@ethersproject/wordlists@5.8.0", "", { "dependencies": { "@ethersproject/bytes": "^5.8.0", "@ethersproject/hash": "^5.8.0", "@ethersproject/logger": "^5.8.0", "@ethersproject/properties": "^5.8.0", "@ethersproject/strings": "^5.8.0" } }, "sha512-2df9bbXicZws2Sb5S6ET493uJ0Z84Fjr3pC4tu/qlnZERibZCeUVuqdtt+7Tv9xxhUxHoIekIA7avrKUWHrezg=="],
 
+    "@gar/promise-retry": ["@gar/promise-retry@1.0.3", "", {}, "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA=="],
+
     "@gemini-wallet/core": ["@gemini-wallet/core@0.3.2", "", { "dependencies": { "@metamask/rpc-errors": "7.0.2", "eventemitter3": "5.0.1" }, "peerDependencies": { "viem": ">=2.0.0" } }, "sha512-Z4aHi3ECFf5oWYWM3F1rW83GJfB9OvhBYPTmb5q+VyK3uvzvS48lwo+jwh2eOoCRWEuT/crpb9Vwp2QaS5JqgQ=="],
 
     "@grammyjs/types": ["@grammyjs/types@3.25.0", "", {}, "sha512-iN9i5p+8ZOu9OMxWNcguojQfz4K/PDyMPOnL7PPCON+SoA/F8OKMH3uR7CVUkYfdNe0GCz8QOzAWrnqusQYFOg=="],
@@ -177,6 +183,10 @@
     "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
 
     "@inquirer/external-editor": ["@inquirer/external-editor@1.0.3", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA=="],
+
+    "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
+
+    "@isaacs/string-locale-compare": ["@isaacs/string-locale-compare@1.1.0", "", {}, "sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ=="],
 
     "@jimp/core": ["@jimp/core@1.6.0", "", { "dependencies": { "@jimp/file-ops": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "await-to-js": "^3.0.0", "exif-parser": "^0.1.12", "file-type": "^16.0.0", "mime": "3" } }, "sha512-EQQlKU3s9QfdJqiSrZWNTxBs3rKXgO2W+GxNXDtwchF3a4IqxDheFX1ti+Env9hdJXDiYLp2jTRjlxhPthsk8w=="],
 
@@ -282,6 +292,36 @@
 
     "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
+    "@npm/types": ["@npm/types@1.0.2", "", {}, "sha512-KXZccTDEnWqNrrx6JjpJKU/wJvNeg9BDgjS0XhmlZab7br921HtyVbsYzJr4L+xIvjdJ20Wh9dgxgCI2a5CEQw=="],
+
+    "@npmcli/agent": ["@npmcli/agent@4.0.0", "", { "dependencies": { "agent-base": "^7.1.0", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.1", "lru-cache": "^11.2.1", "socks-proxy-agent": "^8.0.3" } }, "sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA=="],
+
+    "@npmcli/arborist": ["@npmcli/arborist@9.4.2", "", { "dependencies": { "@gar/promise-retry": "^1.0.0", "@isaacs/string-locale-compare": "^1.1.0", "@npmcli/fs": "^5.0.0", "@npmcli/installed-package-contents": "^4.0.0", "@npmcli/map-workspaces": "^5.0.0", "@npmcli/metavuln-calculator": "^9.0.2", "@npmcli/name-from-folder": "^4.0.0", "@npmcli/node-gyp": "^5.0.0", "@npmcli/package-json": "^7.0.0", "@npmcli/query": "^5.0.0", "@npmcli/redact": "^4.0.0", "@npmcli/run-script": "^10.0.0", "bin-links": "^6.0.0", "cacache": "^20.0.1", "common-ancestor-path": "^2.0.0", "hosted-git-info": "^9.0.0", "json-stringify-nice": "^1.1.4", "lru-cache": "^11.2.1", "minimatch": "^10.0.3", "nopt": "^9.0.0", "npm-install-checks": "^8.0.0", "npm-package-arg": "^13.0.0", "npm-pick-manifest": "^11.0.1", "npm-registry-fetch": "^19.0.0", "pacote": "^21.0.2", "parse-conflict-json": "^5.0.1", "proc-log": "^6.0.0", "proggy": "^4.0.0", "promise-all-reject-late": "^1.0.0", "promise-call-limit": "^3.0.1", "semver": "^7.3.7", "ssri": "^13.0.0", "treeverse": "^3.0.0", "walk-up-path": "^4.0.0" }, "bin": { "arborist": "bin/index.js" } }, "sha512-omJgPyzt11cEGrxzgrECoOyxAunmPMgBFTcAB/FbaB+9iOYhGmRdsQqySV8o0LWQ/l2kTeASUIMR4xJufVwmtw=="],
+
+    "@npmcli/fs": ["@npmcli/fs@5.0.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og=="],
+
+    "@npmcli/git": ["@npmcli/git@7.0.2", "", { "dependencies": { "@gar/promise-retry": "^1.0.0", "@npmcli/promise-spawn": "^9.0.0", "ini": "^6.0.0", "lru-cache": "^11.2.1", "npm-pick-manifest": "^11.0.1", "proc-log": "^6.0.0", "semver": "^7.3.5", "which": "^6.0.0" } }, "sha512-oeolHDjExNAJAnlYP2qzNjMX/Xi9bmu78C9dIGr4xjobrSKbuMYCph8lTzn4vnW3NjIqVmw/f8BCfouqyJXlRg=="],
+
+    "@npmcli/installed-package-contents": ["@npmcli/installed-package-contents@4.0.0", "", { "dependencies": { "npm-bundled": "^5.0.0", "npm-normalize-package-bin": "^5.0.0" }, "bin": { "installed-package-contents": "bin/index.js" } }, "sha512-yNyAdkBxB72gtZ4GrwXCM0ZUedo9nIbOMKfGjt6Cu6DXf0p8y1PViZAKDC8q8kv/fufx0WTjRBdSlyrvnP7hmA=="],
+
+    "@npmcli/map-workspaces": ["@npmcli/map-workspaces@5.0.3", "", { "dependencies": { "@npmcli/name-from-folder": "^4.0.0", "@npmcli/package-json": "^7.0.0", "glob": "^13.0.0", "minimatch": "^10.0.3" } }, "sha512-o2grssXo1e774E5OtEwwrgoszYRh0lqkJH+Pb9r78UcqdGJRDRfhpM8DvZPjzNLLNYeD/rNbjOKM3Ss5UABROw=="],
+
+    "@npmcli/metavuln-calculator": ["@npmcli/metavuln-calculator@9.0.3", "", { "dependencies": { "cacache": "^20.0.0", "json-parse-even-better-errors": "^5.0.0", "pacote": "^21.0.0", "proc-log": "^6.0.0", "semver": "^7.3.5" } }, "sha512-94GLSYhLXF2t2LAC7pDwLaM4uCARzxShyAQKsirmlNcpidH89VA4/+K1LbJmRMgz5gy65E/QBBWQdUvGLe2Frg=="],
+
+    "@npmcli/name-from-folder": ["@npmcli/name-from-folder@4.0.0", "", {}, "sha512-qfrhVlOSqmKM8i6rkNdZzABj8MKEITGFAY+4teqBziksCQAOLutiAxM1wY2BKEd8KjUSpWmWCYxvXr0y4VTlPg=="],
+
+    "@npmcli/node-gyp": ["@npmcli/node-gyp@5.0.0", "", {}, "sha512-uuG5HZFXLfyFKqg8QypsmgLQW7smiRjVc45bqD/ofZZcR/uxEjgQU8qDPv0s9TEeMUiAAU/GC5bR6++UdTirIQ=="],
+
+    "@npmcli/package-json": ["@npmcli/package-json@7.0.5", "", { "dependencies": { "@npmcli/git": "^7.0.0", "glob": "^13.0.0", "hosted-git-info": "^9.0.0", "json-parse-even-better-errors": "^5.0.0", "proc-log": "^6.0.0", "semver": "^7.5.3", "spdx-expression-parse": "^4.0.0" } }, "sha512-iVuTlG3ORq2iaVa1IWUxAO/jIp77tUKBhoMjuzYW2kL4MLN1bi/ofqkZ7D7OOwh8coAx1/S2ge0rMdGv8sLSOQ=="],
+
+    "@npmcli/promise-spawn": ["@npmcli/promise-spawn@9.0.1", "", { "dependencies": { "which": "^6.0.0" } }, "sha512-OLUaoqBuyxeTqUvjA3FZFiXUfYC1alp3Sa99gW3EUDz3tZ3CbXDdcZ7qWKBzicrJleIgucoWamWH1saAmH/l2Q=="],
+
+    "@npmcli/query": ["@npmcli/query@5.0.0", "", { "dependencies": { "postcss-selector-parser": "^7.0.0" } }, "sha512-8TZWfTQOsODpLqo9SVhVjHovmKXNpevHU0gO9e+y4V4fRIOneiXy0u0sMP9LmS71XivrEWfZWg50ReH4WRT4aQ=="],
+
+    "@npmcli/redact": ["@npmcli/redact@4.0.0", "", {}, "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q=="],
+
+    "@npmcli/run-script": ["@npmcli/run-script@10.0.4", "", { "dependencies": { "@npmcli/node-gyp": "^5.0.0", "@npmcli/package-json": "^7.0.0", "@npmcli/promise-spawn": "^9.0.0", "node-gyp": "^12.1.0", "proc-log": "^6.0.0" } }, "sha512-mGUWr1uMnf0le2TwfOZY4SFxZGXGfm4Jtay/nwAa2FLNAKXUoUwaGwBMNH36UHPtinWfTSJ3nqFQr0091CxVGg=="],
+
     "@opensea/seaport-js": ["@opensea/seaport-js@4.0.7", "", { "dependencies": { "ethers": "^6.16.0", "merkletreejs": "^0.6.0" } }, "sha512-0RHcTyCQLgHxzvNirCaJI0Uy7G90DDx9fKk1Xed6I+rzcvz+rzJrHQSRMtw25PLllQxudcIatTpd9GK4YBvjJQ=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
@@ -375,6 +415,18 @@
     "@scure/bip32": ["@scure/bip32@1.7.0", "", { "dependencies": { "@noble/curves": "~1.9.0", "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw=="],
 
     "@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
+
+    "@sigstore/bundle": ["@sigstore/bundle@4.0.0", "", { "dependencies": { "@sigstore/protobuf-specs": "^0.5.0" } }, "sha512-NwCl5Y0V6Di0NexvkTqdoVfmjTaQwoLM236r89KEojGmq/jMls8S+zb7yOwAPdXvbwfKDlP+lmXgAL4vKSQT+A=="],
+
+    "@sigstore/core": ["@sigstore/core@3.2.0", "", {}, "sha512-kxHrDQ9YgfrWUSXU0cjsQGv8JykOFZQ9ErNKbFPWzk3Hgpwu8x2hHrQ9IdA8yl+j9RTLTC3sAF3Tdq1IQCP4oA=="],
+
+    "@sigstore/protobuf-specs": ["@sigstore/protobuf-specs@0.5.1", "", {}, "sha512-/ScWUhhoFasJsSRGTVBwId1loQjjnjAfE4djL6ZhrXRpNCmPTnUKF5Jokd58ILseOMjzET3UrMOtJPS9sYeI0g=="],
+
+    "@sigstore/sign": ["@sigstore/sign@4.1.1", "", { "dependencies": { "@gar/promise-retry": "^1.0.2", "@sigstore/bundle": "^4.0.0", "@sigstore/core": "^3.2.0", "@sigstore/protobuf-specs": "^0.5.0", "make-fetch-happen": "^15.0.4", "proc-log": "^6.1.0" } }, "sha512-Hf4xglukg0XXQ2RiD5vSoLjdPe8OBUPA8XeVjUObheuDcWdYWrnH/BNmxZCzkAy68MzmNCxXLeurJvs6hcP2OQ=="],
+
+    "@sigstore/tuf": ["@sigstore/tuf@4.0.2", "", { "dependencies": { "@sigstore/protobuf-specs": "^0.5.0", "tuf-js": "^4.1.0" } }, "sha512-TCAzTy0xzdP79EnxSjq9KQ3eaR7+FmudLC6eRKknVKZbV7ZNlGLClAAQb/HMNJ5n2OBNk2GT1tEmU0xuPr+SLQ=="],
+
+    "@sigstore/verify": ["@sigstore/verify@3.1.0", "", { "dependencies": { "@sigstore/bundle": "^4.0.0", "@sigstore/core": "^3.1.0", "@sigstore/protobuf-specs": "^0.5.0" } }, "sha512-mNe0Iigql08YupSOGv197YdHpPPr+EzDZmfCgMc7RPNaZTw5aLN01nBl6CHJOh3BGtnMIj83EeN4butBchc8Ag=="],
 
     "@simplewebauthn/browser": ["@simplewebauthn/browser@9.0.1", "", { "dependencies": { "@simplewebauthn/types": "^9.0.1" } }, "sha512-wD2WpbkaEP4170s13/HUxPcAV5y4ZXaKo1TfNklS5zDefPinIgXOpgz1kpEvobAsaLPa2KeH7AKKX/od1mrBJw=="],
 
@@ -496,7 +548,13 @@
 
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
 
+    "@tufjs/canonical-json": ["@tufjs/canonical-json@2.0.0", "", {}, "sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA=="],
+
+    "@tufjs/models": ["@tufjs/models@4.1.0", "", { "dependencies": { "@tufjs/canonical-json": "2.0.0", "minimatch": "^10.1.1" } }, "sha512-Y8cK9aggNRsqJVaKUlEYs4s7CvQ1b1ta2DVPyAimb0I2qhzjNk+A+mxvll/klL0RlfuIUei8BF7YWiua4kQqww=="],
+
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+
+    "@types/cacache": ["@types/cacache@20.0.1", "", { "dependencies": { "@types/node": "*", "minipass": "*" } }, "sha512-QlKW3AFoFr/hvPHwFHMIVUH/ZCYeetBNou3PCmxu5LaNDvrtBlPJtIA6uhmU9JRt9oxj7IYoqoLcpxtzpPiTcw=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
@@ -516,9 +574,25 @@
 
     "@types/node": ["@types/node@22.19.15", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg=="],
 
+    "@types/node-fetch": ["@types/node-fetch@2.6.13", "", { "dependencies": { "@types/node": "*", "form-data": "^4.0.4" } }, "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw=="],
+
+    "@types/npm-package-arg": ["@types/npm-package-arg@6.1.4", "", {}, "sha512-vDgdbMy2QXHnAruzlv68pUtXCjmqUk3WrBAsRboRovsOmxbfn/WiYCjmecyKjGztnMps5dWp4Uq2prp+Ilo17Q=="],
+
+    "@types/npm-registry-fetch": ["@types/npm-registry-fetch@8.0.9", "", { "dependencies": { "@types/node": "*", "@types/node-fetch": "*", "@types/npm-package-arg": "*", "@types/npmlog": "*", "@types/ssri": "*" } }, "sha512-7NxvodR5Yrop3pb6+n8jhJNyzwOX0+6F+iagNEoi9u1CGxruYAwZD8pvGc9prIkL0+FdX5Xp0p80J9QPrGUp/g=="],
+
+    "@types/npmcli__arborist": ["@types/npmcli__arborist@6.3.3", "", { "dependencies": { "@npm/types": "^1", "@types/cacache": "*", "@types/node": "*", "@types/npmcli__package-json": "*", "@types/pacote": "*" } }, "sha512-kyrX932Qr+/Y4OB47Jamgc2YWa/HlXTCN0KVJsq04XDHUGkfbprJA8rd66zZXHmHmvnz1LR4X17zsE/H8Mklew=="],
+
+    "@types/npmcli__package-json": ["@types/npmcli__package-json@4.0.4", "", {}, "sha512-6QjlFUSHBmZJWuC08bz1ZCx6tm4t+7+OJXAdvM6tL2pI7n6Bh5SIp/YxQvnOLFf8MzCXs2ijyFgrzaiu1UFBGA=="],
+
+    "@types/npmlog": ["@types/npmlog@7.0.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-hJWbrKFvxKyWwSUXjZMYTINsSOY6IclhvGOZ97M8ac2tmR9hMwmTnYaMdpGhvju9ctWLTPhCS+eLfQNluiEjQQ=="],
+
+    "@types/pacote": ["@types/pacote@11.1.8", "", { "dependencies": { "@types/node": "*", "@types/npm-registry-fetch": "*", "@types/npmlog": "*", "@types/ssri": "*" } }, "sha512-/XLR0VoTh2JEO0jJg1q/e6Rh9bxjBq9vorJuQmtT7rRrXSiWz7e7NsvXVYJQ0i8JxMlBMPPYDTnrRe7MZRFA8Q=="],
+
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
+
+    "@types/ssri": ["@types/ssri@7.1.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-odD/56S3B51liILSk5aXJlnYt99S6Rt9EFDDqGtJM26rKHApHcwyU/UoYHrzKkdkHMAIquGWCuHtQTbes+FRQw=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
@@ -624,6 +698,8 @@
 
     "@zoralabs/protocol-deployments": ["@zoralabs/protocol-deployments@0.6.1", "", {}, "sha512-iDO5EhLrqDw0keudRq9omuSdvHG852de5/apY2p7QLBDxitQuJ/6/jOaq2WB4B6GPVUh2fTd5+CdoSsbJhJv5g=="],
 
+    "abbrev": ["abbrev@4.0.0", "", {}, "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA=="],
+
     "abitype": ["abitype@1.0.6", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3 >=3.22.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A=="],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
@@ -631,6 +707,8 @@
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "aes-js": ["aes-js@4.0.0-beta.5", "", {}, "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="],
+
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "agent-desktop": ["agent-desktop@0.1.11", "", { "bin": { "agent-desktop": "bin/agent-desktop.js" } }, "sha512-qK+d09VLsNSJMOjM/8bHIy4dEPzqVmgu6TQGwH7wXH0Fz6O0bXFyvvNxCLAX0ryxXQEnE/+xXoA8oOlRCU4unw=="],
 
@@ -670,6 +748,8 @@
 
     "axios-retry": ["axios-retry@4.5.0", "", { "dependencies": { "is-retry-allowed": "^2.2.0" }, "peerDependencies": { "axios": "0.x || 1.x" } }, "sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ=="],
 
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
     "base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
@@ -681,6 +761,8 @@
     "bigint-buffer": ["bigint-buffer@1.1.5", "", { "dependencies": { "bindings": "^1.3.0" } }, "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA=="],
 
     "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
+
+    "bin-links": ["bin-links@6.0.0", "", { "dependencies": { "cmd-shim": "^8.0.0", "npm-normalize-package-bin": "^5.0.0", "proc-log": "^6.0.0", "read-cmd-shim": "^6.0.0", "write-file-atomic": "^7.0.0" } }, "sha512-X4CiKlcV2GjnCMwnKAfbVWpHa++65th9TuzAEYtZoATiOE2DQKhSp4CJlyLoTqdhBKlXjpXjCTYPNNFS33Fi6w=="],
 
     "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
 
@@ -699,6 +781,8 @@
     "borsh": ["borsh@0.7.0", "", { "dependencies": { "bn.js": "^5.2.0", "bs58": "^4.0.0", "text-encoding-utf-8": "^1.0.2" } }, "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA=="],
 
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
+
+    "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "brorand": ["brorand@1.1.0", "", {}, "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="],
 
@@ -728,6 +812,8 @@
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
+    "cacache": ["cacache@20.0.4", "", { "dependencies": { "@npmcli/fs": "^5.0.0", "fs-minipass": "^3.0.0", "glob": "^13.0.0", "lru-cache": "^11.1.0", "minipass": "^7.0.3", "minipass-collect": "^2.0.1", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "p-map": "^7.0.2", "ssri": "^13.0.0" } }, "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA=="],
+
     "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
@@ -750,6 +836,8 @@
 
     "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
+    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
+
     "cipher-base": ["cipher-base@1.0.7", "", { "dependencies": { "inherits": "^2.0.4", "safe-buffer": "^5.2.1", "to-buffer": "^1.2.2" } }, "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA=="],
 
     "clanker-sdk": ["clanker-sdk@4.2.16", "", { "dependencies": { "@openzeppelin/merkle-tree": "^1.0.8", "abitype": "^1.0.8", "commander": "^14.0.3", "inquirer": "^8.2.6", "viem": "^2.38.3", "zod": "^4.1.12" }, "bin": { "clanker-sdk": "dist/cli/cli.js" } }, "sha512-0IYawR515W2JScOIOU20cnkSlAw9x3/Hhbuf4iBapujruKC6v06rY+h03pqH5GsfpPLmWd95CoOil97byTpfDw=="],
@@ -768,6 +856,8 @@
 
     "clsx": ["clsx@1.2.1", "", {}, "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="],
 
+    "cmd-shim": ["cmd-shim@8.0.0", "", {}, "sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA=="],
+
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
@@ -777,6 +867,8 @@
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
     "commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
+    "common-ancestor-path": ["common-ancestor-path@2.0.0", "", {}, "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng=="],
 
     "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
 
@@ -807,6 +899,8 @@
     "crypt": ["crypt@0.0.2", "", {}, "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="],
 
     "crypto-js": ["crypto-js@4.2.0", "", {}, "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="],
+
+    "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
@@ -872,6 +966,8 @@
 
     "engine.io-parser": ["engine.io-parser@5.2.3", "", {}, "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q=="],
 
+    "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
+
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
@@ -930,6 +1026,8 @@
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
+    "exponential-backoff": ["exponential-backoff@3.1.3", "", {}, "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA=="],
+
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
     "express-rate-limit": ["express-rate-limit@8.3.1", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw=="],
@@ -976,6 +1074,8 @@
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
+    "fs-minipass": ["fs-minipass@3.0.3", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw=="],
+
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
@@ -992,7 +1092,11 @@
 
     "gifwrap": ["gifwrap@0.10.1", "", { "dependencies": { "image-q": "^4.0.0", "omggif": "^1.0.10" } }, "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw=="],
 
+    "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
+
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "grammy": ["grammy@1.41.1", "", { "dependencies": { "@grammyjs/types": "3.25.0", "abort-controller": "^3.0.0", "debug": "^4.4.3", "node-fetch": "^2.7.0" } }, "sha512-wcHAQ1e7svL3fJMpDchcQVcWUmywhuepOOjHUHmMmWAwUJEIyK5ea5sbSjZd+Gy1aMpZeP8VYJa+4tP+j1YptQ=="],
 
@@ -1020,7 +1124,15 @@
 
     "hono": ["hono@4.12.8", "", {}, "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A=="],
 
+    "hosted-git-info": ["hosted-git-info@9.0.2", "", { "dependencies": { "lru-cache": "^11.1.0" } }, "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg=="],
+
+    "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
+
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "humanize-ms": ["humanize-ms@1.2.1", "", { "dependencies": { "ms": "^2.0.0" } }, "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ=="],
 
@@ -1032,9 +1144,13 @@
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
+    "ignore-walk": ["ignore-walk@8.0.0", "", { "dependencies": { "minimatch": "^10.0.3" } }, "sha512-FCeMZT4NiRQGh+YkeKMtWrOmBgWjHjMJ26WQWrRQyoyzqevdaGSakUaJW5xQYmjLlUVk2qUnCjYVBax9EKKg8A=="],
+
     "image-q": ["image-q@4.0.0", "", { "dependencies": { "@types/node": "16.9.1" } }, "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
 
     "inquirer": ["inquirer@8.2.7", "", { "dependencies": { "@inquirer/external-editor": "^1.0.0", "ansi-escapes": "^4.2.1", "chalk": "^4.1.1", "cli-cursor": "^3.1.0", "cli-width": "^3.0.0", "figures": "^3.0.0", "lodash": "^4.17.21", "mute-stream": "0.0.8", "ora": "^5.4.1", "run-async": "^2.4.0", "rxjs": "^7.5.5", "string-width": "^4.1.0", "strip-ansi": "^6.0.0", "through": "^2.3.6", "wrap-ansi": "^6.0.1" } }, "sha512-UjOaSel/iddGZJ5xP/Eixh6dY1XghiBw4XK13rCCIJcJfyhhoul/7KhLLUGtebEj6GDYM6Vnx/mVsjx2L/mFIA=="],
 
@@ -1088,6 +1204,8 @@
 
     "js-sha3": ["js-sha3@0.8.0", "", {}, "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="],
 
+    "json-parse-even-better-errors": ["json-parse-even-better-errors@5.0.0", "", {}, "sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ=="],
+
     "json-rpc-engine": ["json-rpc-engine@6.1.0", "", { "dependencies": { "@metamask/safe-event-emitter": "^2.0.0", "eth-rpc-errors": "^4.0.2" } }, "sha512-NEdLrtrq1jUZyfjkr9OCz9EzCNhnRyWtt1PAnvnhwy6e8XETS0Dtc+ZNCO2gvuAoKsIn2+vCSowXTYE4CkgnAQ=="],
 
     "json-rpc-random-id": ["json-rpc-random-id@1.0.1", "", {}, "sha512-RJ9YYNCkhVDBuP4zN5BBtYAzEl03yq/jIIsyif0JY9qyJuQQZNeDK7anAPKKlyEtLSj2s8h6hNh2F8zO5q7ScA=="],
@@ -1098,7 +1216,15 @@
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
+    "json-stringify-nice": ["json-stringify-nice@1.1.4", "", {}, "sha512-5Z5RFW63yxReJ7vANgW6eZFGWaQvnPE3WNmZoOJrSkGju2etKA2L5rrOa1sm877TVTFt57A80BH1bArcmlLfPw=="],
+
     "json-stringify-safe": ["json-stringify-safe@5.0.1", "", {}, "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="],
+
+    "jsonparse": ["jsonparse@1.3.1", "", {}, "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg=="],
+
+    "just-diff": ["just-diff@6.0.2", "", {}, "sha512-S59eriX5u3/QhMNq3v/gm8Kd0w8OS6Tz2FS1NG4blv+z0MuQcBRJyFWjdovM0Rad4/P4aUPFtnkNjMjyMlMSYA=="],
+
+    "just-diff-apply": ["just-diff-apply@5.5.0", "", {}, "sha512-OYTthRfSh55WOItVqwpefPtNt2VdKsq5AnAK6apdtR6yCH8pr0CmSr710J0Mf+WdQy7K/OzMy7K2MgAfdQURDw=="],
 
     "keccak": ["keccak@3.0.4", "", { "dependencies": { "node-addon-api": "^2.0.0", "node-gyp-build": "^4.2.0", "readable-stream": "^3.6.0" } }, "sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q=="],
 
@@ -1152,6 +1278,8 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "make-fetch-happen": ["make-fetch-happen@15.0.5", "", { "dependencies": { "@gar/promise-retry": "^1.0.0", "@npmcli/agent": "^4.0.0", "@npmcli/redact": "^4.0.0", "cacache": "^20.0.1", "http-cache-semantics": "^4.1.1", "minipass": "^7.0.2", "minipass-fetch": "^5.0.0", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "negotiator": "^1.0.0", "proc-log": "^6.0.0", "ssri": "^13.0.0" } }, "sha512-uCbIa8jWWmQZt4dSnEStkVC6gdakiinAm4PiGsywIkguF0eWMdcjDz0ECYhUolFU3pFLOev9VNPCEygydXnddg=="],
+
     "marked": ["marked@17.0.1", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
@@ -1182,6 +1310,22 @@
 
     "minimalistic-crypto-utils": ["minimalistic-crypto-utils@1.0.1", "", {}, "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="],
 
+    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "minipass-collect": ["minipass-collect@2.0.1", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw=="],
+
+    "minipass-fetch": ["minipass-fetch@5.0.2", "", { "dependencies": { "minipass": "^7.0.3", "minipass-sized": "^2.0.0", "minizlib": "^3.0.1" }, "optionalDependencies": { "iconv-lite": "^0.7.2" } }, "sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ=="],
+
+    "minipass-flush": ["minipass-flush@1.0.7", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA=="],
+
+    "minipass-pipeline": ["minipass-pipeline@1.2.4", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A=="],
+
+    "minipass-sized": ["minipass-sized@2.0.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA=="],
+
+    "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
+
     "mipd": ["mipd@0.0.7", "", { "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-aAPZPNDQ3uMTdKbuO2YmAw2TxLHO0moa4YKAyETM/DTj5FloZo+a+8tU+iv4GmW+sOxKLSRwcSFuczk+Cpt6fg=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
@@ -1200,11 +1344,29 @@
 
     "node-fetch-native": ["node-fetch-native@1.6.7", "", {}, "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="],
 
+    "node-gyp": ["node-gyp@12.2.0", "", { "dependencies": { "env-paths": "^2.2.0", "exponential-backoff": "^3.1.1", "graceful-fs": "^4.2.6", "make-fetch-happen": "^15.0.0", "nopt": "^9.0.0", "proc-log": "^6.0.0", "semver": "^7.3.5", "tar": "^7.5.4", "tinyglobby": "^0.2.12", "which": "^6.0.0" }, "bin": { "node-gyp": "bin/node-gyp.js" } }, "sha512-q23WdzrQv48KozXlr0U1v9dwO/k59NHeSzn6loGcasyf0UnSrtzs8kRxM+mfwJSf0DkX0s43hcqgnSO4/VNthQ=="],
+
     "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
 
     "node-mock-http": ["node-mock-http@1.0.4", "", {}, "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ=="],
 
+    "nopt": ["nopt@9.0.0", "", { "dependencies": { "abbrev": "^4.0.0" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw=="],
+
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
+
+    "npm-bundled": ["npm-bundled@5.0.0", "", { "dependencies": { "npm-normalize-package-bin": "^5.0.0" } }, "sha512-JLSpbzh6UUXIEoqPsYBvVNVmyrjVZ1fzEFbqxKkTJQkWBO3xFzFT+KDnSKQWwOQNbuWRwt5LSD6HOTLGIWzfrw=="],
+
+    "npm-install-checks": ["npm-install-checks@8.0.0", "", { "dependencies": { "semver": "^7.1.1" } }, "sha512-ScAUdMpyzkbpxoNekQ3tNRdFI8SJ86wgKZSQZdUxT+bj0wVFpsEMWnkXP0twVe1gJyNF5apBWDJhhIbgrIViRA=="],
+
+    "npm-normalize-package-bin": ["npm-normalize-package-bin@5.0.0", "", {}, "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag=="],
+
+    "npm-package-arg": ["npm-package-arg@13.0.2", "", { "dependencies": { "hosted-git-info": "^9.0.0", "proc-log": "^6.0.0", "semver": "^7.3.5", "validate-npm-package-name": "^7.0.0" } }, "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA=="],
+
+    "npm-packlist": ["npm-packlist@10.0.4", "", { "dependencies": { "ignore-walk": "^8.0.0", "proc-log": "^6.0.0" } }, "sha512-uMW73iajD8hiH4ZBxEV3HC+eTnppIqwakjOYuvgddnalIw2lJguKviK1pcUJDlIWm1wSJkchpDZDSVVsZEYRng=="],
+
+    "npm-pick-manifest": ["npm-pick-manifest@11.0.3", "", { "dependencies": { "npm-install-checks": "^8.0.0", "npm-normalize-package-bin": "^5.0.0", "npm-package-arg": "^13.0.0", "semver": "^7.3.5" } }, "sha512-buzyCfeoGY/PxKqmBqn1IUJrZnUi1VVJTdSSRPGI60tJdUhUoSQFhs0zycJokDdOznQentgrpf8LayEHyyYlqQ=="],
+
+    "npm-registry-fetch": ["npm-registry-fetch@19.1.1", "", { "dependencies": { "@npmcli/redact": "^4.0.0", "jsonparse": "^1.3.1", "make-fetch-happen": "^15.0.0", "minipass": "^7.0.2", "minipass-fetch": "^5.0.0", "minizlib": "^3.0.1", "npm-package-arg": "^13.0.0", "proc-log": "^6.0.0" } }, "sha512-TakBap6OM1w0H73VZVDf44iFXsOS3h+L4wVMXmbWOQroZgFhMch0juN6XSzBNlD965yIKvWg2dfu7NSiaYLxtw=="],
 
     "number-to-bn": ["number-to-bn@1.7.0", "", { "dependencies": { "bn.js": "4.11.6", "strip-hex-prefix": "1.0.0" } }, "sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig=="],
 
@@ -1242,7 +1404,11 @@
 
     "p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
+    "p-map": ["p-map@7.0.4", "", {}, "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ=="],
+
     "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
+
+    "pacote": ["pacote@21.5.0", "", { "dependencies": { "@gar/promise-retry": "^1.0.0", "@npmcli/git": "^7.0.0", "@npmcli/installed-package-contents": "^4.0.0", "@npmcli/package-json": "^7.0.0", "@npmcli/promise-spawn": "^9.0.0", "@npmcli/run-script": "^10.0.0", "cacache": "^20.0.0", "fs-minipass": "^3.0.0", "minipass": "^7.0.2", "npm-package-arg": "^13.0.0", "npm-packlist": "^10.0.1", "npm-pick-manifest": "^11.0.1", "npm-registry-fetch": "^19.0.0", "proc-log": "^6.0.0", "sigstore": "^4.0.0", "ssri": "^13.0.0", "tar": "^7.4.3" }, "bin": { "pacote": "bin/index.js" } }, "sha512-VtZ0SB8mb5Tzw3dXDfVAIjhyVKUHZkS/ZH9/5mpKenwC9sFOXNI0JI7kEF7IMkwOnsWMFrvAZHzx1T5fmrp9FQ=="],
 
     "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
 
@@ -1252,11 +1418,15 @@
 
     "parse-bmfont-xml": ["parse-bmfont-xml@1.1.6", "", { "dependencies": { "xml-parse-from-string": "^1.0.0", "xml2js": "^0.5.0" } }, "sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA=="],
 
+    "parse-conflict-json": ["parse-conflict-json@5.0.1", "", { "dependencies": { "json-parse-even-better-errors": "^5.0.0", "just-diff": "^6.0.0", "just-diff-apply": "^5.2.0" } }, "sha512-ZHEmNKMq1wyJXNwLxyHnluPfRAFSIliBvbK/UiOceROt4Xh9Pz0fq49NytIaeaCUf5VR86hwQ/34FCcNU5/LKQ=="],
+
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
 
     "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
@@ -1292,13 +1462,23 @@
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
+    "postcss-selector-parser": ["postcss-selector-parser@7.1.1", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
+
     "preact": ["preact@10.24.2", "", {}, "sha512-1cSoF0aCC8uaARATfrlz4VCBqE8LwZwRfLgkxJOQwAlQt6ayTmi0D9OF7nXid1POI5SZidFuG9CnlXbDfLqY/Q=="],
+
+    "proc-log": ["proc-log@6.1.0", "", {}, "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ=="],
 
     "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
 
     "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
 
     "process-warning": ["process-warning@1.0.0", "", {}, "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="],
+
+    "proggy": ["proggy@4.0.0", "", {}, "sha512-MbA4R+WQT76ZBm/5JUpV9yqcJt92175+Y0Bodg3HgiXzrmKu7Ggq+bpn6y6wHH+gN9NcyKn3yg1+d47VaKwNAQ=="],
+
+    "promise-all-reject-late": ["promise-all-reject-late@1.0.1", "", {}, "sha512-vuf0Lf0lOxyQREH7GDIOUMLS7kz+gs8i6B+Yi8dC68a2sychGrHTJYghMBD6k7eUcH0H5P73EckCA48xijWqXw=="],
+
+    "promise-call-limit": ["promise-call-limit@3.0.2", "", {}, "sha512-mRPQO2T1QQVw11E7+UdCJu7S61eJVWknzml9sC1heAdj1jxl0fWMBypIt9ZOcLFf8FkG995ZD7RnVk7HH72fZw=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
@@ -1329,6 +1509,8 @@
     "react-devtools-core": ["react-devtools-core@7.0.1", "", { "dependencies": { "shell-quote": "^1.6.1", "ws": "^7" } }, "sha512-C3yNvRHaizlpiASzy7b9vbnBGLrhvdhl1CbdU6EnZgxPNbai60szdLtl+VL76UNOt5bOoVTOz5rNWZxgGt+Gsw=="],
 
     "react-reconciler": ["react-reconciler@0.32.0", "", { "dependencies": { "scheduler": "^0.26.0" }, "peerDependencies": { "react": "^19.1.0" } }, "sha512-2NPMOzgTlG0ZWdIf3qG+dcbLSoAc/uLfOwckc3ofy5sSK0pLJqnQLpUFxvGcN2rlXSjnVtGeeFLNimCQEj5gOQ=="],
+
+    "read-cmd-shim": ["read-cmd-shim@6.0.0", "", {}, "sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A=="],
 
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
@@ -1414,21 +1596,37 @@
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
+    "sigstore": ["sigstore@4.1.0", "", { "dependencies": { "@sigstore/bundle": "^4.0.0", "@sigstore/core": "^3.1.0", "@sigstore/protobuf-specs": "^0.5.0", "@sigstore/sign": "^4.1.0", "@sigstore/tuf": "^4.0.1", "@sigstore/verify": "^3.1.0" } }, "sha512-/fUgUhYghuLzVT/gaJoeVehLCgZiUxPCPMcyVNY0lIf/cTCz58K/WTI7PefDarXxp9nUKpEwg1yyz3eSBMTtgA=="],
+
     "simple-xml-to-json": ["simple-xml-to-json@1.2.4", "", {}, "sha512-3MY16e0ocMHL7N1ufpdObURGyX+lCo0T/A+y6VCwosLdH1HSda4QZl1Sdt/O+2qWp48WFi26XEp5rF0LoaL0Dg=="],
 
     "slice-ansi": ["slice-ansi@8.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg=="],
+
+    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
 
     "socket.io-client": ["socket.io-client@4.8.3", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1", "engine.io-client": "~6.6.1", "socket.io-parser": "~4.2.4" } }, "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g=="],
 
     "socket.io-parser": ["socket.io-parser@4.2.6", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1" } }, "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg=="],
 
+    "socks": ["socks@2.8.7", "", { "dependencies": { "ip-address": "^10.0.1", "smart-buffer": "^4.2.0" } }, "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A=="],
+
+    "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
+
     "sonic-boom": ["sonic-boom@2.8.0", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
+    "spdx-exceptions": ["spdx-exceptions@2.5.0", "", {}, "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w=="],
+
+    "spdx-expression-parse": ["spdx-expression-parse@4.0.0", "", { "dependencies": { "spdx-exceptions": "^2.1.0", "spdx-license-ids": "^3.0.0" } }, "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ=="],
+
+    "spdx-license-ids": ["spdx-license-ids@3.0.23", "", {}, "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw=="],
+
     "split-on-first": ["split-on-first@1.1.0", "", {}, "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="],
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
+    "ssri": ["ssri@13.0.1", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
@@ -1468,6 +1666,8 @@
 
     "svix": ["svix@1.90.0", "", { "dependencies": { "standardwebhooks": "1.0.0", "uuid": "^10.0.0" } }, "sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw=="],
 
+    "tar": ["tar@7.5.13", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng=="],
+
     "text-encoding-utf-8": ["text-encoding-utf-8@1.0.2", "", {}, "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="],
 
     "thread-stream": ["thread-stream@0.15.2", "", { "dependencies": { "real-require": "^0.1.0" } }, "sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA=="],
@@ -1500,9 +1700,13 @@
 
     "treeify": ["treeify@1.1.0", "", {}, "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A=="],
 
+    "treeverse": ["treeverse@3.0.0", "", {}, "sha512-gcANaAnd2QDZFmHFEOF4k7uc1J/6a6z3DJMd/QwEyxLoKGiptJRwid582r7QIsFlFMIZ3SnxfS52S4hm2DHkuQ=="],
+
     "ts-case-convert": ["ts-case-convert@2.1.0", "", {}, "sha512-Ye79el/pHYXfoew6kqhMwCoxp4NWjKNcm2kBzpmEMIU9dd9aBmHNNFtZ+WTm0rz1ngyDmfqDXDlyUnBXayiD0w=="],
 
     "tslib": ["tslib@2.7.0", "", {}, "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="],
+
+    "tuf-js": ["tuf-js@4.1.0", "", { "dependencies": { "@tufjs/models": "4.1.0", "debug": "^4.4.3", "make-fetch-happen": "^15.0.1" } }, "sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ=="],
 
     "tweetnacl": ["tweetnacl@1.0.3", "", {}, "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="],
 
@@ -1544,6 +1748,8 @@
 
     "uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
+    "validate-npm-package-name": ["validate-npm-package-name@7.0.2", "", {}, "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A=="],
+
     "valtio": ["valtio@1.13.2", "", { "dependencies": { "derive-valtio": "0.1.0", "proxy-compare": "2.6.0", "use-sync-external-store": "1.2.0" }, "peerDependencies": { "@types/react": ">=16.8", "react": ">=16.8" }, "optionalPeers": ["@types/react", "react"] }, "sha512-Qik0o+DSy741TmkqmRfjq+0xpZBXi/Y6+fXZLn0xNF1z/waFMbE3rkivv5Zcf9RrMUp6zswf2J7sbh2KBlba5A=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
@@ -1554,7 +1760,13 @@
 
     "vitest": ["vitest@4.1.0", "", { "dependencies": { "@vitest/expect": "4.1.0", "@vitest/mocker": "4.1.0", "@vitest/pretty-format": "4.1.0", "@vitest/runner": "4.1.0", "@vitest/snapshot": "4.1.0", "@vitest/spy": "4.1.0", "@vitest/utils": "4.1.0", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.0", "@vitest/browser-preview": "4.1.0", "@vitest/browser-webdriverio": "4.1.0", "@vitest/ui": "4.1.0", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw=="],
 
+    "vscode-jsonrpc": ["vscode-jsonrpc@8.2.1", "", {}, "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ=="],
+
+    "vscode-languageserver-types": ["vscode-languageserver-types@3.17.5", "", {}, "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="],
+
     "wagmi": ["wagmi@2.19.5", "", { "dependencies": { "@wagmi/connectors": "6.2.0", "@wagmi/core": "2.22.1", "use-sync-external-store": "1.4.0" }, "peerDependencies": { "@tanstack/react-query": ">=5.0.0", "react": ">=18", "typescript": ">=5.0.4", "viem": "2.x" }, "optionalPeers": ["typescript"] }, "sha512-RQUfKMv6U+EcSNNGiPbdkDtJwtuFxZWLmvDiQmjjBgkuPulUwDJsKhi7gjynzJdsx2yDqhHCXkKsbbfbIsHfcQ=="],
+
+    "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
 
     "wcwidth": ["wcwidth@1.0.1", "", { "dependencies": { "defaults": "^1.0.3" } }, "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg=="],
 
@@ -1582,6 +1794,8 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
+    "write-file-atomic": ["write-file-atomic@7.0.1", "", { "dependencies": { "signal-exit": "^4.0.1" } }, "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg=="],
+
     "ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
     "x402": ["x402@0.6.6", "", { "dependencies": { "@scure/base": "^1.2.6", "@solana-program/compute-budget": "^0.8.0", "@solana-program/token": "^0.5.1", "@solana-program/token-2022": "^0.4.2", "@solana/kit": "^2.1.1", "@solana/transaction-confirmation": "^2.1.1", "viem": "^2.21.26", "wagmi": "^2.15.6", "zod": "^3.24.2" } }, "sha512-gKkxqKBT0mH7fSLld6Mz9ML52dmu1XeOPhVtiUCA3EzkfY6p0EJ3ijKhIKN0Jh8Q6kVXrFlJ/4iAUS1dNDA2lA=="],
@@ -1599,6 +1813,8 @@
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
     "y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
+
+    "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
     "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
@@ -1727,6 +1943,10 @@
     "@metamask/sdk-communication-layer/uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
 
     "@metamask/utils/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
+
+    "@npmcli/git/which": ["which@6.0.1", "", { "dependencies": { "isexe": "^4.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg=="],
+
+    "@npmcli/promise-spawn/which": ["which@6.0.1", "", { "dependencies": { "isexe": "^4.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg=="],
 
     "@opensea/seaport-js/merkletreejs": ["merkletreejs@0.6.0", "", { "dependencies": { "buffer-reverse": "^1.0.1", "crypto-js": "^4.2.0", "treeify": "^1.1.0" } }, "sha512-cyiratjG7fyHsa4DVfYVPxcoAh3zmUuOPItIfZex8f0pUVptNEmiiTOoeS0JnDDTWy+n3FKnI0K1gCzti7rGMg=="],
 
@@ -1978,6 +2198,12 @@
 
     "log-update/slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
 
+    "minipass-flush/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "minipass-pipeline/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "node-gyp/which": ["which@6.0.1", "", { "dependencies": { "isexe": "^4.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg=="],
+
     "number-to-bn/bn.js": ["bn.js@4.11.6", "", {}, "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA=="],
 
     "obj-multiplex/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
@@ -2129,6 +2355,10 @@
     "@metamask/sdk-communication-layer/debug/ms": ["ms@2.1.2", "", {}, "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="],
 
     "@metamask/sdk/debug/ms": ["ms@2.1.2", "", {}, "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="],
+
+    "@npmcli/git/which/isexe": ["isexe@4.0.0", "", {}, "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="],
+
+    "@npmcli/promise-spawn/which/isexe": ["isexe@4.0.0", "", {}, "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="],
 
     "@privy-io/public-api/bs58/base-x": ["base-x@4.0.1", "", {}, "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="],
 
@@ -2533,6 +2763,12 @@
     "inquirer/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "log-symbols/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "minipass-flush/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "minipass-pipeline/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "node-gyp/which/isexe": ["isexe@4.0.0", "", {}, "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="],
 
     "obj-multiplex/readable-stream/isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@ai-sdk/xai": "^3.0.67",
     "@coinbase/agentkit": "^0.10.4",
     "@modelcontextprotocol/sdk": "^1.27.1",
+    "@npmcli/arborist": "^9.4.2",
     "@opentui/core": "^0.1.88",
     "@opentui/react": "^0.1.88",
     "agent-desktop": "^0.1.11",
@@ -58,12 +59,15 @@
     "grammy": "^1.41.1",
     "react": "^19.2.4",
     "semver": "^7.7.4",
+    "vscode-jsonrpc": "^8.2.1",
+    "vscode-languageserver-types": "^3.17.5",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.8",
     "@types/diff": "^8.0.0",
     "@types/node": "^22.19.15",
+    "@types/npmcli__arborist": "^6.3.3",
     "@types/react": "^19.2.14",
     "@types/semver": "^7.7.1",
     "husky": "^9.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grok-dev",
-  "version": "1.1.5-rc2",
+  "version": "1.1.5-rc3",
   "description": "An open-source AI coding agent powered by Grok, built with Bun and OpenTUI.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -32,6 +32,7 @@ import type {
   TaskCreatedHookInput,
   UserPromptSubmitHookInput,
 } from "../hooks/types";
+import { shutdownWorkspaceLspManager } from "../lsp/runtime";
 import { buildMcpToolSet } from "../mcp/runtime";
 import {
   appendCompaction,
@@ -161,6 +162,7 @@ ${ENVIRONMENT}
 
 TOOLS:
 - read_file: Read file contents with start_line/end_line for iterative reading. Use for examining code.
+- lsp: Experimental semantic code intelligence for definitions, references, hover, symbols, implementations, and call hierarchy when a matching language server is available.
 - write_file: Create new files or overwrite existing ones with full content.
 - edit_file: Replace a unique string in a file with new content. The old_string must be unique — include enough context lines.
 - bash: Execute shell commands. Set background=true for long-running processes (dev servers, watchers, builds). Returns a process ID immediately.
@@ -203,7 +205,7 @@ TOOLS:
 WORKFLOW:
 1. Understand the request
 2. Decide whether a sub-agent should handle the first investigation pass
-3. Use read_file and bash to explore the codebase directly when the task is small or tightly scoped
+3. Use read_file, lsp, and bash to explore the codebase directly when the task is small or tightly scoped
 4. Use bash with background=true for dev servers, watchers, or any long-running process — then continue working
 5. Use delegate for read-only work that can run in parallel, then continue productive work
 6. Use edit_file for targeted changes, write_file for new files or full rewrites
@@ -240,6 +242,7 @@ EXAMPLES:
 
 IMPORTANT:
 - Prefer edit_file for surgical changes to existing files — it shows a clean diff.
+- Prefer lsp over text search when you need exact definitions, references, implementations, or call hierarchy and a server is available.
 - Use write_file only for new files or when most of the file is changing.
 - Use read_file instead of cat/head/tail for reading files.
 - When the user asks for an automated recurring or one-time run, use the schedule tools instead of only describing the setup.
@@ -253,12 +256,14 @@ ${ENVIRONMENT}
 
 TOOLS:
 - read_file: Read file contents for analysis.
+- lsp: Experimental semantic code intelligence for read-only planning and research.
 - bash: ONLY for searching (find, grep, ls) — NEVER modify files.
 - task: Delegate a focused task to a sub-agent when deeper research or specialized analysis would help.
 - generate_plan: ALWAYS use this to present your plan. Creates an interactive UI with steps and questions.
 
 BEHAVIOR:
 - Explore the codebase first using read_file and bash to understand the current state
+- Prefer lsp for exact symbol navigation when a matching server is available
 - ALWAYS call generate_plan to present your plan — never just describe it in text
 - Include clear, ordered steps with affected file paths
 - Include questions when you need user input on approach, trade-offs, or preferences
@@ -272,12 +277,13 @@ ${ENVIRONMENT}
 
 TOOLS:
 - read_file: Read file contents for context.
+- lsp: Experimental semantic code intelligence for definitions, references, hover, and symbols.
 - bash: ONLY for searching (find, grep, ls) — NEVER modify.
 - task: Delegate a focused task to a sub-agent when specialized analysis or deeper investigation would help.
 
 BEHAVIOR:
 - Answer the user's question directly and thoroughly
-- Use tools to gather context when needed
+- Use tools to gather context when needed, preferring lsp for exact symbol questions when available
 - Provide code examples when helpful
 - NEVER create, modify, or delete files
 - Focus on explanation, not execution`,
@@ -507,7 +513,7 @@ function applyModelConstraints(system: string, modelId: string): string {
     "",
     "MODEL CONSTRAINTS:",
     "- The selected model does not support client-side CLI tool calls in this environment.",
-    "- Do not call bash, read_file, write_file, edit_file, task, delegate, delegation, or MCP tools.",
+    "- Do not call bash, read_file, lsp, write_file, edit_file, task, delegate, delegation, or MCP tools.",
     "- Answer directly using only the conversation context already provided.",
   ].join("\n");
 }
@@ -698,6 +704,10 @@ export class Agent {
   abort(): void {
     this.abortController?.abort();
     this.emitSubagentStatus(null);
+  }
+
+  async cleanup(): Promise<void> {
+    await Promise.allSettled([this.bash.cleanup(), shutdownWorkspaceLspManager(this.bash.getCwd())]);
   }
 
   respondToToolApproval(approvalId: string, approved: boolean): void {
@@ -2516,6 +2526,7 @@ function toToolResult(output: unknown): ToolResult {
       backgroundProcess?: ToolResult["backgroundProcess"];
       media?: ToolResult["media"];
       computer?: ToolResult["computer"];
+      lspDiagnostics?: ToolResult["lspDiagnostics"];
     };
     return {
       success: r.success,
@@ -2528,6 +2539,7 @@ function toToolResult(output: unknown): ToolResult {
       backgroundProcess: r.backgroundProcess,
       media: r.media,
       computer: r.computer,
+      lspDiagnostics: r.lspDiagnostics,
     };
   }
   return { success: true, output: String(output) };
@@ -2536,6 +2548,7 @@ function toToolResult(output: unknown): ToolResult {
 function formatSubagentActivity(toolName: string, args?: unknown): string {
   const parsed = parseToolArgs(args);
   if (toolName === "read_file") return `Read ${parsed.path || "file"}`;
+  if (toolName === "lsp") return `LSP ${parsed.operation || "query"} ${parsed.filePath || ""}`.trim();
   if (toolName === "write_file") return `Write ${parsed.path || "file"}`;
   if (toolName === "edit_file") return `Edit ${parsed.path || "file"}`;
   if (toolName === "search_web") return `Web search "${truncate(parsed.query || "", 50)}"`;

--- a/src/grok/lsp-tools.test.ts
+++ b/src/grok/lsp-tools.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import { BashTool } from "../tools/bash";
+import { toolSetToBatchTools } from "./tool-schemas";
+import { createTools } from "./tools";
+
+const queryLspMock = vi.fn<(cwd: string, input: unknown) => Promise<{ success: boolean; output: string }>>(
+  async () => ({
+    success: true,
+    output: "[]",
+  }),
+);
+
+vi.mock("../lsp/runtime", () => ({
+  isLspToolEnabled: vi.fn(() => true),
+  queryLsp: (cwd: string, input: unknown) => queryLspMock(cwd, input),
+}));
+
+describe("lsp tool", () => {
+  it("registers and routes the first-party lsp tool", async () => {
+    const tools = createTools(new BashTool("/tmp"), {} as never, "ask") as Record<
+      string,
+      { execute: (input: unknown, context?: unknown) => Promise<unknown>; description?: string }
+    >;
+
+    expect(tools).toHaveProperty("lsp");
+    expect(tools.lsp.description).toContain("Language Server Protocol");
+
+    const result = await tools.lsp.execute(
+      {
+        operation: "hover",
+        filePath: "src/index.ts",
+        line: 3,
+        character: 7,
+      },
+      { abortSignal: undefined },
+    );
+
+    expect(queryLspMock).toHaveBeenCalledWith("/tmp", {
+      operation: "hover",
+      filePath: "src/index.ts",
+      line: 3,
+      character: 7,
+      query: undefined,
+    });
+    expect(result).toEqual({ success: true, output: "[]" });
+  });
+
+  it("is compatible with batch tool schema conversion", async () => {
+    const tools = createTools(new BashTool("/tmp"), {} as never, "agent");
+    const batchTools = await toolSetToBatchTools(tools);
+    const lspTool = batchTools.find((entry) => entry.function.name === "lsp");
+
+    expect(lspTool).toBeDefined();
+    expect(lspTool?.function.parameters).toMatchObject({
+      properties: {
+        operation: {
+          type: "string",
+        },
+        filePath: {
+          type: "string",
+        },
+      },
+    });
+  });
+});

--- a/src/grok/tools.ts
+++ b/src/grok/tools.ts
@@ -1,6 +1,8 @@
 import { generateText, type ToolSet, tool } from "ai";
 import { z } from "zod";
 import { executePostToolFailureHooks, executePostToolHooks, executePreToolHooks } from "../hooks/index";
+import { isLspToolEnabled, queryLsp } from "../lsp/runtime";
+import { LSP_TOOL_OPERATIONS } from "../lsp/types";
 import type { BashTool } from "../tools/bash";
 import {
   computerClick,
@@ -266,6 +268,37 @@ export function createTools(
   };
 
   const tools: ToolSet = { ...base };
+
+  if (isLspToolEnabled(cwd())) {
+    tools.lsp = tool({
+      description:
+        "Experimental Language Server Protocol access for semantic code intelligence. Use for go-to-definition, references, hover, symbols, implementations, and call hierarchy when a matching LSP server is available.",
+      inputSchema: z.object({
+        operation: z.enum(LSP_TOOL_OPERATIONS).describe("The LSP operation to perform"),
+        filePath: z.string().describe("The absolute or cwd-relative path to the target file"),
+        line: z.number().int().min(1).describe("The 1-based line number in the file"),
+        character: z.number().int().min(1).describe("The 1-based character offset in the file"),
+        query: z.string().optional().describe("Optional symbol query. Used primarily with workspaceSymbol."),
+      }),
+      execute: async ({ operation, filePath, line, character, query }) => {
+        try {
+          return await queryLsp(cwd(), {
+            operation,
+            filePath,
+            line,
+            character,
+            query,
+          });
+        } catch (err: unknown) {
+          const msg = err instanceof Error ? err.message : String(err);
+          return {
+            success: false,
+            output: `LSP query failed: ${msg}`,
+          };
+        }
+      },
+    });
+  }
 
   if (options.sendTelegramFile) {
     const sendFile = options.sendTelegramFile;

--- a/src/grok/tools.ts
+++ b/src/grok/tools.ts
@@ -276,8 +276,22 @@ export function createTools(
       inputSchema: z.object({
         operation: z.enum(LSP_TOOL_OPERATIONS).describe("The LSP operation to perform"),
         filePath: z.string().describe("The absolute or cwd-relative path to the target file"),
-        line: z.number().int().min(1).describe("The 1-based line number in the file"),
-        character: z.number().int().min(1).describe("The 1-based character offset in the file"),
+        line: z
+          .number()
+          .int()
+          .min(1)
+          .optional()
+          .describe(
+            "The 1-based line number. Required for position-based operations (definition, references, hover, implementation, callHierarchy). Not needed for documentSymbol or workspaceSymbol.",
+          ),
+        character: z
+          .number()
+          .int()
+          .min(1)
+          .optional()
+          .describe(
+            "The 1-based character offset. Required for position-based operations. Not needed for documentSymbol or workspaceSymbol.",
+          ),
         query: z.string().optional().describe("Optional symbol query. Used primarily with workspaceSymbol."),
       }),
       execute: async ({ operation, filePath, line, character, query }) => {
@@ -285,8 +299,8 @@ export function createTools(
           return await queryLsp(cwd(), {
             operation,
             filePath,
-            line,
-            character,
+            line: line ?? 1,
+            character: character ?? 1,
             query,
           });
         } catch (err: unknown) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,8 +77,10 @@ async function startInteractive(
   });
 
   const onExit = () => {
-    renderer.destroy();
-    process.exit(0);
+    void agent.cleanup().finally(() => {
+      renderer.destroy();
+      process.exit(0);
+    });
   };
 
   createRoot(renderer).render(
@@ -121,25 +123,29 @@ async function runHeadless(
   if (prelude.stdout) process.stdout.write(prelude.stdout);
   if (prelude.stderr) process.stderr.write(prelude.stderr);
 
-  const { enhancedMessage } = processAtMentions(prompt, process.cwd());
+  try {
+    const { enhancedMessage } = processAtMentions(prompt, process.cwd());
 
-  if (format === "json") {
-    const { observer, consumeChunk, flush } = createHeadlessJsonlEmitter(agent.getSessionId() || undefined);
-    for await (const chunk of agent.processMessage(enhancedMessage, observer)) {
-      const writes = consumeChunk(chunk);
-      if (writes.stdout) process.stdout.write(writes.stdout);
-      if (writes.stderr) process.stderr.write(writes.stderr ?? "");
+    if (format === "json") {
+      const { observer, consumeChunk, flush } = createHeadlessJsonlEmitter(agent.getSessionId() || undefined);
+      for await (const chunk of agent.processMessage(enhancedMessage, observer)) {
+        const writes = consumeChunk(chunk);
+        if (writes.stdout) process.stdout.write(writes.stdout);
+        if (writes.stderr) process.stderr.write(writes.stderr ?? "");
+      }
+      const tail = flush();
+      if (tail.stdout) process.stdout.write(tail.stdout);
+      if (tail.stderr) process.stderr.write(tail.stderr ?? "");
+      return;
     }
-    const tail = flush();
-    if (tail.stdout) process.stdout.write(tail.stdout);
-    if (tail.stderr) process.stderr.write(tail.stderr ?? "");
-    return;
-  }
 
-  for await (const chunk of agent.processMessage(enhancedMessage)) {
-    const writes = renderHeadlessChunk(chunk);
-    if (writes.stdout) process.stdout.write(writes.stdout);
-    if (writes.stderr) process.stderr.write(writes.stderr);
+    for await (const chunk of agent.processMessage(enhancedMessage)) {
+      const writes = renderHeadlessChunk(chunk);
+      if (writes.stdout) process.stdout.write(writes.stdout);
+      if (writes.stderr) process.stderr.write(writes.stderr);
+    }
+  } finally {
+    await agent.cleanup();
   }
 }
 
@@ -175,6 +181,7 @@ function resolveCliSandboxMode(value: string | boolean | undefined): SandboxMode
 
 async function runBackgroundDelegation(jobPath: string, options: CliOptions) {
   let output = "";
+  let agent: Agent | undefined;
 
   try {
     const delegation = await loadDelegation(jobPath);
@@ -189,7 +196,7 @@ async function runBackgroundDelegation(jobPath: string, options: CliOptions) {
       parseInt(stringOption(options.maxToolRounds) || String(delegation.maxToolRounds), 10) || delegation.maxToolRounds;
     const sandboxMode = resolveCliSandboxMode(options.sandbox) || delegation.sandboxMode || getCurrentSandboxMode();
     const sandboxSettings = mergeSandboxSettings(getCurrentSandboxSettings(), delegation.sandboxSettings);
-    const agent = new Agent(apiKey, baseURL, model, maxToolRounds, {
+    agent = new Agent(apiKey, baseURL, model, maxToolRounds, {
       persistSession: false,
       sandboxMode,
       sandboxSettings,
@@ -217,6 +224,8 @@ async function runBackgroundDelegation(jobPath: string, options: CliOptions) {
       // Best effort — background tasks should fail silently if persistence is unavailable.
     }
     process.exit(1);
+  } finally {
+    await agent?.cleanup();
   }
 }
 

--- a/src/lsp/builtins.test.ts
+++ b/src/lsp/builtins.test.ts
@@ -1,0 +1,104 @@
+import { mkdir, mkdtemp, rm, writeFile } from "fs/promises";
+import os from "os";
+import path from "path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./npm-cache", () => ({
+  lspNpmWhich: vi.fn(async () => null),
+}));
+
+const { createRuntimeLspDefinitions } = await import("./builtins");
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("createRuntimeLspDefinitions", () => {
+  it("includes all built-in definitions when no overrides are set", () => {
+    const defs = createRuntimeLspDefinitions("/tmp", {
+      enabled: true,
+      tool: true,
+      autoInstall: false,
+      startupTimeoutMs: 5000,
+      diagnosticsDebounceMs: 0,
+      builtins: {},
+      servers: [],
+    });
+
+    const ids = defs.map((d) => d.id);
+    expect(ids).toContain("typescript");
+    expect(ids).toContain("pyright");
+    expect(ids).toContain("gopls");
+    expect(ids).toContain("rust-analyzer");
+  });
+
+  it("excludes a built-in when disabled via settings", () => {
+    const defs = createRuntimeLspDefinitions("/tmp", {
+      enabled: true,
+      tool: true,
+      autoInstall: false,
+      startupTimeoutMs: 5000,
+      diagnosticsDebounceMs: 0,
+      builtins: {
+        typescript: { enabled: false },
+      },
+      servers: [],
+    });
+
+    const ids = defs.map((d) => d.id);
+    expect(ids).not.toContain("typescript");
+    expect(ids).toContain("pyright");
+  });
+
+  it("includes custom server definitions", () => {
+    const defs = createRuntimeLspDefinitions("/tmp", {
+      enabled: true,
+      tool: true,
+      autoInstall: false,
+      startupTimeoutMs: 5000,
+      diagnosticsDebounceMs: 0,
+      builtins: {},
+      servers: [
+        {
+          id: "custom-lsp",
+          command: "custom-server",
+          extensions: [".xyz"],
+        },
+      ],
+    });
+
+    const custom = defs.find((d) => d.id === "custom-lsp");
+    expect(custom).toBeDefined();
+    expect(custom!.extensions).toEqual([".xyz"]);
+  });
+
+  it("resolves root using nearest marker from the file upward", async () => {
+    const workspace = await createTempWorkspace();
+    const nestedDir = path.join(workspace, "packages", "core", "src");
+    await mkdir(nestedDir, { recursive: true });
+    await writeFile(path.join(workspace, "packages", "core", "tsconfig.json"), "{}");
+
+    const defs = createRuntimeLspDefinitions(workspace, {
+      enabled: true,
+      tool: true,
+      autoInstall: false,
+      startupTimeoutMs: 5000,
+      diagnosticsDebounceMs: 0,
+      builtins: {},
+      servers: [],
+    });
+
+    const tsDef = defs.find((d) => d.id === "typescript")!;
+    const root = await tsDef.resolveRoot(path.join(nestedDir, "index.ts"), workspace);
+    expect(root).toBe(path.join(workspace, "packages", "core"));
+  });
+});
+
+async function createTempWorkspace(): Promise<string> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "grok-lsp-builtins-"));
+  tempDirs.push(root);
+  await mkdir(path.join(root, ".git"), { recursive: true });
+  return root;
+}

--- a/src/lsp/builtins.ts
+++ b/src/lsp/builtins.ts
@@ -1,0 +1,415 @@
+import { access } from "fs/promises";
+import path from "path";
+import { lspNpmWhich } from "./npm-cache";
+import type {
+  LspBuiltInServerId,
+  LspBuiltInServerSettings,
+  LspCustomServerConfig,
+  LspLaunchSpec,
+  NormalizedLspSettings,
+} from "./types";
+
+export interface RuntimeLspServerDefinition {
+  id: string;
+  extensions: string[];
+  languageIds: Record<string, string>;
+  resolveRoot(filePath: string, cwd: string): Promise<string | null>;
+  resolveLaunch(root: string, settings: NormalizedLspSettings): Promise<LspLaunchSpec | null>;
+}
+
+interface BuiltInDefinition {
+  id: LspBuiltInServerId;
+  extensions: string[];
+  languageIds: Record<string, string>;
+  rootMarkers: string[];
+  resolveLaunch(root: string, settings: NormalizedLspSettings): Promise<LspLaunchSpec | null>;
+}
+
+const LOCKFILE_MARKERS = ["bun.lock", "bun.lockb", "package-lock.json", "pnpm-lock.yaml", "yarn.lock"];
+
+const BUILT_IN_DEFINITIONS: Record<LspBuiltInServerId, BuiltInDefinition> = {
+  typescript: {
+    id: "typescript",
+    extensions: [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts"],
+    languageIds: {
+      ".ts": "typescript",
+      ".tsx": "typescriptreact",
+      ".js": "javascript",
+      ".jsx": "javascriptreact",
+      ".mjs": "javascript",
+      ".cjs": "javascript",
+      ".mts": "typescript",
+      ".cts": "typescript",
+    },
+    rootMarkers: ["tsconfig.json", "jsconfig.json", "package.json", ...LOCKFILE_MARKERS],
+    async resolveLaunch(root, settings) {
+      const override = settings.builtins.typescript;
+      const resolved =
+        override?.command && override?.args
+          ? { command: override.command, args: override.args }
+          : await resolveNodeServerLaunch(
+              root,
+              "typescript-language-server",
+              "typescript-language-server",
+              ["--stdio"],
+              settings.autoInstall,
+            );
+      if (!resolved && !override?.command) return null;
+      const tsserver = await resolveTypeScriptServer(root);
+      return {
+        command: override?.command ?? resolved?.command ?? "",
+        args: override?.args ?? resolved?.args ?? ["--stdio"],
+        env: override?.env,
+        initializationOptions: {
+          ...(tsserver ? { tsserver: { path: tsserver } } : {}),
+          ...override?.initialization,
+        },
+      };
+    },
+  },
+  pyright: {
+    id: "pyright",
+    extensions: [".py", ".pyi"],
+    languageIds: {
+      ".py": "python",
+      ".pyi": "python",
+    },
+    rootMarkers: ["pyproject.toml", "requirements.txt", "setup.py", "setup.cfg", ".venv", ".git"],
+    async resolveLaunch(root, settings) {
+      const override = settings.builtins.pyright;
+      const resolved =
+        override?.command && override?.args
+          ? { command: override.command, args: override.args }
+          : (await resolveNodeServerLaunch(root, "pyright-langserver", "pyright", ["--stdio"], settings.autoInstall)) ||
+            (await resolveNodeServerLaunch(
+              root,
+              "basedpyright-langserver",
+              "basedpyright",
+              ["--stdio"],
+              settings.autoInstall,
+            ));
+      if (!resolved && !override?.command) return null;
+      return {
+        command: override?.command ?? resolved?.command ?? "",
+        args: override?.args ?? resolved?.args ?? ["--stdio"],
+        env: override?.env,
+        initializationOptions: override?.initialization,
+      };
+    },
+  },
+  gopls: {
+    id: "gopls",
+    extensions: [".go"],
+    languageIds: {
+      ".go": "go",
+    },
+    rootMarkers: ["go.work", "go.mod", ".git"],
+    async resolveLaunch(root, settings) {
+      const override = settings.builtins.gopls;
+      const command = override?.command || (await resolveCommand(root, "gopls"));
+      if (!command) return null;
+      return {
+        command,
+        args: override?.args ?? [],
+        env: override?.env,
+        initializationOptions: override?.initialization,
+      };
+    },
+  },
+  "rust-analyzer": {
+    id: "rust-analyzer",
+    extensions: [".rs"],
+    languageIds: {
+      ".rs": "rust",
+    },
+    rootMarkers: ["Cargo.toml", "rust-project.json", ".git"],
+    async resolveLaunch(root, settings) {
+      const override = settings.builtins["rust-analyzer"];
+      const command = override?.command || (await resolveCommand(root, "rust-analyzer"));
+      if (!command) return null;
+      return {
+        command,
+        args: override?.args ?? [],
+        env: override?.env,
+        initializationOptions: override?.initialization,
+      };
+    },
+  },
+  "bash-language-server": {
+    id: "bash-language-server",
+    extensions: [".sh", ".bash", ".zsh", ".ksh"],
+    languageIds: {
+      ".sh": "shellscript",
+      ".bash": "shellscript",
+      ".zsh": "shellscript",
+      ".ksh": "shellscript",
+    },
+    rootMarkers: [".git"],
+    async resolveLaunch(root, settings) {
+      const override = settings.builtins["bash-language-server"];
+      const resolved =
+        override?.command && override?.args
+          ? { command: override.command, args: override.args }
+          : await resolveNodeServerLaunch(
+              root,
+              "bash-language-server",
+              "bash-language-server",
+              ["start"],
+              settings.autoInstall,
+            );
+      if (!resolved && !override?.command) return null;
+      return {
+        command: override?.command ?? resolved?.command ?? "",
+        args: override?.args ?? resolved?.args ?? ["start"],
+        env: override?.env,
+        initializationOptions: override?.initialization,
+      };
+    },
+  },
+  "yaml-language-server": {
+    id: "yaml-language-server",
+    extensions: [".yaml", ".yml"],
+    languageIds: {
+      ".yaml": "yaml",
+      ".yml": "yaml",
+    },
+    rootMarkers: [".git"],
+    async resolveLaunch(root, settings) {
+      const override = settings.builtins["yaml-language-server"];
+      const resolved =
+        override?.command && override?.args
+          ? { command: override.command, args: override.args }
+          : await resolveNodeServerLaunch(
+              root,
+              "yaml-language-server",
+              "yaml-language-server",
+              ["--stdio"],
+              settings.autoInstall,
+            );
+      if (!resolved && !override?.command) return null;
+      return {
+        command: override?.command ?? resolved?.command ?? "",
+        args: override?.args ?? resolved?.args ?? ["--stdio"],
+        env: override?.env,
+        initializationOptions: override?.initialization,
+      };
+    },
+  },
+  clangd: {
+    id: "clangd",
+    extensions: [".c", ".cc", ".cpp", ".cxx", ".h", ".hh", ".hpp", ".hxx"],
+    languageIds: {
+      ".c": "c",
+      ".cc": "cpp",
+      ".cpp": "cpp",
+      ".cxx": "cpp",
+      ".h": "c",
+      ".hh": "cpp",
+      ".hpp": "cpp",
+      ".hxx": "cpp",
+    },
+    rootMarkers: ["compile_commands.json", "compile_flags.txt", ".clangd", ".git"],
+    async resolveLaunch(root, settings) {
+      const override = settings.builtins.clangd;
+      const command = override?.command || (await resolveCommand(root, "clangd"));
+      if (!command) return null;
+      return {
+        command,
+        args: override?.args ?? [],
+        env: override?.env,
+        initializationOptions: override?.initialization,
+      };
+    },
+  },
+  jdtls: {
+    id: "jdtls",
+    extensions: [".java"],
+    languageIds: {
+      ".java": "java",
+    },
+    rootMarkers: ["pom.xml", "build.gradle", "build.gradle.kts", ".git"],
+    async resolveLaunch(root, settings) {
+      const override = settings.builtins.jdtls;
+      const command = override?.command || (await resolveCommand(root, "jdtls"));
+      if (!command) return null;
+      return {
+        command,
+        args: override?.args ?? [],
+        env: override?.env,
+        initializationOptions: override?.initialization,
+      };
+    },
+  },
+  "sourcekit-lsp": {
+    id: "sourcekit-lsp",
+    extensions: [".swift"],
+    languageIds: {
+      ".swift": "swift",
+    },
+    rootMarkers: ["Package.swift", ".git"],
+    async resolveLaunch(root, settings) {
+      const override = settings.builtins["sourcekit-lsp"];
+      const command = override?.command || (await resolveCommand(root, "sourcekit-lsp"));
+      if (!command) return null;
+      return {
+        command,
+        args: override?.args ?? [],
+        env: override?.env,
+        initializationOptions: override?.initialization,
+      };
+    },
+  },
+};
+
+export function createRuntimeLspDefinitions(
+  cwd: string,
+  settings: NormalizedLspSettings,
+): RuntimeLspServerDefinition[] {
+  const definitions: RuntimeLspServerDefinition[] = [];
+
+  for (const definition of Object.values(BUILT_IN_DEFINITIONS)) {
+    const override = settings.builtins[definition.id];
+    if (override?.enabled === false) continue;
+    definitions.push({
+      id: definition.id,
+      extensions: normalizeExtensions(override?.extensions ?? definition.extensions),
+      languageIds: definition.languageIds,
+      resolveRoot: async (filePath) => findNearestRoot(filePath, cwd, override?.rootMarkers ?? definition.rootMarkers),
+      resolveLaunch: async (root, normalizedSettings) => {
+        const launch = await definition.resolveLaunch(root, normalizedSettings);
+        if (!launch) return null;
+        return {
+          ...launch,
+          env: {
+            ...(launch.env ?? {}),
+            ...(override?.env ?? {}),
+          },
+          initializationOptions: {
+            ...(launch.initializationOptions ?? {}),
+            ...(override?.initialization ?? {}),
+          },
+        };
+      },
+    });
+  }
+
+  for (const custom of settings.servers) {
+    if (custom.enabled === false) continue;
+    definitions.push(createCustomRuntimeDefinition(cwd, custom));
+  }
+
+  return definitions;
+}
+
+function createCustomRuntimeDefinition(cwd: string, config: LspCustomServerConfig): RuntimeLspServerDefinition {
+  return {
+    id: config.id,
+    extensions: normalizeExtensions(config.extensions),
+    languageIds:
+      config.languageIds ?? Object.fromEntries(config.extensions.map((extension) => [extension, extension.slice(1)])),
+    resolveRoot: async (filePath) => findNearestRoot(filePath, cwd, config.rootMarkers ?? [".git"]),
+    resolveLaunch: async () => ({
+      command: config.command,
+      args: config.args ?? [],
+      env: config.env,
+      initializationOptions: config.initialization,
+    }),
+  };
+}
+
+async function resolveCommand(root: string, binary: string): Promise<string | null> {
+  const localBinary = await findLocalBinary(root, binary);
+  if (localBinary) return localBinary;
+  return findCommandOnPath(binary);
+}
+
+async function resolveTypeScriptServer(root: string): Promise<string | null> {
+  const modulePath = path.join("node_modules", "typescript", "lib", "tsserver.js");
+  let current = root;
+
+  while (true) {
+    const candidate = path.join(current, modulePath);
+    if (await pathExists(candidate)) return candidate;
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+
+  return null;
+}
+
+async function findLocalBinary(root: string, binary: string): Promise<string | null> {
+  const ext = process.platform === "win32" ? ".cmd" : "";
+  const candidate = path.join(root, "node_modules", ".bin", `${binary}${ext}`);
+  return (await pathExists(candidate)) ? candidate : null;
+}
+
+async function resolveNodeServerLaunch(
+  root: string,
+  binary: string,
+  packageName: string,
+  baseArgs: string[],
+  autoInstall: boolean,
+): Promise<{ command: string; args: string[] } | null> {
+  const command = await resolveCommand(root, binary);
+  if (command) {
+    return { command, args: baseArgs };
+  }
+
+  if (!autoInstall) return null;
+
+  const cached = await lspNpmWhich(packageName);
+  if (cached) {
+    return { command: cached, args: baseArgs };
+  }
+
+  return null;
+}
+
+async function findCommandOnPath(binary: string): Promise<string | null> {
+  const pathValue = process.env.PATH;
+  if (!pathValue) return null;
+
+  const suffixes = process.platform === "win32" ? [".cmd", ".exe", ".bat", ""] : [""];
+  for (const segment of pathValue.split(path.delimiter)) {
+    for (const suffix of suffixes) {
+      const candidate = path.join(segment, `${binary}${suffix}`);
+      if (await pathExists(candidate)) return candidate;
+    }
+  }
+
+  return null;
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function findNearestRoot(filePath: string, cwd: string, markers: string[]): Promise<string | null> {
+  const normalizedMarkers = markers.length > 0 ? markers : [".git"];
+  let current = path.dirname(path.resolve(filePath));
+  const stop = path.resolve(cwd);
+
+  while (true) {
+    for (const marker of normalizedMarkers) {
+      if (await pathExists(path.join(current, marker))) return current;
+    }
+    if (current === stop) break;
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+
+  return stop;
+}
+
+function normalizeExtensions(extensions: string[]): string[] {
+  return extensions.map((extension) =>
+    extension.startsWith(".") ? extension.toLowerCase() : `.${extension.toLowerCase()}`,
+  );
+}

--- a/src/lsp/client.ts
+++ b/src/lsp/client.ts
@@ -1,0 +1,340 @@
+import { type ChildProcessWithoutNullStreams, spawn } from "child_process";
+import { fileURLToPath, pathToFileURL } from "url";
+import {
+  createMessageConnection,
+  type MessageConnection,
+  StreamMessageReader,
+  StreamMessageWriter,
+} from "vscode-jsonrpc/node";
+import type { Diagnostic } from "vscode-languageserver-types";
+import type { LspDiagnostic, LspLaunchSpec } from "./types";
+
+export interface LspClientOptions {
+  serverId: string;
+  root: string;
+  launch: LspLaunchSpec;
+  startupTimeoutMs: number;
+  diagnosticsDebounceMs: number;
+}
+
+export interface LspClientSession {
+  readonly serverId: string;
+  readonly root: string;
+  openOrChangeFile(filePath: string, languageId: string, text: string): Promise<void>;
+  saveFile(filePath: string): Promise<void>;
+  closeFile(filePath: string): Promise<void>;
+  sendRequest<TResult>(method: string, params: unknown): Promise<TResult>;
+  waitForDiagnostics(filePath: string, timeoutMs?: number): Promise<LspDiagnostic[]>;
+  getDiagnostics(filePath: string): LspDiagnostic[];
+  stop(): Promise<void>;
+}
+
+interface DiagnosticWaiter {
+  resolve: () => void;
+  timer?: ReturnType<typeof setTimeout>;
+}
+
+export async function createLspClientSession(options: LspClientOptions): Promise<LspClientSession> {
+  const childProcess = await spawnProcess(options.launch, options.root);
+  const connection = createConnection(childProcess);
+  const versions = new Map<string, number>();
+  const diagnostics = new Map<string, LspDiagnostic[]>();
+  const waiters = new Map<string, DiagnosticWaiter[]>();
+  let stopped = false;
+
+  if (childProcess.stderr) {
+    childProcess.stderr.on("data", (data: Buffer) => {
+      const output = data.toString().trim();
+      if (output) {
+        console.error(`[lsp:${options.serverId}:stderr] ${output}`);
+      }
+    });
+  }
+
+  childProcess.on("exit", (code) => {
+    if (code !== 0 && code !== null && !stopped) {
+      console.error(`[lsp:${options.serverId}] process exited with code ${code}`);
+    }
+  });
+
+  connection.onNotification("textDocument/publishDiagnostics", (params: { uri: string; diagnostics: Diagnostic[] }) => {
+    const filePath = normalizeUriPath(params.uri);
+    diagnostics.set(filePath, params.diagnostics.map(normalizeDiagnostic));
+    const listeners = waiters.get(filePath) ?? [];
+    for (const waiter of listeners) {
+      if (waiter.timer) clearTimeout(waiter.timer);
+      waiter.timer = setTimeout(waiter.resolve, options.diagnosticsDebounceMs);
+    }
+  });
+
+  connection.onRequest("workspace/configuration", async () => [options.launch.initializationOptions ?? {}]);
+  connection.onRequest("window/workDoneProgress/create", async () => null);
+  connection.onRequest("client/registerCapability", async () => null);
+  connection.onRequest("client/unregisterCapability", async () => null);
+  connection.listen();
+
+  try {
+    await withTimeout(
+      connection.sendRequest("initialize", {
+        processId: childProcess.pid,
+        rootUri: pathToFileURL(options.root).href,
+        rootPath: options.root,
+        workspaceFolders: [
+          {
+            uri: pathToFileURL(options.root).href,
+            name: options.root.split(/[\\/]/).pop() || "workspace",
+          },
+        ],
+        initializationOptions: options.launch.initializationOptions ?? {},
+        capabilities: {
+          workspace: {
+            configuration: true,
+          },
+          textDocument: {
+            synchronization: {
+              didOpen: true,
+              didChange: true,
+              didSave: true,
+              willSave: false,
+              willSaveWaitUntil: false,
+            },
+            publishDiagnostics: {
+              relatedInformation: true,
+              versionSupport: true,
+            },
+            definition: {
+              linkSupport: true,
+            },
+            hover: {
+              contentFormat: ["markdown", "plaintext"],
+            },
+            documentSymbol: {
+              hierarchicalDocumentSymbolSupport: true,
+            },
+            callHierarchy: {
+              dynamicRegistration: false,
+            },
+          },
+          general: {
+            positionEncodings: ["utf-16"],
+          },
+        },
+      }),
+      options.startupTimeoutMs,
+      `LSP server "${options.serverId}" timed out during initialization`,
+    );
+
+    await connection.sendNotification("initialized", {});
+  } catch (error) {
+    connection.dispose();
+    try {
+      childProcess.kill("SIGTERM");
+    } catch {
+      // Already exited.
+    }
+    throw error;
+  }
+
+  return {
+    serverId: options.serverId,
+    root: options.root,
+    async openOrChangeFile(filePath, languageId, text) {
+      ensureActive(stopped, options.serverId);
+      const normalizedPath = normalizeFsPath(filePath);
+      const uri = pathToFileURL(normalizedPath).href;
+      const version = versions.get(normalizedPath);
+
+      if (version === undefined) {
+        versions.set(normalizedPath, 0);
+        await connection.sendNotification("textDocument/didOpen", {
+          textDocument: {
+            uri,
+            languageId,
+            version: 0,
+            text,
+          },
+        });
+        return;
+      }
+
+      const nextVersion = version + 1;
+      versions.set(normalizedPath, nextVersion);
+      await connection.sendNotification("textDocument/didChange", {
+        textDocument: {
+          uri,
+          version: nextVersion,
+        },
+        contentChanges: [{ text }],
+      });
+    },
+    async saveFile(filePath) {
+      ensureActive(stopped, options.serverId);
+      const normalizedPath = normalizeFsPath(filePath);
+      if (!versions.has(normalizedPath)) return;
+      await connection.sendNotification("textDocument/didSave", {
+        textDocument: {
+          uri: pathToFileURL(normalizedPath).href,
+        },
+      });
+    },
+    async closeFile(filePath) {
+      ensureActive(stopped, options.serverId);
+      const normalizedPath = normalizeFsPath(filePath);
+      if (!versions.has(normalizedPath)) return;
+      versions.delete(normalizedPath);
+      await connection.sendNotification("textDocument/didClose", {
+        textDocument: {
+          uri: pathToFileURL(normalizedPath).href,
+        },
+      });
+    },
+    async sendRequest<TResult>(method: string, params: unknown) {
+      ensureActive(stopped, options.serverId);
+      return connection.sendRequest(method, params);
+    },
+    async waitForDiagnostics(filePath, timeoutMs = 1_500) {
+      const normalizedPath = normalizeFsPath(filePath);
+      if (diagnostics.has(normalizedPath)) {
+        return diagnostics.get(normalizedPath) ?? [];
+      }
+
+      await new Promise<void>((resolve) => {
+        const entry: DiagnosticWaiter = {
+          resolve: () => {
+            cleanup();
+            resolve();
+          },
+        };
+        const cleanup = () => {
+          const next = (waiters.get(normalizedPath) ?? []).filter((item) => item !== entry);
+          if (next.length === 0) waiters.delete(normalizedPath);
+          else waiters.set(normalizedPath, next);
+        };
+
+        const fallback = setTimeout(() => {
+          cleanup();
+          resolve();
+        }, timeoutMs);
+
+        const originalResolve = entry.resolve;
+        entry.resolve = () => {
+          clearTimeout(fallback);
+          originalResolve();
+        };
+
+        waiters.set(normalizedPath, [...(waiters.get(normalizedPath) ?? []), entry]);
+      });
+
+      return diagnostics.get(normalizedPath) ?? [];
+    },
+    getDiagnostics(filePath) {
+      return diagnostics.get(normalizeFsPath(filePath)) ?? [];
+    },
+    async stop() {
+      if (stopped) return;
+      stopped = true;
+      try {
+        await connection.sendRequest("shutdown");
+      } catch {
+        // Some servers exit before responding to shutdown.
+      }
+      try {
+        await connection.sendNotification("exit", {});
+      } catch {
+        // Best-effort during shutdown.
+      }
+      connection.dispose();
+      try {
+        childProcess.kill("SIGTERM");
+      } catch {
+        // Process may have already exited.
+      }
+    },
+  };
+}
+
+function createConnection(process: ChildProcessWithoutNullStreams): MessageConnection {
+  return createMessageConnection(new StreamMessageReader(process.stdout), new StreamMessageWriter(process.stdin));
+}
+
+async function spawnProcess(launch: LspLaunchSpec, cwd: string): Promise<ChildProcessWithoutNullStreams> {
+  const child = spawn(launch.command, launch.args ?? [], {
+    cwd,
+    env: {
+      ...globalThis.process.env,
+      ...launch.env,
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      child.off("spawn", onSpawn);
+      child.off("error", onError);
+    };
+    const onSpawn = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    child.once("spawn", onSpawn);
+    child.once("error", onError);
+  });
+
+  return child;
+}
+
+function normalizeDiagnostic(input: Diagnostic): LspDiagnostic {
+  return {
+    message: input.message,
+    severity: input.severity,
+    source: input.source,
+    code: input.code !== undefined ? String(input.code) : undefined,
+    range: {
+      start: {
+        line: input.range.start.line,
+        character: input.range.start.character,
+      },
+      end: {
+        line: input.range.end.line,
+        character: input.range.end.character,
+      },
+    },
+  };
+}
+
+function normalizeUriPath(uri: string): string {
+  if (uri.startsWith("file://")) {
+    return normalizeFsPath(fileURLToPath(uri));
+  }
+  return normalizeFsPath(uri);
+}
+
+function normalizeFsPath(filePath: string): string {
+  return filePath.replace(/\\/g, "/");
+}
+
+function ensureActive(stopped: boolean, serverId: string): void {
+  if (stopped) {
+    throw new Error(`LSP client "${serverId}" is already stopped.`);
+  }
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message = "Timed out"): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}

--- a/src/lsp/client.ts
+++ b/src/lsp/client.ts
@@ -144,6 +144,8 @@ export async function createLspClientSession(options: LspClientOptions): Promise
       const uri = pathToFileURL(normalizedPath).href;
       const version = versions.get(normalizedPath);
 
+      diagnostics.delete(normalizedPath);
+
       if (version === undefined) {
         versions.set(normalizedPath, 0);
         await connection.sendNotification("textDocument/didOpen", {

--- a/src/lsp/manager.test.ts
+++ b/src/lsp/manager.test.ts
@@ -1,0 +1,164 @@
+import { mkdir, mkdtemp, rm, writeFile } from "fs/promises";
+import os from "os";
+import path from "path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { LspClientSession } from "./client";
+import { createWorkspaceLspManager } from "./manager";
+import type { NormalizedLspSettings } from "./types";
+
+const BASE_SETTINGS: NormalizedLspSettings = {
+  enabled: true,
+  tool: true,
+  autoInstall: false,
+  startupTimeoutMs: 5_000,
+  diagnosticsDebounceMs: 0,
+  builtins: {
+    typescript: {
+      enabled: false,
+    },
+  },
+  servers: [
+    {
+      id: "fake-ts",
+      command: "fake-lsp",
+      extensions: [".ts"],
+      languageIds: {
+        ".ts": "typescript",
+      },
+      rootMarkers: [".git"],
+    },
+  ],
+};
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("createWorkspaceLspManager", () => {
+  it("routes queries through the matching LSP client", async () => {
+    const root = await createTempWorkspace();
+    const filePath = path.join(root, "src", "demo.ts");
+    await mkdir(path.dirname(filePath), { recursive: true });
+    await writeFile(filePath, "const demo = 1;\n");
+
+    const sendRequest = vi.fn(async (method: string, params: unknown) => {
+      expect(method).toBe("textDocument/definition");
+      expect(params).toMatchObject({
+        position: {
+          line: 4,
+          character: 2,
+        },
+      });
+      return [{ uri: "file:///demo.ts", range: { start: { line: 1, character: 0 }, end: { line: 1, character: 4 } } }];
+    });
+    const client = createFakeClient({ sendRequest });
+
+    const manager = createWorkspaceLspManager(root, BASE_SETTINGS, {
+      createClient: async () => client,
+    });
+
+    const result = await manager.query({
+      operation: "goToDefinition",
+      filePath,
+      line: 5,
+      character: 3,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("file:///demo.ts");
+    expect(client.openOrChangeFile).toHaveBeenCalledWith(filePath, "typescript", "const demo = 1;\n");
+    expect(client.waitForDiagnostics).toHaveBeenCalledWith(filePath);
+
+    await manager.close();
+    expect(client.stop).toHaveBeenCalled();
+  });
+
+  it("returns diagnostics after syncing a saved file", async () => {
+    const root = await createTempWorkspace();
+    const filePath = path.join(root, "demo.ts");
+    const diagnostics = [
+      {
+        filePath,
+        serverId: "fake-ts",
+        diagnostics: [
+          {
+            message: "Type error",
+            severity: 1,
+            range: {
+              start: { line: 0, character: 0 },
+              end: { line: 0, character: 4 },
+            },
+          },
+        ],
+      },
+    ];
+
+    const client = createFakeClient({
+      diagnostics: diagnostics[0].diagnostics,
+    });
+
+    const manager = createWorkspaceLspManager(root, BASE_SETTINGS, {
+      createClient: async () => client,
+    });
+
+    const result = await manager.syncFile(filePath, "const broken = true;\n", true, true);
+
+    expect(result).toEqual(diagnostics);
+    expect(client.saveFile).toHaveBeenCalledWith(filePath);
+    expect(client.waitForDiagnostics).toHaveBeenCalledWith(filePath);
+
+    await manager.close();
+  });
+
+  it("reports when no matching server exists", async () => {
+    const root = await createTempWorkspace();
+    const filePath = path.join(root, "demo.rb");
+    await writeFile(filePath, "puts 'hello'\n");
+
+    const manager = createWorkspaceLspManager(root, { ...BASE_SETTINGS, servers: [] });
+    const result = await manager.query({
+      operation: "hover",
+      filePath,
+      line: 1,
+      character: 1,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("No LSP server available");
+
+    await manager.close();
+  });
+});
+
+async function createTempWorkspace(): Promise<string> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "grok-lsp-manager-"));
+  tempDirs.push(root);
+  await mkdir(path.join(root, ".git"), { recursive: true });
+  return root;
+}
+
+function createFakeClient(input: {
+  diagnostics?: LspClientSession["getDiagnostics"] extends (filePath: string) => infer TResult ? TResult : never;
+  sendRequest?: (method: string, params: unknown) => Promise<unknown>;
+}): LspClientSession & {
+  openOrChangeFile: ReturnType<typeof vi.fn>;
+  saveFile: ReturnType<typeof vi.fn>;
+  waitForDiagnostics: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+} {
+  const diagnostics = input.diagnostics ?? [];
+  return {
+    serverId: "fake-ts",
+    root: "/tmp",
+    openOrChangeFile: vi.fn(async () => {}),
+    saveFile: vi.fn(async () => {}),
+    closeFile: vi.fn(async () => {}),
+    sendRequest: (async <TResult>(method: string, params: unknown) =>
+      (input.sendRequest ? await input.sendRequest(method, params) : []) as TResult) as LspClientSession["sendRequest"],
+    waitForDiagnostics: vi.fn(async () => diagnostics),
+    getDiagnostics: vi.fn(() => diagnostics),
+    stop: vi.fn(async () => {}),
+  };
+}

--- a/src/lsp/manager.ts
+++ b/src/lsp/manager.ts
@@ -236,8 +236,8 @@ function getOperationMethod(operation: LspQueryInput["operation"]): string {
 function createOperationParams(input: LspQueryInput, absolutePath: string): Record<string, unknown> {
   const uri = pathToFileURL(absolutePath).href;
   const position = {
-    line: input.line - 1,
-    character: input.character - 1,
+    line: (input.line ?? 1) - 1,
+    character: (input.character ?? 1) - 1,
   };
 
   switch (input.operation) {

--- a/src/lsp/manager.ts
+++ b/src/lsp/manager.ts
@@ -1,0 +1,293 @@
+import { readFile } from "fs/promises";
+import path from "path";
+import { pathToFileURL } from "url";
+import { createRuntimeLspDefinitions, type RuntimeLspServerDefinition } from "./builtins";
+import { createLspClientSession, type LspClientSession } from "./client";
+import type { LspDiagnosticFile, LspQueryInput, LspToolResponse, NormalizedLspSettings } from "./types";
+
+interface ManagedClient {
+  key: string;
+  definition: RuntimeLspServerDefinition;
+  root: string;
+  client: LspClientSession;
+}
+
+interface WorkspaceLspManagerOptions {
+  createClient?: (input: {
+    serverId: string;
+    root: string;
+    definition: RuntimeLspServerDefinition;
+    settings: NormalizedLspSettings;
+  }) => Promise<LspClientSession | null>;
+}
+
+export interface WorkspaceLspManager {
+  touchFile(filePath: string, waitForDiagnostics?: boolean): Promise<LspDiagnosticFile[]>;
+  syncFile(
+    filePath: string,
+    content: string,
+    save?: boolean,
+    waitForDiagnostics?: boolean,
+  ): Promise<LspDiagnosticFile[]>;
+  query(input: LspQueryInput): Promise<LspToolResponse>;
+  close(): Promise<void>;
+}
+
+export function createWorkspaceLspManager(
+  cwd: string,
+  settings: NormalizedLspSettings,
+  options: WorkspaceLspManagerOptions = {},
+): WorkspaceLspManager {
+  const definitions = createRuntimeLspDefinitions(cwd, settings);
+  const clients = new Map<string, Promise<ManagedClient | null>>();
+
+  const createClient =
+    options.createClient ??
+    (async ({ serverId, root, definition, settings: normalizedSettings }) => {
+      const launch = await definition.resolveLaunch(root, normalizedSettings);
+      if (!launch || !launch.command) return null;
+      return createLspClientSession({
+        serverId,
+        root,
+        launch,
+        startupTimeoutMs: normalizedSettings.startupTimeoutMs,
+        diagnosticsDebounceMs: normalizedSettings.diagnosticsDebounceMs,
+      });
+    });
+
+  async function getClientsForFile(filePath: string): Promise<ManagedClient[]> {
+    if (!settings.enabled) return [];
+
+    const normalizedPath = path.resolve(filePath);
+    const extension = path.extname(normalizedPath).toLowerCase();
+    const matches = definitions.filter((definition) => definition.extensions.includes(extension));
+    if (matches.length === 0) return [];
+
+    const resolved = await Promise.all(
+      matches.map(async (definition) => {
+        const root = await definition.resolveRoot(normalizedPath, cwd);
+        if (!root) return null;
+
+        const cacheKey = `${definition.id}:${root}`;
+        const inflight = clients.get(cacheKey);
+        if (inflight) return inflight;
+
+        const next = (async () => {
+          const client = await createClient({
+            serverId: definition.id,
+            root,
+            definition,
+            settings,
+          });
+          if (!client) return null;
+          return { key: cacheKey, definition, root, client };
+        })();
+
+        clients.set(cacheKey, next);
+        try {
+          const value = await next;
+          if (!value) {
+            clients.delete(cacheKey);
+          }
+          return value;
+        } catch (err) {
+          clients.delete(cacheKey);
+          const msg = err instanceof Error ? err.message : String(err);
+          console.error(`[lsp] Failed to start ${definition.id} for ${cacheKey}: ${msg}`);
+          return null;
+        }
+      }),
+    );
+
+    return resolved.filter((value): value is ManagedClient => value !== null);
+  }
+
+  async function touchFile(filePath: string, waitForDiagnostics = true): Promise<LspDiagnosticFile[]> {
+    const content = await readFile(filePath, "utf8");
+    return syncFile(filePath, content, false, waitForDiagnostics);
+  }
+
+  async function syncFile(
+    filePath: string,
+    content: string,
+    save = true,
+    waitForDiagnostics = true,
+  ): Promise<LspDiagnosticFile[]> {
+    const records = await getClientsForFile(filePath);
+    if (records.length === 0) return [];
+
+    const extension = path.extname(filePath).toLowerCase();
+    const diagnostics = await Promise.all(
+      records.map(async ({ key, definition, client }) => {
+        const languageId = definition.languageIds[extension] ?? (extension.slice(1) || "plaintext");
+        try {
+          await client.openOrChangeFile(filePath, languageId, content);
+          if (save) {
+            await client.saveFile(filePath);
+          }
+          if (waitForDiagnostics) {
+            await client.waitForDiagnostics(filePath);
+          }
+          return {
+            filePath,
+            serverId: client.serverId,
+            diagnostics: client.getDiagnostics(filePath),
+          };
+        } catch {
+          clients.delete(key);
+          return null;
+        }
+      }),
+    );
+
+    return diagnostics.filter((entry): entry is LspDiagnosticFile => entry !== null && entry.diagnostics.length > 0);
+  }
+
+  async function query(input: LspQueryInput): Promise<LspToolResponse> {
+    const normalizedPath = path.resolve(cwd, input.filePath);
+    const records = await getClientsForFile(normalizedPath);
+    if (records.length === 0) {
+      return {
+        success: false,
+        output: `No LSP server available for ${path.extname(normalizedPath) || "this file type"}.`,
+      };
+    }
+
+    const lspDiagnostics = await touchFile(normalizedPath, true);
+    const params = createOperationParams(input, normalizedPath);
+    const results = (
+      await Promise.all(
+        records.map(async ({ key, client }) => {
+          if (input.operation === "incomingCalls" || input.operation === "outgoingCalls") {
+            try {
+              const items = await client.sendRequest<unknown[]>("textDocument/prepareCallHierarchy", params);
+              const firstItem = Array.isArray(items) ? items[0] : undefined;
+              if (!firstItem) return [];
+              return client.sendRequest<unknown[]>(
+                input.operation === "incomingCalls" ? "callHierarchy/incomingCalls" : "callHierarchy/outgoingCalls",
+                { item: firstItem },
+              );
+            } catch {
+              clients.delete(key);
+              return [];
+            }
+          }
+
+          try {
+            return await client.sendRequest<unknown>(getOperationMethod(input.operation), params);
+          } catch {
+            clients.delete(key);
+            return [];
+          }
+        }),
+      )
+    )
+      .flatMap((result) => (Array.isArray(result) ? result : result ? [result] : []))
+      .filter(Boolean);
+
+    const output = results.length > 0 ? JSON.stringify(results, null, 2) : `No results found for ${input.operation}.`;
+    return {
+      success: true,
+      output,
+      lspDiagnostics,
+    };
+  }
+
+  async function close(): Promise<void> {
+    const entries = await Promise.allSettled([...clients.values()]);
+    const active = entries
+      .filter((entry): entry is PromiseFulfilledResult<ManagedClient | null> => entry.status === "fulfilled")
+      .map((entry) => entry.value)
+      .filter((value): value is ManagedClient => value !== null);
+    await Promise.allSettled(active.map((entry) => entry.client.stop()));
+    clients.clear();
+  }
+
+  return {
+    touchFile,
+    syncFile,
+    query,
+    close,
+  };
+}
+
+function getOperationMethod(operation: LspQueryInput["operation"]): string {
+  switch (operation) {
+    case "goToDefinition":
+      return "textDocument/definition";
+    case "findReferences":
+      return "textDocument/references";
+    case "hover":
+      return "textDocument/hover";
+    case "documentSymbol":
+      return "textDocument/documentSymbol";
+    case "workspaceSymbol":
+      return "workspace/symbol";
+    case "goToImplementation":
+      return "textDocument/implementation";
+    case "prepareCallHierarchy":
+      return "textDocument/prepareCallHierarchy";
+    case "incomingCalls":
+    case "outgoingCalls":
+      return "textDocument/prepareCallHierarchy";
+  }
+}
+
+function createOperationParams(input: LspQueryInput, absolutePath: string): Record<string, unknown> {
+  const uri = pathToFileURL(absolutePath).href;
+  const position = {
+    line: input.line - 1,
+    character: input.character - 1,
+  };
+
+  switch (input.operation) {
+    case "goToDefinition":
+    case "hover":
+    case "goToImplementation":
+    case "prepareCallHierarchy":
+    case "incomingCalls":
+    case "outgoingCalls":
+      return {
+        textDocument: { uri },
+        position,
+      };
+    case "findReferences":
+      return {
+        textDocument: { uri },
+        position,
+        context: { includeDeclaration: true },
+      };
+    case "documentSymbol":
+      return {
+        textDocument: { uri },
+      };
+    case "workspaceSymbol":
+      return {
+        query: input.query ?? "",
+      };
+  }
+}
+
+export function summarizeLspDiagnostics(diagnostics: LspDiagnosticFile[]): string | null {
+  const counts = diagnostics
+    .flatMap((entry) => entry.diagnostics)
+    .reduce(
+      (acc, diagnostic) => {
+        const severity = diagnostic.severity ?? 1;
+        if (severity === 1) acc.errors += 1;
+        else if (severity === 2) acc.warnings += 1;
+        else acc.infos += 1;
+        return acc;
+      },
+      { errors: 0, warnings: 0, infos: 0 },
+    );
+
+  const total = counts.errors + counts.warnings + counts.infos;
+  if (total === 0) return null;
+
+  const parts = [`${total} LSP issue${total === 1 ? "" : "s"}`];
+  if (counts.errors > 0) parts.push(`${counts.errors} error${counts.errors === 1 ? "" : "s"}`);
+  if (counts.warnings > 0) parts.push(`${counts.warnings} warning${counts.warnings === 1 ? "" : "s"}`);
+  if (counts.infos > 0) parts.push(`${counts.infos} info`);
+  return parts.join(" · ");
+}

--- a/src/lsp/npm-cache.test.ts
+++ b/src/lsp/npm-cache.test.ts
@@ -1,0 +1,68 @@
+import { mkdir, mkdtemp, readdir, rm, writeFile } from "fs/promises";
+import os from "os";
+import path from "path";
+import { afterEach, describe, expect, it } from "vitest";
+import { lspNpmWhich } from "./npm-cache";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("lspNpmWhich", () => {
+  it("resolves a single binary from a pre-populated cache", async () => {
+    const dir = await createFakePackageCache("fake-server", { "fake-server": "lib/cli.js" });
+    const result = await lspNpmWhich("fake-server");
+
+    expect(result).toBe(path.join(dir, "node_modules", ".bin", "fake-server"));
+  });
+
+  it("resolves the correct binary from a multi-binary package", async () => {
+    const dir = await createFakePackageCache("multi-bin", {
+      "multi-bin": "lib/main.js",
+      "multi-bin-helper": "lib/helper.js",
+    });
+    const result = await lspNpmWhich("multi-bin");
+
+    expect(result).toBe(path.join(dir, "node_modules", ".bin", "multi-bin"));
+  });
+
+  it("returns null when the package cannot be installed", async () => {
+    const result = await lspNpmWhich("@nonexistent-scope/totally-fake-package-that-does-not-exist-12345");
+    expect(result).toBeNull();
+  });
+});
+
+async function createFakePackageCache(pkg: string, binEntries: Record<string, string>): Promise<string> {
+  const cacheRoot = path.join(os.homedir(), ".grok", "cache", "lsp", pkg);
+  tempDirs.push(cacheRoot);
+
+  const binDir = path.join(cacheRoot, "node_modules", ".bin");
+  const pkgDir = path.join(cacheRoot, "node_modules", pkg);
+  await mkdir(binDir, { recursive: true });
+  await mkdir(pkgDir, { recursive: true });
+
+  for (const [name, target] of Object.entries(binEntries)) {
+    const targetPath = path.join(pkgDir, target);
+    await mkdir(path.dirname(targetPath), { recursive: true });
+    await writeFile(targetPath, "#!/usr/bin/env node\n", { mode: 0o755 });
+
+    const linkPath = path.join(binDir, name);
+    const { symlink } = await import("fs/promises");
+    await symlink(path.relative(binDir, targetPath), linkPath).catch(() => {
+      // Fallback: write a stub file if symlinks fail (Windows)
+      return writeFile(linkPath, `#!/bin/sh\nnode "${targetPath}" "$@"\n`, { mode: 0o755 });
+    });
+  }
+
+  await writeFile(
+    path.join(pkgDir, "package.json"),
+    JSON.stringify({
+      name: pkg,
+      bin: Object.keys(binEntries).length === 1 ? Object.values(binEntries)[0] : binEntries,
+    }),
+  );
+
+  return cacheRoot;
+}

--- a/src/lsp/npm-cache.ts
+++ b/src/lsp/npm-cache.ts
@@ -1,0 +1,108 @@
+import Arborist from "@npmcli/arborist";
+import { access, mkdir, readdir, readFile, rm } from "fs/promises";
+import os from "os";
+import path from "path";
+
+const CACHE_ROOT = path.join(os.homedir(), ".grok", "cache", "lsp");
+const locks = new Map<string, Promise<unknown>>();
+
+function packageDir(pkg: string): string {
+  const sanitized =
+    process.platform === "win32"
+      ? Array.from(pkg, (ch) => (/[<>:"|?*]/.test(ch) || ch.charCodeAt(0) < 32 ? "_" : ch)).join("")
+      : pkg;
+  return path.join(CACHE_ROOT, sanitized);
+}
+
+export async function lspNpmWhich(pkg: string): Promise<string | null> {
+  const dir = packageDir(pkg);
+  const binDir = path.join(dir, "node_modules", ".bin");
+
+  const pick = async (): Promise<string | undefined> => {
+    const files = await readdir(binDir).catch(() => []);
+    if (files.length === 0) return undefined;
+    if (files.length === 1) return files[0];
+
+    const pkgJsonPath = path.join(dir, "node_modules", pkg, "package.json");
+    const pkgJson = await readJsonSafe<{ bin?: string | Record<string, string> }>(pkgJsonPath);
+    if (pkgJson?.bin) {
+      const unscoped = pkg.startsWith("@") ? pkg.split("/")[1]! : pkg;
+      const bin = pkgJson.bin;
+      if (typeof bin === "string") return unscoped;
+      const keys = Object.keys(bin);
+      if (keys.length === 1) return keys[0];
+      return bin[unscoped] ? unscoped : keys[0];
+    }
+    return files[0];
+  };
+
+  const bin = await pick();
+  if (bin) return path.join(binDir, bin);
+
+  try {
+    await rm(path.join(dir, "package-lock.json"), { force: true });
+    await lspNpmAdd(pkg);
+  } catch {
+    return null;
+  }
+  const resolved = await pick();
+  if (!resolved) return null;
+  return path.join(binDir, resolved);
+}
+
+export async function lspNpmAdd(pkg: string): Promise<string> {
+  return withPackageLock(pkg, async () => {
+    const dir = packageDir(pkg);
+    await mkdir(dir, { recursive: true });
+
+    const arborist = new Arborist({
+      path: dir,
+      binLinks: true,
+      progress: false,
+      savePrefix: "",
+      ignoreScripts: true,
+    } as ConstructorParameters<typeof Arborist>[0]);
+
+    const tree = await arborist.loadVirtual().catch(() => undefined);
+    if (tree) {
+      const first = tree.edgesOut.values().next().value?.to;
+      if (first?.path) return first.path as string;
+    }
+
+    const result = await arborist.reify({
+      add: [pkg],
+      save: true,
+      saveType: "prod" as const,
+    });
+
+    const first = result.edgesOut.values().next().value?.to;
+    if (!first?.path) throw new Error(`Failed to install ${pkg}`);
+    return first.path as string;
+  });
+}
+
+async function readJsonSafe<T>(filePath: string): Promise<T | undefined> {
+  try {
+    await access(filePath);
+    const raw = await readFile(filePath, "utf8");
+    return JSON.parse(raw) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+async function withPackageLock<T>(pkg: string, fn: () => Promise<T>): Promise<T> {
+  const key = `lsp-install:${pkg}`;
+  while (locks.has(key)) {
+    await locks.get(key)!.catch(() => {});
+  }
+  const task = fn();
+  locks.set(key, task);
+  try {
+    return await task;
+  } finally {
+    if (locks.get(key) === task) {
+      locks.delete(key);
+    }
+  }
+}

--- a/src/lsp/runtime.ts
+++ b/src/lsp/runtime.ts
@@ -1,0 +1,70 @@
+import { existsSync } from "fs";
+import path from "path";
+import { getCurrentLspSettings } from "../utils/settings";
+import { createWorkspaceLspManager, summarizeLspDiagnostics, type WorkspaceLspManager } from "./manager";
+import type { LspDiagnosticFile, LspQueryInput, LspToolResponse } from "./types";
+
+const managers = new Map<string, WorkspaceLspManager>();
+
+export async function queryLsp(cwd: string, input: LspQueryInput): Promise<LspToolResponse> {
+  const manager = getOrCreateManager(cwd);
+  return manager.query({
+    ...input,
+    filePath: path.isAbsolute(input.filePath) ? input.filePath : path.resolve(cwd, input.filePath),
+  });
+}
+
+export async function syncFileWithLsp(
+  cwd: string,
+  filePath: string,
+  content: string,
+  save = true,
+  waitForDiagnostics = true,
+): Promise<LspDiagnosticFile[]> {
+  const manager = getOrCreateManager(cwd);
+  return manager.syncFile(
+    path.isAbsolute(filePath) ? filePath : path.resolve(cwd, filePath),
+    content,
+    save,
+    waitForDiagnostics,
+  );
+}
+
+export function isLspToolEnabled(cwd: string): boolean {
+  const settings = getCurrentLspSettings();
+  return settings.enabled && settings.tool;
+}
+
+export function summarizeDiagnostics(diagnostics: LspDiagnosticFile[]): string | null {
+  return summarizeLspDiagnostics(diagnostics);
+}
+
+export async function shutdownWorkspaceLspManager(cwd: string): Promise<void> {
+  const key = resolveManagerKey(cwd);
+  const manager = managers.get(key);
+  if (!manager) return;
+  managers.delete(key);
+  await manager.close();
+}
+
+function getOrCreateManager(cwd: string): WorkspaceLspManager {
+  const key = resolveManagerKey(cwd);
+  const existing = managers.get(key);
+  if (existing) return existing;
+
+  const manager = createWorkspaceLspManager(key, getCurrentLspSettings());
+  managers.set(key, manager);
+  return manager;
+}
+
+function resolveManagerKey(cwd: string): string {
+  let current = path.resolve(cwd);
+  while (true) {
+    if (existsSync(path.join(current, ".grok")) || existsSync(path.join(current, ".git"))) {
+      return current;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) return current;
+    current = parent;
+  }
+}

--- a/src/lsp/types.ts
+++ b/src/lsp/types.ts
@@ -104,8 +104,8 @@ export interface NormalizedLspSettings {
 export interface LspQueryInput {
   operation: LspToolOperation;
   filePath: string;
-  line: number;
-  character: number;
+  line?: number;
+  character?: number;
   query?: string;
 }
 

--- a/src/lsp/types.ts
+++ b/src/lsp/types.ts
@@ -1,0 +1,116 @@
+export const LSP_TOOL_OPERATIONS = [
+  "goToDefinition",
+  "findReferences",
+  "hover",
+  "documentSymbol",
+  "workspaceSymbol",
+  "goToImplementation",
+  "prepareCallHierarchy",
+  "incomingCalls",
+  "outgoingCalls",
+] as const;
+
+export type LspToolOperation = (typeof LSP_TOOL_OPERATIONS)[number];
+
+export type LspBuiltInServerId =
+  | "typescript"
+  | "pyright"
+  | "gopls"
+  | "rust-analyzer"
+  | "bash-language-server"
+  | "yaml-language-server"
+  | "clangd"
+  | "jdtls"
+  | "sourcekit-lsp";
+
+export interface LspPosition {
+  line: number;
+  character: number;
+}
+
+export interface LspRange {
+  start: LspPosition;
+  end: LspPosition;
+}
+
+export interface LspLocation {
+  uri: string;
+  range: LspRange;
+}
+
+export interface LspDiagnostic {
+  message: string;
+  severity?: number;
+  source?: string;
+  code?: string;
+  range: LspRange;
+}
+
+export interface LspDiagnosticFile {
+  filePath: string;
+  serverId: string;
+  diagnostics: LspDiagnostic[];
+}
+
+export interface LspLaunchSpec {
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  initializationOptions?: Record<string, unknown>;
+}
+
+export interface LspBuiltInServerSettings {
+  enabled?: boolean;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  initialization?: Record<string, unknown>;
+  rootMarkers?: string[];
+  extensions?: string[];
+}
+
+export interface LspCustomServerConfig {
+  id: string;
+  enabled?: boolean;
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  initialization?: Record<string, unknown>;
+  rootMarkers?: string[];
+  extensions: string[];
+  languageIds?: Record<string, string>;
+}
+
+export interface LspSettings {
+  enabled?: boolean;
+  tool?: boolean;
+  autoInstall?: boolean;
+  startupTimeoutMs?: number;
+  diagnosticsDebounceMs?: number;
+  builtins?: Partial<Record<LspBuiltInServerId, LspBuiltInServerSettings>>;
+  servers?: LspCustomServerConfig[];
+}
+
+export interface NormalizedLspSettings {
+  enabled: boolean;
+  tool: boolean;
+  autoInstall: boolean;
+  startupTimeoutMs: number;
+  diagnosticsDebounceMs: number;
+  builtins: Partial<Record<LspBuiltInServerId, LspBuiltInServerSettings>>;
+  servers: LspCustomServerConfig[];
+}
+
+export interface LspQueryInput {
+  operation: LspToolOperation;
+  filePath: string;
+  line: number;
+  character: number;
+  query?: string;
+}
+
+export interface LspToolResponse {
+  success: boolean;
+  output: string;
+  lspDiagnostics?: LspDiagnosticFile[];
+}

--- a/src/tools/file.test.ts
+++ b/src/tools/file.test.ts
@@ -1,0 +1,95 @@
+import { mkdtemp, readFile, rm, writeFile as writeFsFile } from "fs/promises";
+import os from "os";
+import path from "path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { editFile, writeFile } from "./file";
+
+const summarizeDiagnosticsMock = vi.fn<(diagnostics: unknown) => string>(() => "1 LSP issue · 1 error");
+const syncFileWithLspMock = vi.fn<
+  (
+    cwd: string,
+    filePath: string,
+    content: string,
+    save: boolean,
+    waitForDiagnostics: boolean,
+  ) => Promise<
+    Array<{
+      filePath: string;
+      serverId: string;
+      diagnostics: Array<{
+        message: string;
+        severity: number;
+        range: {
+          start: { line: number; character: number };
+          end: { line: number; character: number };
+        };
+      }>;
+    }>
+  >
+>(async () => [
+  {
+    filePath: "/tmp/demo.ts",
+    serverId: "typescript",
+    diagnostics: [
+      {
+        message: "Type error",
+        severity: 1,
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 5 },
+        },
+      },
+    ],
+  },
+]);
+
+vi.mock("../lsp/runtime", () => ({
+  summarizeDiagnostics: (diagnostics: unknown) => summarizeDiagnosticsMock(diagnostics),
+  syncFileWithLsp: (cwd: string, filePath: string, content: string, save: boolean, waitForDiagnostics: boolean) =>
+    syncFileWithLspMock(cwd, filePath, content, save, waitForDiagnostics),
+}));
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  summarizeDiagnosticsMock.mockClear();
+  syncFileWithLspMock.mockClear();
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("file tool LSP integration", () => {
+  it("includes diagnostics metadata when writing a file", async () => {
+    const cwd = await createTempDir();
+    const result = await writeFile("demo.ts", "const answer = 42;\n", cwd);
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("1 LSP issue");
+    expect(result.lspDiagnostics).toHaveLength(1);
+    expect(syncFileWithLspMock).toHaveBeenCalledWith(
+      cwd,
+      path.join(cwd, "demo.ts"),
+      "const answer = 42;\n",
+      true,
+      true,
+    );
+  });
+
+  it("syncs edited file contents through the LSP runtime", async () => {
+    const cwd = await createTempDir();
+    const filePath = path.join(cwd, "demo.ts");
+    await writeFsFile(filePath, "const answer = 41;\n", "utf8");
+
+    const result = await editFile("demo.ts", "41", "42", cwd);
+    const content = await readFile(filePath, "utf8");
+
+    expect(result.success).toBe(true);
+    expect(content).toContain("42");
+    expect(syncFileWithLspMock).toHaveBeenCalledWith(cwd, filePath, "const answer = 42;\n", true, true);
+  });
+});
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "grok-file-tools-"));
+  tempDirs.push(dir);
+  return dir;
+}

--- a/src/tools/file.ts
+++ b/src/tools/file.ts
@@ -1,6 +1,8 @@
 import { createTwoFilesPatch } from "diff";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { dirname, isAbsolute, resolve } from "path";
+import { summarizeDiagnostics, syncFileWithLsp } from "../lsp/runtime";
+import type { LspDiagnosticFile } from "../lsp/types";
 
 export interface FileDiff {
   filePath: string;
@@ -14,6 +16,7 @@ export interface FileResult {
   success: boolean;
   output: string;
   diff?: FileDiff;
+  lspDiagnostics?: LspDiagnosticFile[];
 }
 
 function resolvePath(filePath: string, cwd: string): string {
@@ -58,7 +61,7 @@ export function readFile(filePath: string, cwd: string, startLine?: number, endL
   }
 }
 
-export function writeFile(filePath: string, content: string, cwd: string): FileResult {
+export async function writeFile(filePath: string, content: string, cwd: string): Promise<FileResult> {
   try {
     const full = resolvePath(filePath, cwd);
     const before = existsSync(full) ? readFileSync(full, "utf-8") : "";
@@ -68,10 +71,13 @@ export function writeFile(filePath: string, content: string, cwd: string): FileR
 
     const diff = computeDiff(filePath, before, content);
     const verb = before === "" ? "Created" : "Updated";
+    const lspDiagnostics = await syncFileWithLsp(cwd, full, content, true, true).catch(() => [] as LspDiagnosticFile[]);
+    const lspSummary = summarizeDiagnostics(lspDiagnostics);
     return {
       success: true,
-      output: `${verb} ${filePath} (+${diff.additions} -${diff.removals})`,
+      output: `${verb} ${filePath} (+${diff.additions} -${diff.removals})${lspSummary ? `\n${lspSummary}` : ""}`,
       diff,
+      lspDiagnostics,
     };
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -79,7 +85,12 @@ export function writeFile(filePath: string, content: string, cwd: string): FileR
   }
 }
 
-export function editFile(filePath: string, oldString: string, newString: string, cwd: string): FileResult {
+export async function editFile(
+  filePath: string,
+  oldString: string,
+  newString: string,
+  cwd: string,
+): Promise<FileResult> {
   try {
     const full = resolvePath(filePath, cwd);
     if (!existsSync(full)) {
@@ -102,10 +113,13 @@ export function editFile(filePath: string, oldString: string, newString: string,
     writeFileSync(full, after, "utf-8");
 
     const diff = computeDiff(filePath, before, after);
+    const lspDiagnostics = await syncFileWithLsp(cwd, full, after, true, true).catch(() => [] as LspDiagnosticFile[]);
+    const lspSummary = summarizeDiagnostics(lspDiagnostics);
     return {
       success: true,
-      output: `Edited ${filePath} (+${diff.additions} -${diff.removals})`,
+      output: `Edited ${filePath} (+${diff.additions} -${diff.removals})${lspSummary ? `\n${lspSummary}` : ""}`,
       diff,
+      lspDiagnostics,
     };
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 import type { ModelMessage } from "ai";
+import type { LspDiagnosticFile } from "../lsp/types";
 
 export interface FileDiff {
   filePath: string;
@@ -175,6 +176,7 @@ export interface ToolResult {
   media?: MediaAsset[];
   computer?: ComputerToolMetadata;
   verifyRecipe?: VerifyRecipe;
+  lspDiagnostics?: LspDiagnosticFile[];
 }
 
 export interface ToolCall {

--- a/src/ui/app.tsx
+++ b/src/ui/app.tsx
@@ -4191,6 +4191,21 @@ function MessageView({
         return <ToolTextOutputView t={t} label={toolLabel(entry.toolCall!)} content={entry.content} />;
       }
 
+      if (name === "lsp") {
+        const lspOp = tryParseArg(entry.toolCall, "operation") || "query";
+        const lspFile = tryParseArg(entry.toolCall, "filePath") || "";
+        const lspLine = tryParseArg(entry.toolCall, "line");
+        const lspPos = lspLine ? `:${lspLine}` : "";
+        return (
+          <box gap={0} marginTop={1}>
+            <InlineTool t={t} pending={false}>
+              {`lsp ${lspOp} ${lspFile}${lspPos}`}
+            </InlineTool>
+            <LspResultView t={t} operation={lspOp} filePath={lspFile} position={lspPos} content={entry.content} />
+          </box>
+        );
+      }
+
       if ((entry.toolResult?.media?.length ?? 0) > 0) {
         if (name === "generate_image" || name === "generate_video") {
           return <MediaAutoOpenView t={t} label={toolLabel(entry.toolCall!)} toolResult={entry.toolResult!} />;
@@ -4207,6 +4222,9 @@ function MessageView({
               {label}
             </InlineTool>
             {diff && <DiffView t={t} diff={diff} />}
+            {(entry.toolResult?.lspDiagnostics?.length ?? 0) > 0 && (
+              <LspDiagnosticsView t={t} diagnostics={entry.toolResult?.lspDiagnostics ?? []} />
+            )}
           </box>
         );
       }
@@ -4381,6 +4399,96 @@ function DiffView({ t, diff }: { t: Theme; diff: FileDiff }) {
       </box>
     </box>
   );
+}
+
+const MAX_LSP_RESULT_LINES = 10;
+
+function LspResultView({
+  t,
+  operation,
+  filePath,
+  position,
+  content,
+}: {
+  t: Theme;
+  operation: string;
+  filePath: string;
+  position: string;
+  content: string;
+}) {
+  const body = content.trim();
+  const lines = body.split("\n");
+  const truncated = lines.length > MAX_LSP_RESULT_LINES;
+  const visible = truncated ? lines.slice(0, MAX_LSP_RESULT_LINES).join("\n") : body;
+  const label = `${operation} ${filePath}${position}`;
+
+  return (
+    <box paddingLeft={5} marginTop={0} flexShrink={0}>
+      <box flexDirection="column">
+        <box backgroundColor={t.diffHeader} paddingLeft={1} paddingRight={1}>
+          <text>
+            <span style={{ fg: t.primary }}>{"lsp"}</span>
+            <span style={{ fg: t.textDim }}>{" · "}</span>
+            <span style={{ fg: t.diffHeaderFg }}>{label}</span>
+          </text>
+        </box>
+        <box backgroundColor={t.mdCodeBlockBg} paddingLeft={1} paddingRight={1}>
+          <text fg={t.mdCodeBlockFg}>{visible}</text>
+        </box>
+        {truncated && (
+          <box backgroundColor={t.diffSeparator} paddingLeft={1}>
+            <text fg={t.diffSeparatorFg}>
+              {"⌃  "}
+              {lines.length - MAX_LSP_RESULT_LINES}
+              {" more lines"}
+            </text>
+          </box>
+        )}
+      </box>
+    </box>
+  );
+}
+
+function LspDiagnosticsView({ t, diagnostics }: { t: Theme; diagnostics: NonNullable<ToolResult["lspDiagnostics"]> }) {
+  const files = diagnostics.slice(0, 3);
+  return (
+    <box paddingLeft={5} marginTop={1}>
+      <box flexDirection="column">
+        <box>
+          <text fg={t.textMuted}>{"LSP diagnostics"}</text>
+        </box>
+        {files.map((entry) => (
+          <box key={`${entry.serverId}:${entry.filePath}`} flexDirection="column">
+            <text fg={t.textDim}>{`${entry.serverId} • ${entry.filePath}`}</text>
+            {entry.diagnostics.slice(0, 5).map((diagnostic, index) => (
+              <text
+                // biome-ignore lint/suspicious/noArrayIndexKey: diagnostics may not include stable ids
+                key={`${entry.serverId}:${entry.filePath}:${index}`}
+                fg={diagnostic.severity === 1 ? t.diffRemovedFg : diagnostic.severity === 2 ? t.primary : t.textMuted}
+              >
+                {`${formatLspSeverity(diagnostic.severity)} ${diagnostic.range.start.line + 1}:${diagnostic.range.start.character + 1} ${diagnostic.message}`}
+              </text>
+            ))}
+          </box>
+        ))}
+      </box>
+    </box>
+  );
+}
+
+function formatLspSeverity(severity?: number): string {
+  switch (severity) {
+    case 1:
+      return "error";
+    case 2:
+      return "warning";
+    case 3:
+      return "info";
+    case 4:
+      return "hint";
+    default:
+      return "issue";
+  }
 }
 
 function ShimmerText({ t, text }: { t: Theme; text: string }) {
@@ -5500,6 +5608,7 @@ function toolArgs(tc?: ToolCall): string {
       return a.path || "";
     if (tc.function.name === "generate_image" || tc.function.name === "generate_video") return a.prompt || "";
     if (tc.function.name === "task") return a.description || "";
+    if (tc.function.name === "lsp") return `${a.operation || "query"} ${a.filePath || ""}`.trim();
     if (tc.function.name === "delegate") return a.description || "";
     if (tc.function.name === "delegation_read") return a.id || "";
     if (tc.function.name === "process_logs" || tc.function.name === "process_stop")

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -3,6 +3,13 @@ import * as os from "os";
 import * as path from "path";
 import { DEFAULT_MODEL, getEffectiveReasoningEffort, getModelIds, normalizeModelId } from "../grok/models";
 import type { HooksConfig } from "../hooks/types";
+import type {
+  LspBuiltInServerId,
+  LspBuiltInServerSettings,
+  LspCustomServerConfig,
+  LspSettings,
+  NormalizedLspSettings,
+} from "../lsp/types";
 import type { ReasoningEffort } from "../types/index";
 
 export type TelegramStreamingMode = "off" | "partial";
@@ -26,6 +33,16 @@ const DEFAULT_PAYMENT_SETTINGS: Required<PaymentSettings> = {
   approval: {
     autoApprove: false,
   },
+};
+
+const DEFAULT_LSP_SETTINGS: NormalizedLspSettings = {
+  enabled: true,
+  tool: true,
+  autoInstall: false,
+  startupTimeoutMs: 30_000,
+  diagnosticsDebounceMs: 200,
+  builtins: {},
+  servers: [],
 };
 
 export interface SandboxSecretConfig {
@@ -161,6 +178,7 @@ export interface UserSettings {
   defaultModel?: string;
   sandboxMode?: SandboxMode;
   sandbox?: SandboxSettings;
+  lsp?: LspSettings;
   reasoningEffortByModel?: Record<string, ReasoningEffort>;
   telegram?: TelegramSettings;
   mcp?: McpSettings;
@@ -173,6 +191,7 @@ export interface ProjectSettings {
   model?: string;
   sandboxMode?: SandboxMode;
   sandbox?: SandboxSettings;
+  lsp?: LspSettings;
 }
 
 const USER_DIR = path.join(os.homedir(), ".grok");
@@ -256,6 +275,11 @@ export function saveUserSettings(partial: Partial<UserSettings>): void {
     ...(partial.sandbox !== undefined
       ? { sandbox: normalizeSandboxSettings({ ...current.sandbox, ...partial.sandbox }) }
       : {}),
+    ...(partial.lsp !== undefined
+      ? {
+          lsp: mergeLspSettings(current.lsp, partial.lsp),
+        }
+      : {}),
     ...(partial.payments !== undefined
       ? {
           payments: {
@@ -288,6 +312,11 @@ export function saveProjectSettings(partial: Partial<ProjectSettings>): void {
     ...(partial.sandboxMode !== undefined ? { sandboxMode: normalizeSandboxMode(partial.sandboxMode) } : {}),
     ...(partial.sandbox !== undefined
       ? { sandbox: normalizeSandboxSettings({ ...current.sandbox, ...partial.sandbox }) }
+      : {}),
+    ...(partial.lsp !== undefined
+      ? {
+          lsp: mergeLspSettings(current.lsp, partial.lsp),
+        }
       : {}),
   });
 }
@@ -388,6 +417,145 @@ export function mergeSandboxSettings(
   };
 }
 
+function normalizeLspBuiltInServerSettings(raw: unknown): LspBuiltInServerSettings | undefined {
+  if (!isNonNullObject(raw)) return undefined;
+  const result: LspBuiltInServerSettings = {};
+
+  if (typeof raw.enabled === "boolean") result.enabled = raw.enabled;
+  if (typeof raw.command === "string" && raw.command.trim()) result.command = raw.command.trim();
+  if (Array.isArray(raw.args)) {
+    const args = raw.args.filter((value): value is string => typeof value === "string");
+    if (args.length > 0) result.args = args;
+  }
+  if (isNonNullObject(raw.env)) {
+    const envEntries = Object.entries(raw.env).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string",
+    );
+    const env = Object.fromEntries(envEntries);
+    if (Object.keys(env).length > 0) result.env = env;
+  }
+  if (isNonNullObject(raw.initialization)) {
+    result.initialization = raw.initialization;
+  }
+  if (Array.isArray(raw.rootMarkers)) {
+    const rootMarkers = raw.rootMarkers.filter(
+      (value): value is string => typeof value === "string" && value.trim() !== "",
+    );
+    if (rootMarkers.length > 0) result.rootMarkers = rootMarkers;
+  }
+  if (Array.isArray(raw.extensions)) {
+    const extensions = raw.extensions.filter(
+      (value): value is string => typeof value === "string" && value.trim() !== "",
+    );
+    if (extensions.length > 0) result.extensions = extensions;
+  }
+
+  return result;
+}
+
+function normalizeLspCustomServerConfig(raw: unknown): LspCustomServerConfig | null {
+  if (!isNonNullObject(raw)) return null;
+  const id = typeof raw.id === "string" ? raw.id.trim() : "";
+  const command = typeof raw.command === "string" ? raw.command.trim() : "";
+  const extensions = Array.isArray(raw.extensions)
+    ? raw.extensions.filter((value): value is string => typeof value === "string" && value.trim() !== "")
+    : [];
+  if (!id || !command || extensions.length === 0) return null;
+
+  const result: LspCustomServerConfig = {
+    id,
+    command,
+    extensions,
+  };
+
+  if (typeof raw.enabled === "boolean") result.enabled = raw.enabled;
+  if (Array.isArray(raw.args)) {
+    result.args = raw.args.filter((value): value is string => typeof value === "string");
+  }
+  if (isNonNullObject(raw.env)) {
+    result.env = Object.fromEntries(
+      Object.entries(raw.env).filter((entry): entry is [string, string] => typeof entry[1] === "string"),
+    );
+  }
+  if (isNonNullObject(raw.initialization)) {
+    result.initialization = raw.initialization;
+  }
+  if (Array.isArray(raw.rootMarkers)) {
+    result.rootMarkers = raw.rootMarkers.filter(
+      (value): value is string => typeof value === "string" && value.trim() !== "",
+    );
+  }
+  if (isNonNullObject(raw.languageIds)) {
+    result.languageIds = Object.fromEntries(
+      Object.entries(raw.languageIds)
+        .filter((entry): entry is [string, string] => typeof entry[1] === "string" && entry[0].trim() !== "")
+        .map(([key, value]) => [key.trim(), value]),
+    );
+  }
+
+  return result;
+}
+
+export function normalizeLspSettings(raw: unknown): NormalizedLspSettings {
+  if (!isNonNullObject(raw)) return { ...DEFAULT_LSP_SETTINGS };
+
+  const builtins: Partial<Record<LspBuiltInServerId, LspBuiltInServerSettings>> = {};
+  if (isNonNullObject(raw.builtins)) {
+    for (const [key, value] of Object.entries(raw.builtins)) {
+      const normalized = normalizeLspBuiltInServerSettings(value);
+      if (!normalized) continue;
+      builtins[key as LspBuiltInServerId] = normalized;
+    }
+  }
+
+  return {
+    enabled: typeof raw.enabled === "boolean" ? raw.enabled : DEFAULT_LSP_SETTINGS.enabled,
+    tool: typeof raw.tool === "boolean" ? raw.tool : DEFAULT_LSP_SETTINGS.tool,
+    autoInstall: typeof raw.autoInstall === "boolean" ? raw.autoInstall : DEFAULT_LSP_SETTINGS.autoInstall,
+    startupTimeoutMs:
+      typeof raw.startupTimeoutMs === "number" && raw.startupTimeoutMs > 0
+        ? raw.startupTimeoutMs
+        : DEFAULT_LSP_SETTINGS.startupTimeoutMs,
+    diagnosticsDebounceMs:
+      typeof raw.diagnosticsDebounceMs === "number" && raw.diagnosticsDebounceMs >= 0
+        ? raw.diagnosticsDebounceMs
+        : DEFAULT_LSP_SETTINGS.diagnosticsDebounceMs,
+    builtins,
+    servers: Array.isArray(raw.servers)
+      ? raw.servers
+          .map(normalizeLspCustomServerConfig)
+          .filter((value): value is LspCustomServerConfig => value !== null)
+      : [],
+  };
+}
+
+export function mergeLspSettings(
+  base: LspSettings | undefined,
+  override: LspSettings | undefined,
+): NormalizedLspSettings {
+  const baseNormalized = normalizeLspSettings(base);
+  const overrideNormalized = normalizeLspSettings(override);
+
+  return {
+    enabled: override?.enabled ?? base?.enabled ?? DEFAULT_LSP_SETTINGS.enabled,
+    tool: override?.tool ?? base?.tool ?? DEFAULT_LSP_SETTINGS.tool,
+    autoInstall: override?.autoInstall ?? base?.autoInstall ?? DEFAULT_LSP_SETTINGS.autoInstall,
+    startupTimeoutMs: override?.startupTimeoutMs ?? base?.startupTimeoutMs ?? DEFAULT_LSP_SETTINGS.startupTimeoutMs,
+    diagnosticsDebounceMs:
+      override?.diagnosticsDebounceMs ?? base?.diagnosticsDebounceMs ?? DEFAULT_LSP_SETTINGS.diagnosticsDebounceMs,
+    builtins: {
+      ...baseNormalized.builtins,
+      ...overrideNormalized.builtins,
+    },
+    servers:
+      override?.servers !== undefined
+        ? overrideNormalized.servers
+        : base?.servers !== undefined
+          ? baseNormalized.servers
+          : DEFAULT_LSP_SETTINGS.servers,
+  };
+}
+
 export function getCurrentSandboxMode(): SandboxMode {
   const project = loadProjectSettings();
   if (project.sandboxMode) return normalizeSandboxMode(project.sandboxMode);
@@ -400,6 +568,12 @@ export function getCurrentSandboxSettings(): SandboxSettings {
   const user = loadUserSettings();
   const project = loadProjectSettings();
   return mergeSandboxSettings(user.sandbox, project.sandbox);
+}
+
+export function getCurrentLspSettings(): NormalizedLspSettings {
+  const user = loadUserSettings();
+  const project = loadProjectSettings();
+  return mergeLspSettings(user.lsp, project.lsp);
 }
 
 export function getReasoningEffortForModel(modelId: string): ReasoningEffort | undefined {


### PR DESCRIPTION
## What does this PR do?

Adds first-party Language Server Protocol (LSP) support to grok-cli. The agent gains semantic code intelligence -- go-to-definition, find-references, hover, symbols, call hierarchy -- through a new `lsp` tool and automatic post-edit diagnostics.

### Key changes

- **New `src/lsp/` runtime** -- server catalog with 9 built-in language servers (TypeScript, Python, Go, Rust, C/C++, Java, Swift, Bash, YAML), JSON-RPC client, file syncing, diagnostics cache, and workspace-scoped lifecycle management.
- **npm cache** (`src/lsp/npm-cache.ts`) -- installs language server binaries into `~/.grok/cache/lsp/` using `@npmcli/arborist` with concurrency locking. Never mutates user projects.
- **First-party `lsp` tool** registered in `src/grok/tools.ts` across all modes (agent/ask/plan) with 9 operations: `goToDefinition`, `findReferences`, `hover`, `documentSymbol`, `workspaceSymbol`, `goToImplementation`, `prepareCallHierarchy`, `incomingCalls`, `outgoingCalls`.
- **Post-edit diagnostics** -- `write_file` and `edit_file` sync with LSP servers and surface type/lint errors inline. LSP failures are isolated so file operations always succeed.
- **TUI rendering** -- LSP results display in a visual box (header + capped code block + truncation footer), diagnostics appear below file diffs.
- **Settings** -- `lsp` section in user/project settings with `enabled`, `tool`, `autoInstall`, `startupTimeoutMs`, `diagnosticsDebounceMs`, built-in overrides, and custom server config.
- **Lifecycle** -- proper cleanup on exit (kills language server processes), zombie process prevention on init timeout, waiter cleanup on diagnostics timeout.

### Dependencies added

- `vscode-jsonrpc` -- JSON-RPC over stdio for LSP protocol
- `vscode-languageserver-types` -- LSP type definitions
- `@npmcli/arborist` -- npm's dependency resolver for isolated package cache

## Checklist

- [x] I tested my changes
- [x] I reviewed my own code