### PR TITLE
docs(readme): add Network behavior section documenting every endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,46 @@ The agent inspects your project, figures out how to build and run it, spins up a
 
 ---
 
+## Network behavior
+
+Grok connects to a small, well-defined set of HTTPS endpoints. This section documents what hits the network and when, so you know what to expect — especially useful for network-restricted environments, compliance reviews, or running Grok in sensitive repos.
+
+### Always on
+
+| Host | Purpose | Source |
+| --- | --- | --- |
+| `api.x.ai` | xAI Grok API — the model provider. This is where your prompts and model responses travel. | `src/grok/client.ts` |
+| `api.github.com` | Version resolution for `grok update` and release-manifest checks. | `src/utils/install-manager.ts` |
+
+### Feature-gated (only when the feature is used)
+
+| Host | Triggered by | Source |
+| --- | --- | --- |
+| `api.telegram.org` | Telegram remote-control pairing, headless Telegram bridge (`grok telegram-bridge`), voice/audio messages | `src/telegram/` |
+| `api.brin.sh` | **Autonomous agent payments (x402 protocol)** — scores the payee/target domain before approving a payment operation. Verdicts: `safe` / `caution` / `suspicious` / `dangerous`. Provided by [brin.sh](https://brin.sh), a first-party threat-detection service from the Grok team. Does not see your prompts or code — only the URL being checked. | `src/payments/brin.ts` |
+| `ai-gateway.vercel.sh`, `ai-sdk.dev` | AI Gateway routing when configured as an alternative to direct xAI access | `@ai-sdk/*` dependencies |
+| `mainnet.base.org`, `basescan.org`, `api.basescan.org`, `sepolia.base.org` | Coinbase AgentKit tools — Ethereum/Base wallet operations. Only reached when the agent invokes wallet/on-chain functions. | `@coinbase/agentkit` |
+| `abitype.dev`, `openchain.xyz`, `4byte.sourcify.dev`, `docs.soliditylang.org` | Solidity ABI lookups and contract decoding (Coinbase AgentKit). Only reached when decoding on-chain data. | `@coinbase/agentkit` |
+| `ipfs.io`, `arweave.net` | Decentralized storage for generated media (images, videos) via the built-in `generate_image` / `generate_video` tools | agent tools |
+| `fulcio.sigstore.dev` | Sigstore verification for signed release artifacts | `@npmcli/arborist` |
+| `api.github.com/repos/*`, `raw.githubusercontent.com` | Skill installs, release artifact downloads, MCP server fetches | `@modelcontextprotocol/sdk` and skill subsystem |
+
+### What is not sent
+
+- **No analytics / telemetry pings** in the default configuration. Grok does not emit usage metrics, crash reports, or feature-flag checks to any third party.
+- **Your prompts and code do not leave the provider channel** (`api.x.ai`, or your configured `GROK_BASE_URL`). The helper endpoints above exchange only the minimum data needed for their feature (a URL for brin, a tag name for GitHub, a message for Telegram).
+
+### Network-restricted environments
+
+If you operate behind an allowlist, the minimum viable set is:
+
+- `api.x.ai` (provider)
+- `api.github.com` (if `grok update` is used)
+
+Everything else is feature-gated — only allowlist the hosts above that correspond to features you actually use. The [Sandbox](#sandbox) mode additionally restricts outbound connections at the microVM level (see `--allow-host` and `--allow-net` flags).
+
+---
+
 ## Development
 
 From a clone:


### PR DESCRIPTION
## Summary

Adds a "Network behavior" section to the README that documents every host Grok connects to, when, and why.

## Why

While evaluating Grok CLI I ran `strings` on the compiled binary to understand its network surface before wiring it into sensitive workflows. I was initially surprised to see Coinbase AgentKit hosts (`basescan.org`, `mainnet.base.org`), the brin.sh endpoint, and several blockchain-tooling domains (`abitype.dev`, `openchain.xyz`, `4byte.sourcify.dev`). All of them turned out to be legitimate — but tracing each one back to its triggering code path took time that would be better spent once, in docs.

This PR captures that research so the next curious user (or compliance reviewer) doesn't have to redo it.

## Structure

Two tables, grouped by trigger:

- **Always on** (2 hosts) — `api.x.ai` (provider), `api.github.com` (updates)
- **Feature-gated** (8 hosts/groups) — Telegram, payments/brin, AI Gateway, Coinbase AgentKit (wallet + Solidity), IPFS/Arweave, sigstore, skills/MCP

Each row traces back to a source file or dependency so the table can be mechanically updated as code evolves.

## Notable specifics

- **`api.brin.sh` is explained correctly**: it's scoped to the x402 payments feature and only sees the target domain of a payment operation — not prompts, not code. First-party threat-detection from the same team. Having this documented upfront preempts "why is this binary calling an unknown endpoint" concerns.
- **Blockchain endpoints are attributed to `@coinbase/agentkit`** so users understand they're dormant unless wallet/on-chain tools are invoked.
- **Explicit "no telemetry / no analytics"** statement — rare-but-valuable reassurance for enterprise evaluators.

## Non-goals

- This PR does not add any opt-out env vars (none currently exist in the code). If you want to add e.g. `GROK_DISABLE_BRIN=1`, that's a separate PR I'm happy to send.
- This PR does not change behavior — docs only.

## Test plan

- [ ] Review the table accuracy against current code — every row is cited, but confirm per-file attributions
- [ ] Check the rendered markdown in GitHub's preview
- [ ] Flag any hosts I missed (the table is based on `strings` of the binary + source grep; bundled deps may reach additional hosts I didn't catch)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only updates documentation and does not change runtime behavior. The main risk is documentation drift or inaccurate endpoint listings that could mislead compliance/network-allowlist setups.
> 
> **Overview**
> Adds a new **`Network behavior`** section to `README.md` that documents which HTTPS hosts Grok may contact, split into **always-on** vs **feature-gated** traffic, with pointers to the triggering codepaths/dependencies.
> 
> Also clarifies **what is not sent** (no default telemetry; prompts/code stay within the model provider channel) and provides guidance for **network-restricted/allowlist** environments, including the minimum required hosts and how sandbox flags further constrain egress.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7943680386f9ccacaf4fcfc2c490828319895bd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->