### PR TITLE
feat: add dedicated grep tool powered by npm ripgrep WASM

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
         "dotenv": "^16.6.1",
         "grammy": "^1.41.1",
         "react": "^19.2.4",
+        "ripgrep": "^0.3.1",
         "semver": "^7.7.4",
         "vscode-jsonrpc": "^8.2.1",
         "vscode-languageserver-types": "^3.17.5",
@@ -1535,6 +1536,8 @@
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
     "ripemd160": ["ripemd160@2.0.3", "", { "dependencies": { "hash-base": "^3.1.2", "inherits": "^2.0.4" } }, "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA=="],
+
+    "ripgrep": ["ripgrep@0.3.1", "", { "bin": { "rg": "lib/rg.mjs", "ripgrep": "lib/rg.mjs" } }, "sha512-6bDtNIBh1qPviVIU685/4uv0Ap5t8eS4wiJhy/tR2LdIeIey9CVasENlGS+ul3HnTmGANIp7AjnfsztsRmALfQ=="],
 
     "rolldown": ["rolldown@1.0.0-rc.10", "", { "dependencies": { "@oxc-project/types": "=0.120.0", "@rolldown/pluginutils": "1.0.0-rc.10" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.10", "@rolldown/binding-darwin-arm64": "1.0.0-rc.10", "@rolldown/binding-darwin-x64": "1.0.0-rc.10", "@rolldown/binding-freebsd-x64": "1.0.0-rc.10", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.10", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.10", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.10", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.10", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.10", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.10", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.10", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.10", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.10", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.10", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.10" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-q7j6vvarRFmKpgJUT8HCAUljkgzEp4LAhPlJUvQhA5LA1SUL36s5QCysMutErzL3EbNOZOkoziSx9iZC4FddKA=="],
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "dotenv": "^16.6.1",
     "grammy": "^1.41.1",
     "react": "^19.2.4",
+    "ripgrep": "^0.3.1",
     "semver": "^7.7.4",
     "vscode-jsonrpc": "^8.2.1",
     "vscode-languageserver-types": "^3.17.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grok-dev",
-  "version": "1.1.5-rc5",
+  "version": "1.1.5-rc6",
   "description": "An open-source AI coding agent powered by Grok, built with Bun and OpenTUI.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -164,6 +164,7 @@ ${ENVIRONMENT}
 
 TOOLS:
 - read_file: Read file contents with start_line/end_line for iterative reading. Use for examining code.
+- grep: Fast regex content search across the codebase. Prefer this over bash for finding patterns in files. Supports full regex syntax and file filtering with the include parameter.
 - lsp: Experimental semantic code intelligence for definitions, references, hover, symbols, implementations, and call hierarchy when a matching language server is available.
 - write_file: Create new files or overwrite existing ones with full content.
 - edit_file: Replace a unique string in a file with new content. The old_string must be unique — include enough context lines.
@@ -207,7 +208,7 @@ TOOLS:
 WORKFLOW:
 1. Understand the request
 2. Decide whether a sub-agent should handle the first investigation pass
-3. Use read_file, lsp, and bash to explore the codebase directly when the task is small or tightly scoped
+3. Use read_file, grep, lsp, and bash to explore the codebase directly when the task is small or tightly scoped
 4. Use bash with background=true for dev servers, watchers, or any long-running process — then continue working
 5. Use delegate for read-only work that can run in parallel, then continue productive work
 6. Use edit_file for targeted changes, write_file for new files or full rewrites
@@ -244,6 +245,7 @@ EXAMPLES:
 
 IMPORTANT:
 - Prefer edit_file for surgical changes to existing files — it shows a clean diff.
+- Prefer grep over bash for searching file contents. Use bash only for find, ls, git, and other shell commands.
 - Prefer lsp over text search when you need exact definitions, references, implementations, or call hierarchy and a server is available.
 - Use write_file only for new files or when most of the file is changing.
 - Use read_file instead of cat/head/tail for reading files.
@@ -258,13 +260,14 @@ ${ENVIRONMENT}
 
 TOOLS:
 - read_file: Read file contents for analysis.
+- grep: Fast regex content search across the codebase. Prefer this over bash for finding patterns in files.
 - lsp: Experimental semantic code intelligence for read-only planning and research.
-- bash: ONLY for searching (find, grep, ls) — NEVER modify files.
+- bash: ONLY for searching (find, ls), git inspection — NEVER modify files.
 - task: Delegate a focused task to a sub-agent when deeper research or specialized analysis would help.
 - generate_plan: ALWAYS use this to present your plan. Creates an interactive UI with steps and questions.
 
 BEHAVIOR:
-- Explore the codebase first using read_file and bash to understand the current state
+- Explore the codebase first using read_file, grep, and bash to understand the current state
 - Prefer lsp for exact symbol navigation when a matching server is available
 - ALWAYS call generate_plan to present your plan — never just describe it in text
 - Include clear, ordered steps with affected file paths
@@ -279,8 +282,9 @@ ${ENVIRONMENT}
 
 TOOLS:
 - read_file: Read file contents for context.
+- grep: Fast regex content search across the codebase. Prefer this over bash for finding patterns in files.
 - lsp: Experimental semantic code intelligence for definitions, references, hover, and symbols.
-- bash: ONLY for searching (find, grep, ls) — NEVER modify.
+- bash: ONLY for searching (find, ls), git inspection — NEVER modify.
 - task: Delegate a focused task to a sub-agent when specialized analysis or deeper investigation would help.
 
 BEHAVIOR:

--- a/src/grok/tools.ts
+++ b/src/grok/tools.ts
@@ -19,6 +19,7 @@ import {
   computerWait,
 } from "../tools/computer";
 import { editFile, readFile, writeFile } from "../tools/file";
+import { executeGrep } from "../tools/grep";
 import type { ScheduleDaemonStatus, ScheduleManager, StoredSchedule } from "../tools/schedule";
 import type { AgentMode, TaskRequest, ToolResult } from "../types/index";
 import { type CustomSubagentConfig, loadPaymentSettings, loadValidSubAgents } from "../utils/settings";
@@ -179,6 +180,22 @@ export function createTools(
       }),
       execute: async ({ path, start_line, end_line }) => {
         return readFile(path, cwd(), start_line, end_line);
+      },
+    }),
+
+    grep: tool({
+      description:
+        'Fast content search tool that works with any codebase size. Searches file contents using regular expressions. Supports full regex syntax (e.g. "log.*Error", "function\\s+\\w+"). Filter files by pattern with the include parameter (e.g. "*.js", "*.{ts,tsx}"). Returns matching file paths and line numbers sorted by modification time. Use this tool when you need to find files containing specific patterns. If you need to count matches within files, use bash with `rg` directly.',
+      inputSchema: z.object({
+        pattern: z.string().describe("The regex pattern to search for in file contents"),
+        path: z
+          .string()
+          .optional()
+          .describe("The directory or file to search in. Defaults to the current working directory."),
+        include: z.string().optional().describe('File pattern to include in the search (e.g. "*.js", "*.{ts,tsx}")'),
+      }),
+      execute: async ({ pattern, path, include }) => {
+        return executeGrep({ pattern, path, include }, cwd());
       },
     }),
 

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -396,9 +396,9 @@ export class BashTool {
       const hostBrowserNote = s.hostBrowserCommandsOnHost
         ? " Commands that invoke agent-browser run on the host instead of inside Shuru so they can interact with forwarded localhost services."
         : "";
-      return `Execute a bash command inside a Shuru sandbox. Use for searching (grep, rg, find), git inspection, build tools, test runners, and other shell commands that should stay isolated. The current workspace is mounted inside the sandbox at /workspace, ${netStatus}, and shell-side workspace file changes do not persist back to the host in this version, so prefer the dedicated file tools for durable edits.${hostBrowserNote} Set background=true for long-running processes like dev servers or watchers.`;
+      return `Execute a bash command inside a Shuru sandbox. Use for find, ls, git inspection, build tools, test runners, and other shell commands that should stay isolated. For content search, prefer the dedicated grep tool. The current workspace is mounted inside the sandbox at /workspace, ${netStatus}, and shell-side workspace file changes do not persist back to the host in this version, so prefer the dedicated file tools for durable edits.${hostBrowserNote} Set background=true for long-running processes like dev servers or watchers.`;
     }
