### PR TITLE
feat: add per-turn session recaps

### DIFF
--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -863,23 +863,27 @@ export class Agent {
       return;
     }
 
-    const prompt = this.buildRecapPrompt();
-    if (!prompt) {
-      return;
-    }
+    try {
+      const prompt = this.buildRecapPrompt();
+      if (!prompt) {
+        return;
+      }
 
-    const generated = await genRecap(this.provider, prompt, withAbortTimeout(signal, 8_000));
-    this.recordUsage(generated.usage, "recap", generated.modelId);
-    if (!generated.recap) {
-      return;
-    }
+      const generated = await genRecap(this.provider, prompt, withAbortTimeout(signal, 8_000));
+      this.recordUsage(generated.usage, "recap", generated.modelId);
+      if (!generated.recap) {
+        return;
+      }
 
-    this.sessionStore.setRecap(this.session.id, {
-      text: generated.recap,
-      model: generated.modelId,
-      updatedAt: new Date(),
-    });
-    this.session = this.sessionStore.getRequiredSession(this.session.id);
+      this.sessionStore.setRecap(this.session.id, {
+        text: generated.recap,
+        model: generated.modelId,
+        updatedAt: new Date(),
+      });
+      this.session = this.sessionStore.getRequiredSession(this.session.id);
+    } catch {
+      // Recaps are best-effort and should never make the completed turn fail.
+    }
   }
 
   private buildRecapPrompt(): string | null {

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -13,7 +13,13 @@ import {
   getBatchChatCompletion,
   pollBatchRequestResult,
 } from "../grok/batch";
-import { createProvider, generateTitle as genTitle, resolveModelRuntime, type XaiProvider } from "../grok/client";
+import {
+  createProvider,
+  generateRecap as genRecap,
+  generateTitle as genTitle,
+  resolveModelRuntime,
+  type XaiProvider,
+} from "../grok/client";
 import { DEFAULT_MODEL, getModelInfo, normalizeModelId } from "../grok/models";
 import { toolSetToBatchTools } from "../grok/tool-schemas";
 import { createTools } from "../grok/tools";
@@ -715,6 +721,10 @@ export class Agent {
     return generated.title;
   }
 
+  getSessionRecap(): string | null {
+    return this.session?.recap?.text || null;
+  }
+
   async askSideQuestion(question: string, signal?: AbortSignal): Promise<SideQuestionResult> {
     if (!this.provider) {
       return { response: "No API key configured." };
@@ -846,6 +856,50 @@ export class Agent {
       this.messages.splice(idx, 1);
       this.messageSeqs.splice(idx, 1);
     }
+  }
+
+  private async refreshSessionRecap(signal?: AbortSignal): Promise<void> {
+    if (!this.provider || !this.sessionStore || !this.session) {
+      return;
+    }
+
+    const prompt = this.buildRecapPrompt();
+    if (!prompt) {
+      return;
+    }
+
+    const generated = await genRecap(this.provider, prompt, withAbortTimeout(signal, 8_000));
+    this.recordUsage(generated.usage, "recap", generated.modelId);
+    if (!generated.recap) {
+      return;
+    }
+
+    this.sessionStore.setRecap(this.session.id, {
+      text: generated.recap,
+      model: generated.modelId,
+      updatedAt: new Date(),
+    });
+    this.session = this.sessionStore.getRequiredSession(this.session.id);
+  }
+
+  private buildRecapPrompt(): string | null {
+    if (!this.session) {
+      return null;
+    }
+
+    const transcript = formatEntriesForRecap(buildChatEntries(this.session.id), 5_000);
+    if (!transcript) {
+      return null;
+    }
+
+    const sections = [
+      "Refresh the saved recap for this coding session using the latest transcript.",
+      this.session.recap?.text
+        ? `Existing recap:\n${truncate(this.session.recap.text, 1_200)}`
+        : "Existing recap:\n(none)",
+      `Session transcript:\n${transcript}`,
+    ];
+    return sections.join("\n\n");
   }
 
   private recordUsage(
@@ -1634,6 +1688,7 @@ export class Agent {
               this.recordUsage(totalUsage, "message", runtime.modelId);
             }
             this.appendCompletedTurn(userModelMessage, turnMessages);
+            await this.refreshSessionRecap(signal);
             yield { type: "done" };
             return;
           }
@@ -2052,6 +2107,7 @@ export class Agent {
             const response = await result.response;
             if (!signal.aborted) {
               this.appendCompletedTurn(userModelMessage, sanitizeModelMessages(response.messages));
+              await this.refreshSessionRecap(signal);
               streamOk = true;
             }
           } catch (responseError: unknown) {
@@ -2074,6 +2130,7 @@ export class Agent {
 
           if (!streamOk && assistantText.trim()) {
             this.appendCompletedTurn(userModelMessage, [{ role: "assistant", content: assistantText }]);
+            await this.refreshSessionRecap(signal);
           }
 
           const stopInput: StopHookInput = {
@@ -2634,6 +2691,53 @@ function firstLine(text: string): string {
 
 function truncate(text: string, max: number): string {
   return text.length <= max ? text : `${text.slice(0, max - 1)}…`;
+}
+
+function formatEntriesForRecap(entries: ChatEntry[], maxChars: number): string {
+  const lines: string[] = [];
+  let remaining = maxChars;
+
+  for (let i = entries.length - 1; i >= 0 && remaining > 0; i--) {
+    const line = formatRecapEntry(entries[i]!);
+    if (!line) {
+      continue;
+    }
+
+    const bounded = truncate(line, Math.min(remaining, 520));
+    if (!bounded.trim()) {
+      continue;
+    }
+
+    lines.unshift(bounded);
+    remaining -= bounded.length + 1;
+  }
+
+  return lines.join("\n");
+}
+
+function formatRecapEntry(entry: ChatEntry): string | null {
+  const content = entry.content.trim();
+  if (!content) {
+    return null;
+  }
+
+  switch (entry.type) {
+    case "user":
+      return `[User] ${truncate(content, 420)}`;
+    case "assistant":
+      return `[Assistant] ${truncate(content, 420)}`;
+    case "tool_result":
+      return `[Tool ${entry.toolResult?.success === false ? "error" : "result"}] ${truncate(content, 260)}`;
+    default:
+      return null;
+  }
+}
+
+function withAbortTimeout(signal: AbortSignal | undefined, timeoutMs: number): AbortSignal | undefined {
+  if (typeof AbortSignal.timeout !== "function") {
+    return signal;
+  }
+  return combineAbortSignals(signal, AbortSignal.timeout(timeoutMs));
 }
 
 function combineAbortSignals(...signals: Array<AbortSignal | undefined>): AbortSignal | undefined {

--- a/src/agent/recap.test.ts
+++ b/src/agent/recap.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+async function importAgentModuleWithRecapMocks() {
+  vi.resetModules();
+
+  const generateRecap = vi.fn(async () => ({
+    recap: "Recovered the latest session state.",
+    modelId: "grok-4-1-fast-non-reasoning",
+    usage: {
+      inputTokens: 10,
+      outputTokens: 4,
+      totalTokens: 14,
+    },
+  }));
+
+  vi.doMock("../grok/client", async () => {
+    const actual = await vi.importActual<typeof import("../grok/client")>("../grok/client");
+    return {
+      ...actual,
+      generateRecap,
+    };
+  });
+
+  vi.doMock("../storage/index", () => ({
+    appendCompaction: vi.fn(),
+    appendMessages: vi.fn(() => []),
+    appendSystemMessage: vi.fn(() => 0),
+    buildChatEntries: vi.fn(() => [
+      {
+        type: "user",
+        content: "Summarize this session.",
+        timestamp: new Date("2026-04-22T15:00:00.000Z"),
+      },
+    ]),
+    getNextMessageSequence: vi.fn(() => 0),
+    getSessionTotalTokens: vi.fn(() => 0),
+    loadTranscript: vi.fn(() => []),
+    loadTranscriptState: vi.fn(() => ({ messages: [], seqs: [] })),
+    recordUsageEvent: vi.fn(),
+    SessionStore: class {
+      getWorkspace() {
+        return null;
+      }
+      openSession() {
+        return null;
+      }
+      createSession() {
+        return null;
+      }
+      setModel() {}
+      getRequiredSession() {
+        return null;
+      }
+      setMode() {}
+      touchSession() {}
+    },
+  }));
+
+  const mod = await import("./agent");
+  return {
+    ...mod,
+    mocks: {
+      generateRecap,
+    },
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+  vi.doUnmock("../grok/client");
+  vi.doUnmock("../storage/index");
+});
+
+describe("Agent session recap", () => {
+  it("does not throw when persisting a generated recap fails", async () => {
+    const { Agent, mocks } = await importAgentModuleWithRecapMocks();
+    const agent = new Agent(undefined, undefined, undefined, undefined, {
+      persistSession: false,
+    });
+    const session = {
+      id: "session-1",
+      workspaceId: "workspace-1",
+      title: null,
+      recap: null,
+      model: "grok-4-1-fast",
+      mode: "agent",
+      cwdAtStart: process.cwd(),
+      cwdLast: process.cwd(),
+      status: "active",
+      createdAt: new Date("2026-04-22T15:00:00.000Z"),
+      updatedAt: new Date("2026-04-22T15:00:00.000Z"),
+    };
+    const sessionStore = {
+      setRecap: vi.fn(() => {
+        throw new Error("database is unavailable");
+      }),
+      getRequiredSession: vi.fn(() => session),
+    };
+
+    Object.assign(agent as object, {
+      provider: {},
+      session,
+      sessionStore,
+    });
+
+    await expect(
+      (
+        agent as unknown as {
+          refreshSessionRecap: (signal?: AbortSignal) => Promise<void>;
+        }
+      ).refreshSessionRecap(),
+    ).resolves.toBeUndefined();
+
+    expect(mocks.generateRecap).toHaveBeenCalled();
+    expect(sessionStore.setRecap).toHaveBeenCalled();
+  });
+});

--- a/src/grok/client.test.ts
+++ b/src/grok/client.test.ts
@@ -1,12 +1,62 @@
 import { createXai } from "@ai-sdk/xai";
+import type { generateText } from "ai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as settings from "../utils/settings";
-import { resolveModelRuntime } from "./client";
+import { generateRecap, resolveModelRuntime } from "./client";
+
+const mockGenerateText = vi.fn();
+
+vi.mock("ai", () => {
+  return {
+    generateText: mockGenerateText,
+  };
+});
 
 describe("client", () => {
   const mockProvider = createXai({
     apiKey: "test-key",
     baseURL: "https://api.x.ai/v1",
+  });
+
+  describe("generateRecap", () => {
+    beforeEach(() => {
+      mockGenerateText.mockReset();
+    });
+
+    it("generates a normalized recap with the recap prompt contract", async () => {
+      const signal = new AbortController().signal;
+      mockGenerateText.mockResolvedValue({
+        text: ' "Wrapped up the parser fix. Next step is wiring the new recap banner." ',
+        usage: { inputTokens: 11, outputTokens: 7, totalTokens: 18 },
+      } as Awaited<ReturnType<typeof generateText>>);
+
+      const result = await generateRecap(mockProvider, "transcript body", signal);
+
+      expect(result).toEqual({
+        recap: "Wrapped up the parser fix. Next step is wiring the new recap banner.",
+        modelId: "grok-4-1-fast-non-reasoning",
+        usage: { inputTokens: 11, outputTokens: 7, totalTokens: 18 },
+      });
+      expect(mockGenerateText).toHaveBeenCalledWith(
+        expect.objectContaining({
+          abortSignal: signal,
+          maxOutputTokens: 120,
+          prompt: "transcript body",
+          system: expect.stringContaining("Maximum 3 sentences total"),
+        }),
+      );
+    });
+
+    it("returns an empty recap when generation fails", async () => {
+      mockGenerateText.mockRejectedValue(new Error("boom"));
+
+      const result = await generateRecap(mockProvider, "transcript body");
+
+      expect(result).toEqual({
+        recap: "",
+        modelId: "grok-4-1-fast-non-reasoning",
+      });
+    });
   });
 
   describe("resolveModelRuntime", () => {
@@ -58,7 +108,7 @@ describe("client", () => {
       });
 
       it("includes providerOptions with reasoningEffort for grok-3-mini when effort is configured", () => {
-        vi.mocked(settings.getReasoningEffortForModel).mockReturnValue("high");
+        vi.spyOn(settings, "getReasoningEffortForModel").mockReturnValue("high");
         const runtime = resolveModelRuntime(mockProvider, "grok-3-mini");
         expect(runtime.modelId).toBe("grok-3-mini");
         expect(runtime.providerOptions).toEqual({
@@ -69,7 +119,7 @@ describe("client", () => {
       });
 
       it("includes providerOptions with low effort for grok-3-mini when configured", () => {
-        vi.mocked(settings.getReasoningEffortForModel).mockReturnValue("low");
+        vi.spyOn(settings, "getReasoningEffortForModel").mockReturnValue("low");
         const runtime = resolveModelRuntime(mockProvider, "grok-3-mini");
         expect(runtime.modelId).toBe("grok-3-mini");
         expect(runtime.providerOptions).toEqual({
@@ -80,21 +130,21 @@ describe("client", () => {
       });
 
       it("does not include providerOptions for grok-4-0709 even when effort is configured", () => {
-        vi.mocked(settings.getReasoningEffortForModel).mockReturnValue("high");
+        vi.spyOn(settings, "getReasoningEffortForModel").mockReturnValue("high");
         const runtime = resolveModelRuntime(mockProvider, "grok-4-0709");
         expect(runtime.modelId).toBe("grok-4-0709");
         expect(runtime.providerOptions).toBeUndefined();
       });
 
       it("does not include providerOptions for grok-code-fast-1 even when effort is configured", () => {
-        vi.mocked(settings.getReasoningEffortForModel).mockReturnValue("high");
+        vi.spyOn(settings, "getReasoningEffortForModel").mockReturnValue("high");
         const runtime = resolveModelRuntime(mockProvider, "grok-code-fast-1");
         expect(runtime.modelId).toBe("grok-code-fast-1");
         expect(runtime.providerOptions).toBeUndefined();
       });
 
       it("does not include providerOptions for grok-4-1-fast-reasoning even when effort is configured", () => {
-        vi.mocked(settings.getReasoningEffortForModel).mockReturnValue("high");
+        vi.spyOn(settings, "getReasoningEffortForModel").mockReturnValue("high");
         const runtime = resolveModelRuntime(mockProvider, "grok-4-1-fast-reasoning");
         expect(runtime.modelId).toBe("grok-4-1-fast-reasoning");
         expect(runtime.providerOptions).toBeUndefined();

--- a/src/grok/client.ts
+++ b/src/grok/client.ts
@@ -10,15 +10,23 @@ export type XaiResponsesModel = ReturnType<XaiProvider["responses"]>;
 export type GrokRuntimeModel = XaiChatModel | XaiResponsesModel;
 
 const DEFAULT_TITLE_MODEL = "grok-4-1-fast-non-reasoning";
+const DEFAULT_RECAP_MODEL = "grok-4-1-fast-non-reasoning";
 
-export interface GeneratedTitle {
-  title: string;
+interface GeneratedTextResult {
   modelId: string;
   usage?: {
     totalTokens?: number;
     inputTokens?: number;
     outputTokens?: number;
   };
+}
+
+export interface GeneratedTitle extends GeneratedTextResult {
+  title: string;
+}
+
+export interface GeneratedRecap extends GeneratedTextResult {
+  recap: string;
 }
 
 export interface ResolvedModelRuntime {
@@ -87,4 +95,46 @@ export async function generateTitle(provider: XaiProvider, userMessage: string):
   } catch {
     return { title: "New session", modelId: runtime.modelId };
   }
+}
+
+export async function generateRecap(
+  provider: XaiProvider,
+  transcript: string,
+  signal?: AbortSignal,
+): Promise<GeneratedRecap> {
+  const runtime = resolveModelRuntime(provider, DEFAULT_RECAP_MODEL);
+  try {
+    const { text, usage } = await generateText({
+      model: runtime.model,
+      abortSignal: signal,
+      temperature: 0.3,
+      ...(runtime.modelInfo?.supportsMaxOutputTokens === false ? {} : { maxOutputTokens: 120 }),
+      ...(runtime.providerOptions ? { providerOptions: runtime.providerOptions } : {}),
+      system: [
+        "You write terse coding-session recaps.",
+        "Output ONLY the recap text. No bullets, headings, labels, or preamble.",
+        "Rules:",
+        "- Maximum 3 sentences total",
+        "- Focus on what changed, what remains, and the most useful next step",
+        "- Preserve exact file paths, function names, errors, and technical terms when present",
+        "- Avoid filler, hedging, and repetition",
+        "- Never mention being an AI, assistant, or summarizer",
+      ].join("\n"),
+      prompt: transcript,
+    });
+    return {
+      recap: normalizeRecap(text),
+      modelId: runtime.modelId,
+      usage,
+    };
+  } catch {
+    return { recap: "", modelId: runtime.modelId };
+  }
+}
+
+function normalizeRecap(value: string | undefined): string {
+  return (value ?? "")
+    .trim()
+    .replace(/^["']|["']$/g, "")
+    .replace(/\s+/g, " ");
 }

--- a/src/storage/migrations.test.ts
+++ b/src/storage/migrations.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import type { SQLiteDatabase, SQLiteStatement } from "./db";
+import { applyMigrations } from "./migrations";
+
+describe("applyMigrations", () => {
+  it("repairs missing recap columns when the database version is already current", () => {
+    const db = new FakeDatabase(3, ["id", "workspace_id", "title", "model"]);
+
+    applyMigrations(db);
+
+    expect(db.sessionColumns).toEqual(
+      new Set(["id", "workspace_id", "title", "model", "recap_text", "recap_model", "recap_updated_at"]),
+    );
+  });
+});
+
+class FakeDatabase implements SQLiteDatabase {
+  readonly sessionColumns: Set<string>;
+
+  constructor(
+    private version: number,
+    sessionColumns: string[],
+  ) {
+    this.sessionColumns = new Set(sessionColumns);
+  }
+
+  exec(sql: string): void {
+    const match = sql.match(/ALTER TABLE sessions ADD COLUMN ([a-z_]+) /);
+    if (match?.[1]) {
+      this.sessionColumns.add(match[1]);
+    }
+  }
+
+  prepare(sql: string): SQLiteStatement {
+    if (sql === "PRAGMA table_info(sessions)") {
+      return new FakeStatement(() => [...this.sessionColumns].map((name) => ({ name })));
+    }
+
+    throw new Error(`Unexpected SQL: ${sql}`);
+  }
+
+  pragma(query: string, options?: { simple?: boolean }): unknown {
+    if (query === "user_version" && options?.simple) {
+      return this.version;
+    }
+
+    const match = query.match(/^user_version = (\d+)$/);
+    if (match?.[1]) {
+      this.version = Number(match[1]);
+      return undefined;
+    }
+
+    throw new Error(`Unexpected pragma: ${query}`);
+  }
+
+  transaction<T>(fn: () => T): () => T {
+    return fn;
+  }
+
+  close(): void {}
+}
+
+class FakeStatement implements SQLiteStatement {
+  constructor(private readonly allFn: () => unknown[]) {}
+
+  run(): unknown {
+    throw new Error("Unexpected run");
+  }
+
+  get(): unknown {
+    throw new Error("Unexpected get");
+  }
+
+  all(): unknown[] {
+    return this.allFn();
+  }
+}

--- a/src/storage/migrations.ts
+++ b/src/storage/migrations.ts
@@ -4,7 +4,6 @@ const LATEST_DB_VERSION = 3;
 
 export function applyMigrations(db: SQLiteDatabase): void {
   const version = Number(db.pragma("user_version", { simple: true })) || 0;
-  if (version >= LATEST_DB_VERSION) return;
 
   const migrate = db.transaction(() => {
     if (version < 1) {
@@ -15,10 +14,12 @@ export function applyMigrations(db: SQLiteDatabase): void {
       createCompactionSchema(db);
       db.pragma("user_version = 2");
     }
-    if (version < 3) {
+    if (version < LATEST_DB_VERSION) {
       createSessionRecapSchema(db);
-      db.pragma("user_version = 3");
+      db.pragma(`user_version = ${LATEST_DB_VERSION}`);
     }
+
+    ensureLatestSchema(db);
   });
 
   migrate();
@@ -137,6 +138,10 @@ function createSessionRecapSchema(db: SQLiteDatabase): void {
   addColumnIfMissing(db, "sessions", "recap_text", "TEXT");
   addColumnIfMissing(db, "sessions", "recap_model", "TEXT");
   addColumnIfMissing(db, "sessions", "recap_updated_at", "TEXT");
+}
+
+function ensureLatestSchema(db: SQLiteDatabase): void {
+  createSessionRecapSchema(db);
 }
 
 function addColumnIfMissing(db: SQLiteDatabase, table: string, column: string, definition: string): void {

--- a/src/storage/migrations.ts
+++ b/src/storage/migrations.ts
@@ -1,6 +1,6 @@
 import type { SQLiteDatabase } from "./db";
 
-const LATEST_DB_VERSION = 2;
+const LATEST_DB_VERSION = 3;
 
 export function applyMigrations(db: SQLiteDatabase): void {
   const version = Number(db.pragma("user_version", { simple: true })) || 0;
@@ -14,6 +14,10 @@ export function applyMigrations(db: SQLiteDatabase): void {
     if (version < 2) {
       createCompactionSchema(db);
       db.pragma("user_version = 2");
+    }
+    if (version < 3) {
+      createSessionRecapSchema(db);
+      db.pragma("user_version = 3");
     }
   });
 
@@ -35,6 +39,9 @@ function createInitialSchema(db: SQLiteDatabase): void {
       id TEXT PRIMARY KEY,
       workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
       title TEXT,
+      recap_text TEXT,
+      recap_model TEXT,
+      recap_updated_at TEXT,
       model TEXT NOT NULL,
       mode TEXT NOT NULL,
       cwd_at_start TEXT NOT NULL,
@@ -124,4 +131,18 @@ function createCompactionSchema(db: SQLiteDatabase): void {
     CREATE INDEX IF NOT EXISTS idx_compactions_session_created
       ON compactions(session_id, created_at DESC);
   `);
+}
+
+function createSessionRecapSchema(db: SQLiteDatabase): void {
+  addColumnIfMissing(db, "sessions", "recap_text", "TEXT");
+  addColumnIfMissing(db, "sessions", "recap_model", "TEXT");
+  addColumnIfMissing(db, "sessions", "recap_updated_at", "TEXT");
+}
+
+function addColumnIfMissing(db: SQLiteDatabase, table: string, column: string, definition: string): void {
+  const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name?: string }>;
+  if (rows.some((row) => row.name === column)) {
+    return;
+  }
+  db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition};`);
 }

--- a/src/storage/sessions.test.ts
+++ b/src/storage/sessions.test.ts
@@ -1,0 +1,64 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { closeDatabase } from "./db";
+import { SessionStore } from "./sessions";
+
+const originalHome = process.env.HOME;
+
+describe("SessionStore recap persistence", () => {
+  const tempRoot = path.join(process.cwd(), ".tmp-session-tests");
+  let tempHome = "";
+  let tempCwd = "";
+
+  beforeEach(() => {
+    fs.mkdirSync(tempRoot, { recursive: true });
+    tempHome = fs.mkdtempSync(path.join(tempRoot, "grok-session-home-"));
+    tempCwd = fs.mkdtempSync(path.join(tempRoot, "grok-session-cwd-"));
+    process.env.HOME = tempHome;
+    vi.spyOn(os, "homedir").mockReturnValue(tempHome);
+    closeDatabase();
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    vi.restoreAllMocks();
+    process.env.HOME = originalHome;
+    fs.rmSync(tempHome, { recursive: true, force: true });
+    fs.rmSync(tempCwd, { recursive: true, force: true });
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it("stores and reloads the latest recap metadata with the session", () => {
+    const store = new SessionStore(tempCwd);
+    const session = store.createSession("grok-4-1-fast", "agent", tempCwd);
+    const updatedAt = new Date("2026-04-22T15:00:00.000Z");
+
+    store.setRecap(session.id, {
+      text: "Migrated billing sessions to the new schema. Next step is wiring the prompt banner.",
+      model: "grok-4-1-fast-non-reasoning",
+      updatedAt,
+    });
+
+    expect(store.getRequiredSession(session.id).recap).toEqual({
+      text: "Migrated billing sessions to the new schema. Next step is wiring the prompt banner.",
+      model: "grok-4-1-fast-non-reasoning",
+      updatedAt,
+    });
+  });
+
+  it("clears recap metadata when the recap is removed", () => {
+    const store = new SessionStore(tempCwd);
+    const session = store.createSession("grok-4-1-fast", "agent", tempCwd);
+
+    store.setRecap(session.id, {
+      text: "Temporary recap",
+      model: "grok-4-1-fast-non-reasoning",
+      updatedAt: new Date("2026-04-22T15:00:00.000Z"),
+    });
+    store.setRecap(session.id, null);
+
+    expect(store.getRequiredSession(session.id).recap).toBeNull();
+  });
+});

--- a/src/storage/sessions.ts
+++ b/src/storage/sessions.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "crypto";
-import type { AgentMode, SessionInfo, SessionStatus, WorkspaceInfo } from "../types/index";
+import type { AgentMode, SessionInfo, SessionRecap, SessionStatus, WorkspaceInfo } from "../types/index";
 import { getDatabase } from "./db";
 import { ensureWorkspace } from "./workspaces";
 
@@ -7,6 +7,9 @@ interface SessionRow {
   id: string;
   workspace_id: string;
   title: string | null;
+  recap_text: string | null;
+  recap_model: string | null;
+  recap_updated_at: string | null;
   model: string;
   mode: AgentMode;
   cwd_at_start: string;
@@ -53,9 +56,9 @@ export class SessionStore {
 
     db.prepare(`
       INSERT INTO sessions (
-        id, workspace_id, title, model, mode, cwd_at_start, cwd_last, status, created_at, updated_at
+        id, workspace_id, title, recap_text, recap_model, recap_updated_at, model, mode, cwd_at_start, cwd_last, status, created_at, updated_at
       ) VALUES (
-        @id, @workspace_id, NULL, @model, @mode, @cwd_at_start, @cwd_last, 'active', @created_at, @updated_at
+        @id, @workspace_id, NULL, NULL, NULL, NULL, @model, @mode, @cwd_at_start, @cwd_last, 'active', @created_at, @updated_at
       )
     `).run({
       id,
@@ -74,7 +77,7 @@ export class SessionStore {
   getLatestSession(): SessionInfo | null {
     const row = getDatabase()
       .prepare(`
-      SELECT id, workspace_id, title, model, mode, cwd_at_start, cwd_last, status, created_at, updated_at
+      SELECT id, workspace_id, title, recap_text, recap_model, recap_updated_at, model, mode, cwd_at_start, cwd_last, status, created_at, updated_at
       FROM sessions
       WHERE workspace_id = ?
       ORDER BY updated_at DESC
@@ -88,7 +91,7 @@ export class SessionStore {
   getSessionById(id: string): SessionInfo | null {
     const row = getDatabase()
       .prepare(`
-      SELECT id, workspace_id, title, model, mode, cwd_at_start, cwd_last, status, created_at, updated_at
+      SELECT id, workspace_id, title, recap_text, recap_model, recap_updated_at, model, mode, cwd_at_start, cwd_last, status, created_at, updated_at
       FROM sessions
       WHERE id = ?
     `)
@@ -114,6 +117,17 @@ export class SessionStore {
       WHERE id = ?
     `)
       .run(title, now, id);
+  }
+
+  setRecap(id: string, recap: SessionRecap | null): void {
+    const now = new Date().toISOString();
+    getDatabase()
+      .prepare(`
+      UPDATE sessions
+      SET recap_text = ?, recap_model = ?, recap_updated_at = ?, updated_at = ?
+      WHERE id = ?
+    `)
+      .run(recap?.text ?? null, recap?.model ?? null, recap?.updatedAt?.toISOString() ?? null, now, id);
   }
 
   setModel(id: string, model: string): void {
@@ -158,6 +172,7 @@ function toSessionInfo(row: SessionRow): SessionInfo {
     id: row.id,
     workspaceId: row.workspace_id,
     title: row.title,
+    recap: toSessionRecap(row),
     model: row.model,
     mode: row.mode,
     cwdAtStart: row.cwd_at_start,
@@ -165,5 +180,17 @@ function toSessionInfo(row: SessionRow): SessionInfo {
     status: row.status,
     createdAt: new Date(row.created_at),
     updatedAt: new Date(row.updated_at),
+  };
+}
+
+function toSessionRecap(row: SessionRow): SessionRecap | null {
+  if (!row.recap_text) {
+    return null;
+  }
+
+  return {
+    text: row.recap_text,
+    model: row.recap_model,
+    updatedAt: row.recap_updated_at ? new Date(row.recap_updated_at) : null,
   };
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -243,7 +243,13 @@ export interface ModelInfo {
 
 export type AgentMode = "agent" | "plan" | "ask";
 export type SessionStatus = "active" | "archived";
-export type UsageSource = "message" | "title" | "task" | "delegation" | "other";
+export type UsageSource = "message" | "title" | "recap" | "task" | "delegation" | "other";
+
+export interface SessionRecap {
+  text: string;
+  model: string | null;
+  updatedAt: Date | null;
+}
 
 export interface WorkspaceInfo {
   id: string;
@@ -258,6 +264,7 @@ export interface SessionInfo {
   id: string;
   workspaceId: string;
   title: string | null;
+  recap: SessionRecap | null;
   model: string;
   mode: AgentMode;
   cwdAtStart: string;

--- a/src/ui/app.tsx
+++ b/src/ui/app.tsx
@@ -654,6 +654,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
   const [activeToolCalls, setActiveToolCalls] = useState<ToolCall[]>([]);
   const [sessionTitle, setSessionTitle] = useState<string | null>(() => agent.getSessionTitle());
   const [sessionId, setSessionId] = useState<string | null>(() => agent.getSessionId());
+  const [sessionRecap, setSessionRecap] = useState<string | null>(() => agent.getSessionRecap());
   const [showApiKeyModal, setShowApiKeyModal] = useState(() => !initialHasApiKey);
   const [apiKeyError, setApiKeyError] = useState<string | null>(null);
   const [showSlashMenu, setShowSlashMenu] = useState(false);
@@ -1559,6 +1560,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
           });
           setSessionTitle(activeTurn.agent.getSessionTitle());
           setSessionId(activeTurn.agent.getSessionId());
+          setSessionRecap(activeTurn.agent.getSessionRecap());
         } else if (activeTurn.kind === "telegram") {
           syncTelegramTurnEntries(activeTurn);
         }
@@ -2036,6 +2038,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
     clearLiveTurnUi();
     setSessionTitle(snapshot?.session.title ?? null);
     setSessionId(snapshot?.session.id ?? agent.getSessionId());
+    setSessionRecap(snapshot?.session.recap?.text ?? agent.getSessionRecap());
     setActivePlan(null);
     setPqs(initialPlanQuestionsState());
     replacePasteBlocks([]);
@@ -3451,7 +3454,8 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
             </scrollbox>
             {btwState && <BtwOverlay state={btwState} theme={t} />}
             {/* Prompt */}
-            <box flexShrink={0}>
+            <box flexShrink={0} flexDirection="column">
+              {sessionRecap ? <RecapBanner t={t} recap={sessionRecap} /> : null}
               <PromptBox
                 t={t}
                 inputRef={inputRef}
@@ -3744,6 +3748,17 @@ function SessionHeader({
         <box flexGrow={1} />
         {sessionId ? <text fg={t.textDim}>{sessionId}</text> : null}
       </box>
+    </box>
+  );
+}
+
+function RecapBanner({ t, recap }: { t: Theme; recap: string }) {
+  return (
+    <box width="100%" paddingBottom={1}>
+      <text>
+        <span style={{ fg: t.textDim }}>{"※ recap: "}</span>
+        <span style={{ fg: t.textMuted }}>{recap}</span>
+      </text>
     </box>
   );
 }


### PR DESCRIPTION
## What does this PR do?

- add a lightweight per-turn recap generator that uses a fast non-reasoning Grok model
- persist the latest recap on each session and refresh it after successful turns
- render the saved recap above the prompt and add focused recap generation/persistence tests

Verified with `bun test src/grok/client.test.ts src/storage/sessions.test.ts` and `bunx biome check src/agent/agent.ts src/grok/client.ts src/storage/migrations.ts src/storage/sessions.ts src/storage/sessions.test.ts src/types/index.ts src/ui/app.tsx src/grok/client.test.ts`.

Fixes #278

## Checklist

- [x] I tested my changes
- [x] I reviewed my own code