### PR TITLE
feat: add /btw command for side questions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grok-dev",
-  "version": "1.1.5-rc6",
+  "version": "1.1.5-rc7",
   "description": "An open-source AI coding agent powered by Grok, built with Bun and OpenTUI.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -73,6 +73,7 @@ import {
   type SandboxMode,
   type SandboxSettings,
 } from "../utils/settings";
+import { runSideQuestion, type SideQuestionResult } from "../utils/side-question";
 import { discoverSkills, formatSkillsForPrompt } from "../utils/skills";
 import { buildVerifyDetectPrompt, normalizeVerifyRecipe, prepareVerifySandbox } from "../verify/entrypoint";
 import { runVerifyOrchestration } from "../verify/orchestrator";
@@ -712,6 +713,37 @@ export class Agent {
       this.session = this.sessionStore.getRequiredSession(this.session.id);
     }
     return generated.title;
+  }
+
+  async askSideQuestion(question: string, signal?: AbortSignal): Promise<SideQuestionResult> {
+    if (!this.provider) {
+      return { response: "No API key configured." };
+    }
+
+    const contextParts: string[] = [];
+    let charBudget = 2000;
+    for (let i = this.messages.length - 1; i >= 0 && charBudget > 0; i--) {
+      const msg = this.messages[i];
+      if (msg.role !== "user" && msg.role !== "assistant") continue;
+      const text =
+        typeof msg.content === "string"
+          ? msg.content
+          : Array.isArray(msg.content)
+            ? msg.content
+                .filter((p: { type: string }) => p.type === "text")
+                .map((p: { type: string; text?: string }) => p.text ?? "")
+                .join("")
+            : "";
+      if (!text) continue;
+      const snippet = text.length > 400 ? `${text.slice(0, 400)}…` : text;
+      contextParts.unshift(`[${msg.role}]: ${snippet}`);
+      charBudget -= snippet.length;
+    }
+    const conversationContext = contextParts.join("\n\n");
+
+    const result = await runSideQuestion(question, this.provider, this.modelId, conversationContext, signal);
+    this.recordUsage(result.usage, "other");
+    return result;
   }
 
   abort(): void {

--- a/src/ui/app.tsx
+++ b/src/ui/app.tsx
@@ -68,6 +68,7 @@ import {
   SubagentEditorModal,
   SubagentsBrowserModal,
 } from "./agents-modal";
+import { BtwOverlay, type BtwState } from "./components/btw-overlay.js";
 import { SuggestionOverlay } from "./components/SuggestionOverlay.js";
 import { type TypeaheadState, useTypeahead } from "./hooks/useTypeahead.js";
 import { Markdown } from "./markdown";
@@ -311,6 +312,7 @@ const SLASH_MENU_ITEMS: SlashMenuItem[] = [
   { id: "review", label: "review", description: "Review recent changes" },
   { id: "verify", label: "verify", description: "Run local verification" },
   { id: "skills", label: "skills", description: "Manage skills" },
+  { id: "btw", label: "btw", description: "Ask a side question without interrupting" },
   { id: "update", label: "update", description: "Update grok to the latest version" },
 ];
 
@@ -370,6 +372,7 @@ const BUILTIN_TYPED_SLASH_COMMANDS = new Set([
   "/commit-push",
   "/commit-pr",
   "/wallet",
+  "/btw",
 ]);
 
 interface SandboxRow {
@@ -656,6 +659,9 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
   const [showSlashMenu, setShowSlashMenu] = useState(false);
   const [slashMenuIndex, setSlashMenuIndex] = useState(0);
   const [slashSearchQuery, setSlashSearchQuery] = useState("");
+  const [btwState, setBtwState] = useState<BtwState | null>(null);
+  const btwAbortRef = useRef<AbortController | null>(null);
+  const btwStateRef = useRef<BtwState | null>(null);
   const [reasoningEffortByModel, setReasoningEffortByModel] = useState<Record<string, ReasoningEffort>>(() =>
     Object.fromEntries(
       Object.entries(loadUserSettings().reasoningEffortByModel ?? {}).map(([modelId, effort]) => [
@@ -1956,6 +1962,15 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
 
   const interruptActiveRun = useCallback(
     (key?: KeyEvent) => {
+      if (btwStateRef.current) {
+        btwAbortRef.current?.abort();
+        btwAbortRef.current = null;
+        btwStateRef.current = null;
+        setBtwState(null);
+        key?.preventDefault();
+        key?.stopPropagation();
+        return true;
+      }
       if (!isProcessingRef.current) return false;
       key?.preventDefault();
       key?.stopPropagation();
@@ -2255,6 +2270,40 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
         processMessage(COMMIT_PR_PROMPT);
         return true;
       }
+      if (c.startsWith("/btw ") || c === "/btw") {
+        const question = cmd.trim().slice(4).trim();
+        if (!question) {
+          setMessages((prev) => [
+            ...prev,
+            buildAssistantEntry("Usage: /btw <question>\nExample: /btw what does useEffect cleanup do?"),
+          ]);
+          return true;
+        }
+        const ac = new AbortController();
+        btwAbortRef.current = ac;
+        const loadingState: BtwState = { status: "loading", question };
+        btwStateRef.current = loadingState;
+        setBtwState(loadingState);
+        agent
+          .askSideQuestion(question, ac.signal)
+          .then((result) => {
+            if (ac.signal.aborted) return;
+            const doneState: BtwState = { status: "done", question, answer: result.response };
+            btwStateRef.current = doneState;
+            setBtwState(doneState);
+          })
+          .catch((err) => {
+            if (ac.signal.aborted) return;
+            const errState: BtwState = {
+              status: "error",
+              question,
+              error: err instanceof Error ? err.message : String(err),
+            };
+            btwStateRef.current = errState;
+            setBtwState(errState);
+          });
+        return true;
+      }
       const customSubagentCommand = parseCustomSubagentSlashCommand(cmd, subAgents);
       if (customSubagentCommand) {
         if (!customSubagentCommand.prompt) {
@@ -2352,6 +2401,10 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
           break;
         case "commit-pr":
           processMessage(COMMIT_PR_PROMPT);
+          break;
+        case "btw":
+          inputRef.current?.clear();
+          inputRef.current?.insertText("/btw ");
           break;
         case "update":
           setIsUpdating(true);
@@ -2451,8 +2504,21 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
     [pqs, isSinglePlan, submitPlanAnswers],
   );
 
+  const dismissBtw = useCallback(() => {
+    btwAbortRef.current?.abort();
+    btwAbortRef.current = null;
+    btwStateRef.current = null;
+    setBtwState(null);
+  }, []);
+
   const handleKey = useCallback(
     (key: KeyEvent) => {
+      if (btwState) {
+        if (isEscapeKey(key) || key.name === "return") {
+          dismissBtw();
+        }
+        return;
+      }
       if (showPlanPanel) {
         const q = planQuestions[pqs.tab];
 
@@ -3168,11 +3234,13 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
       agentsEditorField,
       agentsModalIndex,
       beginTelegramFromConnect,
+      btwState,
       closeApiKeyModal,
       connectModalIndex,
       cycleMode,
       cycleMcpEditorTransport,
       deleteSavedMcp,
+      dismissBtw,
       dismissPlan,
       editingSubagent,
       editSavedMcp,
@@ -3381,6 +3449,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
               {showPlanPanel && <PlanQuestionsPanel t={t} questions={planQuestions} state={pqs} />}
               {pendingPaymentApproval && <PaymentApprovalPanel t={t} payment={pendingPaymentApproval} />}
             </scrollbox>
+            {btwState && <BtwOverlay state={btwState} theme={t} />}
             {/* Prompt */}
             <box flexShrink={0}>
               <PromptBox

--- a/src/ui/components/btw-overlay.tsx
+++ b/src/ui/components/btw-overlay.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from "react";
+import { Markdown } from "../markdown.js";
+import type { Theme } from "../theme.js";
+
+export interface BtwState {
+  status: "loading" | "done" | "error";
+  question: string;
+  answer?: string;
+  error?: string;
+}
+
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+function Spinner() {
+  const [frame, setFrame] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setFrame((n) => (n + 1) % SPINNER_FRAMES.length), 120);
+    return () => clearInterval(id);
+  }, []);
+  return <>{SPINNER_FRAMES[frame]}</>;
+}
+
+export function BtwOverlay({ state, theme: t }: { state: BtwState; theme: Theme }) {
+  return (
+    <box
+      flexDirection="column"
+      paddingLeft={2}
+      paddingRight={2}
+      paddingTop={1}
+      paddingBottom={1}
+      flexShrink={0}
+      backgroundColor={t.backgroundPanel}
+    >
+      <text>
+        <span style={{ fg: t.accent }}>/btw</span>
+        <span style={{ fg: t.textMuted }}>{" — "}</span>
+        <span style={{ fg: t.text }}>{state.question}</span>
+      </text>
+
+      <box height={1} />
+
+      {state.status === "loading" && (
+        <text>
+          <span style={{ fg: t.textMuted }}>
+            <Spinner />
+          </span>
+          <span style={{ fg: t.textMuted }}> Answering…</span>
+        </text>
+      )}
+
+      {state.status === "done" && state.answer && <Markdown content={state.answer} t={t} />}
+
+      {state.status === "error" && <text fg={t.diffRemovedFg}>{state.error || "Something went wrong."}</text>}
+
+      {state.status !== "loading" && (
+        <>
+          <box height={1} />
+          <text>
+            <span style={{ fg: t.accent }}>esc</span>
+            <span style={{ fg: t.textMuted }}> dismiss</span>
+          </text>
+        </>
+      )}
+    </box>
+  );
+}

--- a/src/ui/components/btw-overlay.tsx
+++ b/src/ui/components/btw-overlay.tsx
@@ -9,15 +9,15 @@ export interface BtwState {
   error?: string;
 }
 
-const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+const LOADING_SPINNER_FRAMES = ["⬒", "⬔", "⬓", "⬕"];
 
-function Spinner() {
+function LoadingSpinner() {
   const [frame, setFrame] = useState(0);
   useEffect(() => {
-    const id = setInterval(() => setFrame((n) => (n + 1) % SPINNER_FRAMES.length), 120);
+    const id = setInterval(() => setFrame((n) => (n + 1) % LOADING_SPINNER_FRAMES.length), 120);
     return () => clearInterval(id);
   }, []);
-  return <>{SPINNER_FRAMES[frame]}</>;
+  return <>{LOADING_SPINNER_FRAMES[frame]}</>;
 }
 
 export function BtwOverlay({ state, theme: t }: { state: BtwState; theme: Theme }) {
@@ -42,7 +42,7 @@ export function BtwOverlay({ state, theme: t }: { state: BtwState; theme: Theme 
       {state.status === "loading" && (
         <text>
           <span style={{ fg: t.textMuted }}>
-            <Spinner />
+            <LoadingSpinner />
           </span>
           <span style={{ fg: t.textMuted }}> Answering…</span>
         </text>

--- a/src/utils/side-question.ts
+++ b/src/utils/side-question.ts
@@ -1,0 +1,38 @@
+import { generateText } from "ai";
+import { resolveModelRuntime, type XaiProvider } from "../grok/client.js";
+
+export interface SideQuestionResult {
+  response: string;
+  usage?: { totalTokens?: number; inputTokens?: number; outputTokens?: number };
+}
+
+const SIDE_QUESTION_SYSTEM = `You are a helpful coding assistant answering a quick side question. The user is in the middle of a coding session and needs a fast, concise answer. Keep your response short and focused — this is a side question, not the main task.
+
+If conversation context is provided below, use it to give a more relevant answer.`;
+
+export async function runSideQuestion(
+  question: string,
+  provider: XaiProvider,
+  modelId: string,
+  conversationContext: string,
+  signal?: AbortSignal,
+): Promise<SideQuestionResult> {
+  const runtime = resolveModelRuntime(provider, modelId);
+  const system = conversationContext
+    ? `${SIDE_QUESTION_SYSTEM}\n\n<conversation_context>\n${conversationContext}\n</conversation_context>`
+    : SIDE_QUESTION_SYSTEM;
+
+  const { text, usage } = await generateText({
+    model: runtime.model,
+    abortSignal: signal,
+    ...(runtime.modelInfo?.supportsMaxOutputTokens === false ? {} : { maxOutputTokens: 2048 }),
+    ...(runtime.providerOptions ? { providerOptions: runtime.providerOptions } : {}),
+    system,
+    prompt: question,
+  });
+
+  return {
+    response: text || "No response generated.",
+    usage,
+  };
+}


### PR DESCRIPTION
## What does this PR do?

Adds a `/btw` slash command that lets users ask quick side questions without interrupting the currently running agent turn. Mirrors the behavior of Claude Code's `/btw` command.

- New `askSideQuestion` method on `Agent` runs an isolated one-shot `generateText` call with no tools, using a condensed tail of the current conversation as context. Does NOT mutate the main message history.
- New `BtwOverlay` component renders a bottom-anchored panel (above the prompt, outside the scrollbox) with the same loading spinner used by the main chat.
- `/btw` is registered in both `SLASH_MENU_ITEMS` and `BUILTIN_TYPED_SLASH_COMMANDS`. Selecting it from the menu pre-fills `/btw ` in the input.
- Esc or Enter dismisses the overlay (and aborts an in-flight request). The `interruptActiveRun` path short-circuits when a btw overlay is active so the main agent turn is not cancelled.

Fixes #262

## Checklist

- [x] I tested my changes
- [x] I reviewed my own code