### PR TITLE
docs: document README troubleshooting in CHANGELOG (#277)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- README troubleshooting section with common issues and solutions (#277)
 - Dedicated grep tool powered by npm ripgrep WASM (#263)
 - `/btw` command for side questions (#264)
 


### PR DESCRIPTION
## Summary
- Add an Unreleased / Added line for the README troubleshooting section shipped in #277 so the changelog matches merged work.

`main` currently includes the troubleshooting docs from #277, but the batch changelog in #275 did not list this follow-up (README was merged after the changelog PR).

## Test plan
- N/A (documentation only)

Made with [Cursor](https://cursor.com)