### PR TITLE
chore(install): warn when auto-resolving to a pre-release version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -233,7 +233,7 @@ warn_if_prerelease() {
 
 Warning: Installing pre-release version ${version}.
 Pre-releases may be unstable. For the latest stable release, re-run with:
-  curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash -s -- --version <stable-version>
+  curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash -s -- --version STABLE_VERSION
 
 See https://github.com/${REPO}/releases for available versions.
 

--- a/install.sh
+++ b/install.sh
@@ -225,6 +225,23 @@ maybe_update_path() {
   add_to_path "$config_file" "$path_command"
 }
 
+warn_if_prerelease() {
+  local version="$1"
+  case "$version" in
+    *-rc*|*-alpha*|*-beta*|*-pre*)
+      cat >&2 <<EOF
+
+Warning: Installing pre-release version ${version}.
+Pre-releases may be unstable. For the latest stable release, re-run with:
+  curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash -s -- --version <stable-version>
+
+See https://github.com/${REPO}/releases for available versions.
+
+EOF
+      ;;
+  esac
+}
+
 resolve_release_version() {
   if [[ -n "$requested_version" ]]; then
     RESOLVED_VERSION="${requested_version}"
@@ -242,6 +259,7 @@ resolve_release_version() {
     exit 1
   fi
   RELEASE_BASE_URL="https://github.com/${REPO}/releases/latest/download"
+  warn_if_prerelease "$RESOLVED_VERSION"
 }
 
 install_downloaded_release() {


### PR DESCRIPTION
## Summary

Defense-in-depth companion to #268. If `/releases/latest` ever returns a pre-release tag (because a release was accidentally published without `prerelease: true`, or an old tag predates proper classification), warn the user to stderr so they know they landed on a non-stable build.

## Why not just rely on #268?

#268 fixes future releases. But:

- **Old tags on GitHub** are immutable — `1.1.5-rc1` through `1.1.5-rc7` will remain as full releases unless someone runs `gh release edit --prerelease` on each
- **`/releases/latest` caching / edge-cases** — if the API ever hiccups, this is a cheap belt-and-suspenders safeguard
- **Other release automation** might diverge from the `release.yml` classification in the future

## Behavior

| Scenario | Before | After |
|---|---|---|
| `curl \| bash` → resolves to `1.1.5-rc7` | Silent install of RC | Warning printed, install proceeds |
| `curl \| bash -s -- --version 1.1.5-rc7` (explicit RC) | Silent install | **Still silent** — explicit opt-in respected |
| `curl \| bash` → resolves to `1.1.4` stable | Silent install | Silent install |

## Test plan

- [ ] Run `install.sh` against a repo where `/releases/latest` returns an RC — warning prints to stderr, install still succeeds
- [ ] Run `install.sh --version 1.1.5-rc7` — no warning (explicit opt-in)
- [ ] Run `install.sh` against a repo where `/releases/latest` returns a stable tag — no warning

## Companion to #268

Merging #268 alone is sufficient for *future* releases. Merging this adds a safety net for cases where the classification is inconsistent. Either can land independently; both is ideal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a simple prerelease detection warning message without changing download/install behavior or version resolution logic beyond an extra stderr print.
> 
> **Overview**
> When no `--version` is provided, the installer now detects pre-release version strings (e.g. `-rc`, `-alpha`, `-beta`, `-pre`) returned from GitHub `releases/latest` and prints a warning to stderr before proceeding.
> 
> Explicit version installs via `--version` are unchanged (no warning), and the download/checksum/install flow remains the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fff9929fe5bbbb52cd3a3477502faf3bbcbe7518. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->