-    return "Execute a bash command. Use for searching (grep, rg, find), git, build tools, package managers, running tests, and any other shell command. Set background=true for long-running processes like dev servers, watchers, or anything that should keep running while you continue working. For file read/write/edit, prefer the dedicated file tools instead.";
+    return "Execute a bash command. Use for find, ls, git, build tools, package managers, running tests, and any other shell command. For content search, prefer the dedicated grep tool. Set background=true for long-running processes like dev servers, watchers, or anything that should keep running while you continue working. For file read/write/edit, prefer the dedicated file tools instead.";
   }
 
   private prepareCommand(command: string): { ok: true; command: string } | { ok: false; error: string } {

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -136,15 +136,17 @@ export async function executeGrep(params: GrepParams, cwd: string): Promise<Tool
       return { success: true, output: msg };
     }
 
-    const uniqueFiles = [...new Set(matches.map((m) => m.path.text))];
-    const mtimes = await getFileMtimes(uniqueFiles, searchCwd);
+    const rebase = (file: string) => path.relative(cwd, path.resolve(searchCwd, file));
+
+    const uniqueFiles = [...new Set(matches.map((m) => rebase(m.path.text)))];
+    const mtimes = await getFileMtimes(uniqueFiles, cwd);
 
     const rows = matches
       .map((m) => ({
-        file: m.path.text,
+        file: rebase(m.path.text),
         line: m.line_number,
         text: m.lines.text.replace(/\n$/, ""),
-        mtime: mtimes.get(m.path.text) ?? 0,
+        mtime: mtimes.get(rebase(m.path.text)) ?? 0,
       }))
       .sort((a, b) => b.mtime - a.mtime);
 

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -1,0 +1,184 @@
+import { stat } from "fs/promises";
+import path from "path";
+import { ripgrep } from "ripgrep";
+import type { ToolResult } from "../types/index";
+
+const MAX_MATCHES = 100;
+const MAX_LINE_LENGTH = 2000;
+
+interface GrepParams {
+  pattern: string;
+  path?: string;
+  include?: string;
+}
+
+interface RipgrepMatch {
+  type: "match";
+  data: {
+    path: { text: string };
+    lines: { text: string };
+    line_number: number;
+    absolute_offset: number;
+    submatches: Array<{ match: { text: string }; start: number; end: number }>;
+  };
+}
+
+function buildArgs(params: GrepParams): string[] {
+  const args = ["--json", "--hidden", "--glob=!.git/*", "--no-messages"];
+
+  if (params.include) {
+    args.push(`--glob=${params.include}`);
+  }
+
+  args.push("--", params.pattern, params.path ?? ".");
+  return args;
+}
+
+function cleanEnv(): Record<string, string> {
+  const env = Object.fromEntries(
+    Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+  );
+  delete env.RIPGREP_CONFIG_PATH;
+  return env;
+}
+
+function cleanPath(file: string): string {
+  return path.normalize(file.replace(/^\.[\\/]/, ""));
+}
+
+function parseMatches(stdout: string): RipgrepMatch["data"][] {
+  if (!stdout.trim()) return [];
+
+  return stdout
+    .trim()
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .flatMap((line) => {
+      try {
+        const parsed = JSON.parse(line);
+        if (parsed.type === "match") {
+          return [
+            {
+              ...parsed.data,
+              path: { ...parsed.data.path, text: cleanPath(parsed.data.path.text) },
+            },
+          ];
+        }
+      } catch {
+        // skip malformed lines
+      }
+      return [];
+    });
+}
+
+async function getFileMtimes(files: string[], cwd: string): Promise<Map<string, number>> {
+  const times = new Map<string, number>();
+  await Promise.all(
+    files.map(async (file) => {
+      const fullPath = path.isAbsolute(file) ? file : path.join(cwd, file);
+      try {
+        const info = await stat(fullPath);
+        times.set(file, info.mtimeMs);
+      } catch {
+        // skip inaccessible files
+      }
+    }),
+  );
+  return times;
+}
+
+export async function executeGrep(params: GrepParams, cwd: string): Promise<ToolResult> {
+  if (!params.pattern) {
+    return { success: false, error: "pattern is required" };
+  }
+
+  const searchPath = params.path ? (path.isAbsolute(params.path) ? params.path : path.join(cwd, params.path)) : cwd;
+
+  let searchCwd: string;
+  let searchTarget: string | undefined;
+  try {
+    const info = await stat(searchPath);
+    if (info.isDirectory()) {
+      searchCwd = searchPath;
+    } else {
+      searchCwd = path.dirname(searchPath);
+      searchTarget = path.relative(searchCwd, searchPath);
+    }
+  } catch {
+    searchCwd = cwd;
+    searchTarget = params.path;
+  }
+
+  const args = buildArgs({ ...params, path: searchTarget });
+
+  try {
+    const result = await ripgrep(args, {
+      buffer: true,
+      env: cleanEnv(),
+      preopens: { ".": searchCwd },
+    });
+
+    const stdout = (result.stdout as string) ?? "";
+    const code = result.code ?? 1;
+
+    if (code !== 0 && code !== 1 && code !== 2) {
+      const stderr = (result.stderr as string) ?? "";
+      return { success: false, error: stderr.trim() || `ripgrep failed with code ${code}` };
+    }
+
+    if (code === 1) {
+      return { success: true, output: "No matches found." };
+    }
+
+    const matches = parseMatches(stdout);
+    if (matches.length === 0) {
+      return { success: true, output: "No matches found." };
+    }
+
+    const uniqueFiles = [...new Set(matches.map((m) => m.path.text))];
+    const mtimes = await getFileMtimes(uniqueFiles, searchCwd);
+
+    const rows = matches
+      .map((m) => ({
+        file: m.path.text,
+        line: m.line_number,
+        text: m.lines.text.replace(/\n$/, ""),
+        mtime: mtimes.get(m.path.text) ?? 0,
+      }))
+      .sort((a, b) => b.mtime - a.mtime);
+
+    const total = rows.length;
+    const truncated = total > MAX_MATCHES;
+    const display = truncated ? rows.slice(0, MAX_MATCHES) : rows;
+
+    const output: string[] = [`Found ${total} matches${truncated ? ` (showing first ${MAX_MATCHES})` : ""}`];
+
+    let currentFile = "";
+    for (const row of display) {
+      if (currentFile !== row.file) {
+        if (currentFile !== "") output.push("");
+        currentFile = row.file;
+        output.push(`${row.file}:`);
+      }
+      const text = row.text.length > MAX_LINE_LENGTH ? `${row.text.substring(0, MAX_LINE_LENGTH)}...` : row.text;
+      output.push(`  Line ${row.line}: ${text}`);
+    }
+
+    if (truncated) {
+      output.push("");
+      output.push(
+        `(Results truncated: showing ${MAX_MATCHES} of ${total} matches. Consider using a more specific path or pattern.)`,
+      );
+    }
+
+    if (code === 2) {
+      output.push("");
+      output.push("(Some paths were inaccessible and skipped)");
+    }
+
+    return { success: true, output: output.join("\n") };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { success: false, error: `Grep failed: ${msg}` };
+  }
+}

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -132,7 +132,8 @@ export async function executeGrep(params: GrepParams, cwd: string): Promise<Tool
 
     const matches = parseMatches(stdout);
     if (matches.length === 0) {
-      return { success: true, output: "No matches found." };
+      const msg = code === 2 ? "No matches found.\n(Some paths were inaccessible and skipped)" : "No matches found.";
+      return { success: true, output: msg };
     }
 
     const uniqueFiles = [...new Set(matches.map((m) => m.path.text))];


### PR DESCRIPTION
## What does this PR do?

Adds a first-class `grep` tool powered by the npm [`ripgrep`](https://www.npmjs.com/package/ripgrep) package (WASM-based, zero native binaries, cross-platform). The agent now uses this dedicated tool for content search instead of shelling out to grep/rg via bash.

- **New `src/tools/grep.ts`**: Wraps the ripgrep WASM API with `executeGrep()` — builds CLI args, parses JSON-line output, sorts by mtime, caps at 100 matches, truncates long lines.
- **Registered in `src/grok/tools.ts`**: Added `grep` to the base toolset (available in all modes) with `pattern`, `path`, and `include` parameters.
- **Updated system prompts in `src/agent/agent.ts`**: Agent, plan, and ask modes now reference the dedicated grep tool and instruct the model to prefer it over bash for content search.
- **Updated `src/tools/bash.ts`**: Removed grep/rg from bash tool descriptions, directing content search to the dedicated tool.

Fixes #261

## Checklist

- [x] I tested my changes
- [x] I reviewed my own code