### PR TITLE
docs: add Keep a Changelog version compare links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,3 +152,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0-rc1] - 2026-03-20
 
 Initial release.
+
+[Unreleased]: https://github.com/superagent-ai/grok-cli/compare/grok-dev@1.1.5...HEAD
+[1.1.5-rc5]: https://github.com/superagent-ai/grok-cli/compare/grok-dev@1.1.5-rc4...grok-dev@1.1.5-rc5
+[1.1.5-rc4]: https://github.com/superagent-ai/grok-cli/compare/grok-dev@1.1.5-rc3...grok-dev@1.1.5-rc4
+[1.1.5-rc3]: https://github.com/superagent-ai/grok-cli/compare/grok-dev@1.1.5-rc2...grok-dev@1.1.5-rc3
+[1.1.5-rc2]: https://github.com/superagent-ai/grok-cli/compare/grok-dev@1.1.5-rc1...grok-dev@1.1.5-rc2
+[1.1.5-rc1]: https://github.com/superagent-ai/grok-cli/compare/grok-dev@1.1.4...grok-dev@1.1.5-rc1
+[1.1.4]: https://github.com/superagent-ai/grok-cli/compare/grok-dev@1.1.3...grok-dev@1.1.4
+[1.1.3]: https://github.com/superagent-ai/grok-cli/compare/grok-dev@1.1.2...grok-dev@1.1.3
+[1.1.2]: https://github.com/superagent-ai/grok-cli/compare/grok-dev@1.1.1...grok-dev@1.1.2
+[1.1.1]: https://github.com/superagent-ai/grok-cli/compare/grok-dev@1.1.0...grok-dev@1.1.1
+[1.1.0]: https://github.com/superagent-ai/grok-cli/compare/grok-dev@1.0.0-rc7...grok-dev@1.1.0
+[1.0.0-rc7]: https://github.com/superagent-ai/grok-cli/compare/grok-dev@1.0.0-rc6...grok-dev@1.0.0-rc7
+[1.0.0-rc6]: https://github.com/superagent-ai/grok-cli/compare/grok-dev@1.0.0-rc5...grok-dev@1.0.0-rc6
+[1.0.0-rc5]: https://github.com/superagent-ai/grok-cli/compare/grok-dev@1.0.0-rc4...grok-dev@1.0.0-rc5
+[1.0.0-rc4]: https://github.com/superagent-ai/grok-cli/compare/grok-dev@1.0.0-rc3...grok-dev@1.0.0-rc4
+[1.0.0-rc3]: https://github.com/superagent-ai/grok-cli/compare/grok-dev@1.0.0-rc2...grok-dev@1.0.0-rc3
+[1.0.0-rc2]: https://github.com/superagent-ai/grok-cli/compare/grok-dev@1.0.0-rc1...grok-dev@1.0.0-rc2
+[1.0.0-rc1]: https://github.com/superagent-ai/grok-cli/releases/tag/grok-dev%401.0.0-rc1


### PR DESCRIPTION
## Summary

- Appends [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) reference links at the end of `CHANGELOG.md`, using the repository’s `grok-dev@…` git tags.
- **`[Unreleased]`** compares `grok-dev@1.1.5` to `HEAD` so pending work since the last stable tag is one click away.
- Each released section links to the GitHub compare range for that version (and `1.0.0-rc1` points at the initial tag).

## Merged PRs already reflected under `[Unreleased]`

Verified against merged PRs **#263–#271** (no merges after [#275](https://github.com/superagent-ai/grok-cli/pull/275) as of this branch):

| PR | Title |
|----|--------|
| #263 | feat: add dedicated grep tool powered by npm ripgrep WASM |
| #264 | feat: add /btw command for side questions |
| #265 / #266 | Grok STT for Telegram audio |
| #268 | fix(release): mark RC tags as GitHub prereleases |
| #269 | chore(install): warn when auto-resolving to a pre-release version |
| #271 | chore(release): add sigstore build-provenance attestations |

Upstream `main` already contained these entries; this PR adds navigable version links without changing the bullet text.
