### PR TITLE
fix: pipe MCP stdio server stderr to prevent logs bleeding into TUI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grok-dev",
-  "version": "1.1.5-rc4",
+  "version": "1.1.5-rc5",
   "description": "An open-source AI coding agent powered by Grok, built with Bun and OpenTUI.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/mcp/runtime.ts
+++ b/src/mcp/runtime.ts
@@ -15,6 +15,7 @@ function toTransport(server: McpServerConfig) {
       args: server.args,
       env: server.env,
       cwd: server.cwd,
+      stderr: "pipe",
     });
   }
 


### PR DESCRIPTION
## What does this PR do?

When an MCP server using stdio transport is connected, its stderr is inherited by the parent process by default (`StdioClientTransport` defaults to `stderr: 'inherit'`). This causes the child server's log output (e.g. `[INFO]`, `[DEBUG]` startup messages) to write directly to the terminal, corrupting the OpenTUI rendering.

This fix adds `stderr: "pipe"` to the `StdioClientTransport` constructor so stderr is captured silently instead of inherited. MCP communication happens over stdin/stdout (JSON-RPC), so piping stderr has no effect on functionality.

Reported by a user running the `@jordonh19/fastmail-mcp-server` MCP server.

## Checklist

- [x] I tested my changes
- [x] I reviewed my own code