### PR TITLE
fix(release): mark RC tags as GitHub prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,7 @@ jobs:
         with:
           tag_name: ${{ env.RELEASE_TAG }}
           generate_release_notes: true
+          prerelease: ${{ contains(env.RELEASE_TAG, '-rc') || contains(env.RELEASE_TAG, '-alpha') || contains(env.RELEASE_TAG, '-beta') || contains(env.RELEASE_TAG, '-pre') }}
           files: |
             release-assets/**/grok-linux-x64
             release-assets/**/grok-darwin-arm64


### PR DESCRIPTION
## Summary

`softprops/action-gh-release@v2` auto-detects the `prerelease` field from the tag only when `semver.valid()` recognizes it. The current tag format `grok-dev@X.Y.Z-rc*` has a non-semver prefix, so detection silently fails and RC tags get published as **full releases**. GitHub's `/releases/latest` endpoint — which `install.sh` uses to resolve the default install version — then serves pre-release builds to `curl | bash` users by default.

Concrete symptom: `curl -fsSL https://raw.githubusercontent.com/superagent-ai/grok-cli/main/install.sh | bash` currently installs `1.1.5-rc7` (the latest RC) rather than `1.1.4` (the latest stable). I hit this myself — took a while to realize I wasn't on a stable release.

## The change

One line in `release.yml`:

```yaml
prerelease: ${{ contains(env.RELEASE_TAG, '-rc') || contains(env.RELEASE_TAG, '-alpha') || contains(env.RELEASE_TAG, '-beta') || contains(env.RELEASE_TAG, '-pre') }}
```

- **Native GitHub expression** — evaluated at workflow-parse time, no shell execution, no injection surface
- **Catches the four common prerelease suffixes**: `-rc`, `-alpha`, `-beta`, `-pre`
- **No retroactive effect** — past releases are immutable; this only affects future publishes

## After merge

- `curl | bash` installs resolve to the latest **stable** tag
- `--version 1.1.5-rc7` still works for users who explicitly want an RC
- Ecosystem tools that respect the `prerelease` flag (GitHub UI "Latest" badge, Dependabot, Renovate, `gh release view`) start behaving correctly

## Test plan

- [ ] Push a tag like `grok-dev@1.1.6-rc1` — release should publish with `prerelease: true`
- [ ] Push a tag like `grok-dev@1.1.5` — release should publish with `prerelease: false`
- [ ] Verify `/releases/latest` API returns the latest stable, not the RC
- [ ] Run `install.sh` from `main` — resolves to the latest stable tag

## Optional follow-up (not in this PR)

If you want to retroactively mark the existing `-rc*` releases as prereleases, a one-liner does it:

```bash
for tag in $(gh release list --repo superagent-ai/grok-cli --limit 50 --json tagName,isPrerelease --jq '.[] | select(.tagName | contains("-rc")) | select(.isPrerelease == false) | .tagName'); do
  gh release edit "$tag" --prerelease --repo superagent-ai/grok-cli
done
```

Happy to send that as a separate PR/script if useful.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single workflow expression change that only affects how future GitHub Releases are flagged, without altering build artifacts or code paths.
> 
> **Overview**
> Ensures GitHub Releases published by `.github/workflows/release.yml` are correctly flagged as *prereleases* when the `RELEASE_TAG` contains `-rc`, `-alpha`, `-beta`, or `-pre`.
> 
> This prevents prerelease tags from being treated as full releases (e.g., for `/releases/latest` resolution) while leaving stable tags unaffected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b5c25bfff9e5e175bab29aa6d51623b19b009ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->