### PR TITLE
docs: update CHANGELOG for README troubleshooting and trademark (#277, #281)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- README troubleshooting section with common issues and solutions (#277)
 - Dedicated grep tool powered by npm ripgrep WASM (#263)
 - `/btw` command for side questions (#264)
 
 ### Changed
+- README: trademark disclaimer and removal of brand-confusing language (#281)
 - Switched Telegram voice/audio transcription from whisper.cpp to Grok STT (`/v1/stt`); removed `whisper-cli`, `ffmpeg`, and model-download requirements (#266, #265)
 - Install script warns when auto-resolving to a pre-release version (#269)
 - Release workflow publishes Sigstore build-provenance attestations (#271)


### PR DESCRIPTION
## Summary

Documents merged README work in `CHANGELOG.md` under **[Unreleased]**:

- **Added**: troubleshooting section shipped in #277
- **Changed**: trademark disclaimer and removal of brand-confusing language from #281

This aligns the changelog with `main` after merges #277 and #281.

Supersedes #280 (changelog-only for #277): this PR includes the same #277 entry plus #281.
