### PR TITLE
docs: update CHANGELOG from merged PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Dedicated grep tool powered by npm ripgrep WASM (#263)
+- `/btw` command for side questions (#264)
+
 ### Changed
-- Switched Telegram voice/audio transcription from whisper.cpp to Grok STT (`/v1/stt`); removed `whisper-cli`, `ffmpeg`, and model-download requirements (#265)
+- Switched Telegram voice/audio transcription from whisper.cpp to Grok STT (`/v1/stt`); removed `whisper-cli`, `ffmpeg`, and model-download requirements (#266, #265)
+- Install script warns when auto-resolving to a pre-release version (#269)
+- Release workflow publishes Sigstore build-provenance attestations (#271)
+
+### Fixed
+- RC version tags are published as GitHub prereleases (#268)
 
 ## [1.1.5-rc5] - 2026-04-15
 


### PR DESCRIPTION
## Summary

Updates `CHANGELOG.md` **Unreleased** to reflect merged PRs since the last changelog pass (notably #263–#271).

### Added
- #263 — grep tool (ripgrep WASM)
- #264 — `/btw` side-question command

### Changed
- #266 / #265 — Grok STT for Telegram audio (existing bullet, PR refs aligned)
- #269 — install warns on pre-release resolution
- #271 — Sigstore build-provenance attestations in release workflow

### Fixed
- #268 — RC tags as GitHub prereleases

No code changes.

Made with [Cursor](https://cursor.com)