### PR TITLE
docs: update CHANGELOG from merged PRs (#263, #264)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.5-rc7] - 2026-04-16
+
+### Added
+- Dedicated grep tool powered by npm ripgrep WASM (#263)
+- `/btw` command for side questions (#264)
+
 ## [1.1.5-rc5] - 2026-04-15
 
 ### Fixed


### PR DESCRIPTION
Documents the following merged PRs in `CHANGELOG.md` under **1.1.5-rc7** (2026-04-16):

- [#263](https://github.com/superagent-ai/grok-cli/pull/263) — Dedicated grep tool powered by npm ripgrep WASM
- [#264](https://github.com/superagent-ai/grok-cli/pull/264) — `/btw` command for side questions

The package version **1.1.5-rc7** matches this changelog section.

Made with [Cursor](https://cursor.com)