### PR TITLE
chore(release): add sigstore build-provenance attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,11 @@ jobs:
 
     runs-on: ${{ matrix.runner }}
 
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+
     steps:
       - uses: actions/checkout@v4
 
@@ -61,6 +66,12 @@ jobs:
           Copy-Item "${{ matrix.build_output }}" "${{ matrix.asset_name }}"
           $hash = (Get-FileHash "${{ matrix.asset_name }}" -Algorithm SHA256).Hash.ToLower()
           "$hash  ${{ matrix.asset_name }}" | Out-File -Encoding ascii "${{ matrix.asset_name }}.sha256"
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            release/${{ matrix.asset_name }}
 
       - name: Upload release artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Generate signed [build-provenance attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) for each release binary using `actions/attest-build-provenance@v2`.

## Why

The install.sh already verifies SHA-256 checksums — that's integrity. But it doesn't verify *provenance* (who built the binary and from what source). An attacker with GitHub Releases write access could swap both the binary and `checksums.txt` and the checksum check would pass.

Build-provenance attestations close this by signing each artifact with a short-lived sigstore identity tied to:

- The exact repo (`superagent-ai/grok-cli`)
- The exact workflow file (`release.yml`)
- The exact commit SHA

After merge, users can verify any release binary with:

```bash
gh attestation verify ~/.grok/bin/grok --repo superagent-ai/grok-cli
```

## The change

Two surgical additions to `release.yml`:

1. **Job-level permissions** on the `build` job:

    ```yaml
    permissions:
      contents: read
      id-token: write     # OIDC token for sigstore
      attestations: write # GitHub attestation store
    ```

2. **Attest step** after the checksum computation, before artifact upload:

    ```yaml
    - name: Attest build provenance
      uses: actions/attest-build-provenance@v2
      with:
        subject-path: |
          release/${{ matrix.asset_name }}
    ```

## Prerequisite for maintainers

This workflow assumes the repository has **Artifact attestations enabled** at the org/repo level. If the first release after merge fails with a permissions error on the "Attest build provenance" step:

1. Go to `Settings → Actions → General`
2. Under "Artifact attestations", enable
3. Retrigger the failed release job

This is a one-time org setting, not something the workflow can toggle itself.

## Scope

- Does **not** change the install.sh side to verify attestations — that's a follow-up PR (and depends on how many releases have been attested, since old ones won't have them).
- Does **not** change checksum behavior — attestations are additive.

## Test plan

- [ ] Verify the workflow parses and lints (GitHub will check on PR open)
- [ ] Push a test tag like `grok-dev@1.1.6-test` and confirm the Attest step succeeds
- [ ] Run `gh attestation verify` against the resulting binary

## Follow-up opportunities

1. Update `install.sh` to optionally run `gh attestation verify` when `gh` is installed.
2. Add a `grok verify` subcommand that checks its own binary's attestation.

Happy to send either as a separate PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts the GitHub Actions release workflow by adding OIDC/attestation permissions and an attestation step; runtime code and published artifacts’ contents shouldn’t change, but releases could fail if repo attestation settings/permissions are misconfigured.
> 
> **Overview**
> Adds **artifact provenance attestations** to the `build` job in `.github/workflows/release.yml` by granting `id-token: write`/`attestations: write` permissions and running `actions/attest-build-provenance@v2` on each generated release binary before uploading artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 254d7a85512041e6332fc0d88cfa4812f0fda193. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->