### PR TITLE
fix: make git inspection errors actionable outside repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Release workflow publishes Sigstore build-provenance attestations (#271)
 
 ### Fixed
+- Git inspection commands now return an actionable non-repository error instead of raw Git discovery failures when run outside a checkout.
 - RC version tags are published as GitHub prereleases (#268)
 
 ## [1.1.5-rc5] - 2026-04-15

--- a/src/tools/bash.test.ts
+++ b/src/tools/bash.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   BashTool,
+  getGitInspectionRepositoryError,
   getSandboxMutationBlockReason,
   shouldRunOnHostInSandboxMode,
   wrapCommandForShuru,
@@ -22,6 +23,49 @@ afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
   }
+});
+
+describe("BashTool git inspection handling", () => {
+  it("returns a clean error for git inspection commands outside a repository", async () => {
+    const dir = makeTempDir("grok-non-git-");
+    const bash = new BashTool(dir);
+
+    const result = await bash.execute("git status --short");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain(`Not a git repository: ${dir}`);
+    expect(result.error).not.toContain("fatal:");
+    expect(result.error).not.toContain("GIT_DISCOVERY_ACROSS_FILESYSTEM");
+  });
+
+  it("normalizes git repository failures inside compound commands", async () => {
+    const dir = makeTempDir("grok-non-git-");
+    const bash = new BashTool(dir);
+
+    const result = await bash.execute("pwd && git rev-parse --show-toplevel && git status --short");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain(`Not a git repository: ${dir}`);
+    expect(result.error).not.toContain("fatal:");
+    expect(result.error).not.toContain("GIT_DISCOVERY_ACROSS_FILESYSTEM");
+  });
+
+  it("does not block unrelated git commands outside a repository", () => {
+    const dir = makeTempDir("grok-non-git-");
+
+    expect(getGitInspectionRepositoryError("git init", dir)).toBeNull();
+  });
+
+  it("does not rewrite unrelated command output that mentions git repository failures", async () => {
+    const dir = makeTempDir("grok-non-git-");
+    const bash = new BashTool(dir);
+
+    const result = await bash.execute('sh -c "echo fatal: not a git repository 1>&2; exit 1"');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("fatal: not a git repository");
+    expect(result.error).not.toContain(`Not a git repository: ${dir}`);
+  });
 });
 
 describe("wrapCommandForShuru", () => {

--- a/src/tools/bash.test.ts
+++ b/src/tools/bash.test.ts
@@ -62,6 +62,17 @@ describe("BashTool git inspection handling", () => {
     expect(result.error).not.toContain(`Not a git repository: ${start}`);
   });
 
+  it("uses the tokenized target when changing directories", async () => {
+    const start = makeTempDir("grok-start-");
+    const target = makeTempDir("grok-target-");
+    const bash = new BashTool(start);
+
+    const result = await bash.execute(`  cd "${target}"`);
+
+    expect(result.success).toBe(true);
+    expect(bash.getCwd()).toBe(target);
+  });
+
   it("understands git global options before read-only subcommands", () => {
     const dir = makeTempDir("grok-non-git-");
 
@@ -72,6 +83,20 @@ describe("BashTool git inspection handling", () => {
       `Not a git repository: ${dir}`,
     );
     expect(getGitInspectionRepositoryError(`git -C ${dir} status --short`, process.cwd())).toContain(
+      `Not a git repository: ${dir}`,
+    );
+  });
+
+  it("understands shell and env prefixes before read-only git inspections", () => {
+    const dir = makeTempDir("grok-non-git-");
+
+    expect(getGitInspectionRepositoryError('bash --norc -c "git status --short"', dir)).toContain(
+      `Not a git repository: ${dir}`,
+    );
+    expect(getGitInspectionRepositoryError("FOO=bar git status --short", dir)).toContain(
+      `Not a git repository: ${dir}`,
+    );
+    expect(getGitInspectionRepositoryError("env -u FOO BAR=baz git status --short", dir)).toContain(
       `Not a git repository: ${dir}`,
     );
   });
@@ -298,6 +323,10 @@ describe("getSandboxMutationBlockReason", () => {
       "Sandbox mode blocks git commands",
     );
     expect(getSandboxMutationBlockReason('bash -c "git push"')).toContain("Sandbox mode blocks git commands");
+    expect(getSandboxMutationBlockReason('bash --norc -c "git push"')).toContain("Sandbox mode blocks git commands");
+    expect(getSandboxMutationBlockReason("FOO=bar git push")).toContain("Sandbox mode blocks git commands");
+    expect(getSandboxMutationBlockReason("env -u FOO BAR=baz git push")).toContain("Sandbox mode blocks git commands");
+    expect(getSandboxMutationBlockReason("FOO=bar git status")).toBeNull();
   });
 
   it("does not block quoted git text in unrelated commands", () => {

--- a/src/tools/bash.test.ts
+++ b/src/tools/bash.test.ts
@@ -50,6 +50,39 @@ describe("BashTool git inspection handling", () => {
     expect(result.error).not.toContain("GIT_DISCOVERY_ACROSS_FILESYSTEM");
   });
 
+  it("uses the effective directory for cd before git inspection commands", async () => {
+    const start = makeTempDir("grok-start-");
+    const target = makeTempDir("grok-target-");
+    const bash = new BashTool(start);
+
+    const result = await bash.execute(`cd ${target} && git status --short`);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain(`Not a git repository: ${target}`);
+    expect(result.error).not.toContain(`Not a git repository: ${start}`);
+  });
+
+  it("understands git global options before read-only subcommands", () => {
+    const dir = makeTempDir("grok-non-git-");
+
+    expect(getGitInspectionRepositoryError("git -c color.ui=false status", dir)).toContain(
+      `Not a git repository: ${dir}`,
+    );
+    expect(getGitInspectionRepositoryError("git --no-optional-locks status --short", dir)).toContain(
+      `Not a git repository: ${dir}`,
+    );
+    expect(getGitInspectionRepositoryError(`git -C ${dir} status --short`, process.cwd())).toContain(
+      `Not a git repository: ${dir}`,
+    );
+  });
+
+  it("does not treat quoted git inspection text as a git invocation", () => {
+    const dir = makeTempDir("grok-non-git-");
+
+    expect(getGitInspectionRepositoryError('echo "git status"', dir)).toBeNull();
+    expect(getGitInspectionRepositoryError('printf "%s\\n" "git diff"', dir)).toBeNull();
+  });
+
   it("does not block unrelated git commands outside a repository", () => {
     const dir = makeTempDir("grok-non-git-");
 
@@ -249,6 +282,8 @@ describe("getSandboxMutationBlockReason", () => {
     expect(getSandboxMutationBlockReason("git rev-parse HEAD")).toBeNull();
     expect(getSandboxMutationBlockReason("git grep foo")).toBeNull();
     expect(getSandboxMutationBlockReason("git ls-files")).toBeNull();
+    expect(getSandboxMutationBlockReason("git -C /repo status --short")).toBeNull();
+    expect(getSandboxMutationBlockReason("git --no-optional-locks diff")).toBeNull();
   });
 
   it("blocks mutating git commands", () => {
@@ -263,6 +298,10 @@ describe("getSandboxMutationBlockReason", () => {
       "Sandbox mode blocks git commands",
     );
     expect(getSandboxMutationBlockReason('bash -c "git push"')).toContain("Sandbox mode blocks git commands");
+  });
+
+  it("does not block quoted git text in unrelated commands", () => {
+    expect(getSandboxMutationBlockReason('echo "git push"')).toBeNull();
   });
 
   it("blocks git branch since it can mutate", () => {

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -6,6 +6,7 @@ import path from "path";
 import { executeEventHooks } from "../hooks/index";
 import type { CwdChangedHookInput } from "../hooks/types";
 import type { ToolResult } from "../types/index";
+import { findGitRoot } from "../utils/git-root";
 import type { SandboxMode, SandboxSettings } from "../utils/settings";
 
 const MAX_TAIL_BYTES = 8_192;
@@ -90,6 +91,11 @@ export class BashTool {
         return { success: false, error: prepared.error };
       }
 
+      const gitRepositoryError = getGitInspectionRepositoryError(command, this.cwd);
+      if (gitRepositoryError) {
+        return { success: false, error: gitRepositoryError };
+      }
+
       return await new Promise<ToolResult>((resolve) => {
         let settled = false;
         let aborted = false;
@@ -119,6 +125,11 @@ export class BashTool {
 
             const output = stdout + (stderr ? `\nSTDERR: ${stderr}` : "");
             if (err) {
+              const gitRepositoryRuntimeError = getGitRepositoryRuntimeError(command, output, this.cwd);
+              if (gitRepositoryRuntimeError) {
+                finish({ success: false, error: gitRepositoryRuntimeError });
+                return;
+              }
               const sandboxError = this.formatSandboxRuntimeError(output, err.message);
               if (sandboxError) {
                 finish({ success: false, error: sandboxError });
@@ -163,6 +174,10 @@ export class BashTool {
       if (err && typeof err === "object" && "stdout" in err) {
         const execErr = err as { stdout?: string; stderr?: string; message: string };
         const output = (execErr.stdout || "") + (execErr.stderr ? `\nSTDERR: ${execErr.stderr}` : "");
+        const gitRepositoryRuntimeError = getGitRepositoryRuntimeError(command, output, this.cwd);
+        if (gitRepositoryRuntimeError) {
+          return { success: false, error: gitRepositoryRuntimeError };
+        }
         if (output.trim()) {
           return { success: false, error: output.trim() };
         }
@@ -565,6 +580,33 @@ function getSandboxUnsupportedReason(): string | null {
     return "Shuru sandbox mode currently requires macOS on Apple Silicon.";
   }
   return null;
+}
+
+const READ_ONLY_GIT_INSPECTION_RE =
+  /^\s*(?:env\s+[A-Za-z_][A-Za-z0-9_]*(?:=\S+)?\s+)*(?:command\s+)?git\s+(?:status|diff|log|show|rev-parse|grep|ls-files)\b/;
+
+export function getGitInspectionRepositoryError(command: string, cwd: string): string | null {
+  if (!READ_ONLY_GIT_INSPECTION_RE.test(command.trim())) return null;
+  if (findGitRoot(cwd)) return null;
+
+  return formatGitRepositoryError(cwd);
+}
+
+export function getGitRepositoryRuntimeError(command: string, output: string, cwd: string): string | null {
+  if (!containsReadOnlyGitInspection(command)) return null;
+  if (!/fatal:\s+not a git repository/i.test(output)) return null;
+  return formatGitRepositoryError(cwd);
+}
+
+function containsReadOnlyGitInspection(command: string): boolean {
+  return /\bgit\s+(?:status|diff|log|show|rev-parse|grep|ls-files)\b/.test(command);
+}
+
+function formatGitRepositoryError(cwd: string): string {
+  return [
+    `Not a git repository: ${cwd}`,
+    "This git inspection command needs a repository checkout. Change into the repo root or a subdirectory before running git status, diff, log, show, rev-parse, grep, or ls-files.",
+  ].join("\n");
 }
 
 export function getSandboxMutationBlockReason(command: string, settings: SandboxSettings = {}): string | null {

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -53,7 +53,7 @@ export class BashTool {
 
   async execute(command: string, timeout = 30_000, abortSignal?: AbortSignal): Promise<ToolResult> {
     try {
-      if (command.startsWith("cd ")) {
+      if (isSimpleCdCommand(command)) {
         const dir = command
           .substring(3)
           .trim()
@@ -582,24 +582,294 @@ function getSandboxUnsupportedReason(): string | null {
   return null;
 }
 
-const READ_ONLY_GIT_INSPECTION_RE =
-  /^\s*(?:env\s+[A-Za-z_][A-Za-z0-9_]*(?:=\S+)?\s+)*(?:command\s+)?git\s+(?:status|diff|log|show|rev-parse|grep|ls-files)\b/;
+const READ_ONLY_GIT_SUBCOMMANDS = new Set(["status", "diff", "log", "show", "rev-parse", "grep", "ls-files"]);
+
+interface ShellWord {
+  type: "word";
+  value: string;
+}
+
+interface ShellOperator {
+  type: "operator";
+  value: string;
+}
+
+type ShellToken = ShellWord | ShellOperator;
+
+interface GitInvocation {
+  subcommand: string;
+  cwd: string;
+  explicitGitDir: boolean;
+}
 
 export function getGitInspectionRepositoryError(command: string, cwd: string): string | null {
-  if (!READ_ONLY_GIT_INSPECTION_RE.test(command.trim())) return null;
-  if (findGitRoot(cwd)) return null;
+  const inspection = findReadOnlyGitInspection(command, cwd);
+  if (!inspection) return null;
+  if (inspection.explicitGitDir) return null;
+  if (findGitRoot(inspection.cwd)) return null;
 
-  return formatGitRepositoryError(cwd);
+  return formatGitRepositoryError(inspection.cwd);
 }
 
 export function getGitRepositoryRuntimeError(command: string, output: string, cwd: string): string | null {
-  if (!containsReadOnlyGitInspection(command)) return null;
+  const inspection = findReadOnlyGitInspection(command, cwd);
+  if (!inspection) return null;
   if (!/fatal:\s+not a git repository/i.test(output)) return null;
-  return formatGitRepositoryError(cwd);
+  return formatGitRepositoryError(inspection.cwd);
 }
 
-function containsReadOnlyGitInspection(command: string): boolean {
-  return /\bgit\s+(?:status|diff|log|show|rev-parse|grep|ls-files)\b/.test(command);
+function findReadOnlyGitInspection(command: string, cwd: string): GitInvocation | null {
+  return findGitInvocation(command, cwd, (subcommand) => READ_ONLY_GIT_SUBCOMMANDS.has(subcommand));
+}
+
+function findGitInvocation(
+  command: string,
+  cwd: string,
+  subcommandMatches: (subcommand: string) => boolean,
+  depth = 0,
+): GitInvocation | null {
+  if (depth > 3) return null;
+
+  let effectiveCwd = cwd;
+  const tokens = tokenizeShell(command);
+
+  for (const segment of splitShellSegments(tokens)) {
+    const words = segment.filter((token): token is ShellWord => token.type === "word").map((token) => token.value);
+    if (words.length === 0) continue;
+
+    const shellCommand = extractShellCommandString(words);
+    if (shellCommand !== null) {
+      const nested = findGitInvocation(shellCommand, effectiveCwd, subcommandMatches, depth + 1);
+      if (nested) return nested;
+      continue;
+    }
+
+    const cdTarget = getSimpleCdTarget(words);
+    if (cdTarget !== null) {
+      effectiveCwd = resolveShellPath(effectiveCwd, cdTarget);
+      continue;
+    }
+
+    const commandIndex = getShellCommandIndex(words);
+    if (commandIndex === null || !isGitExecutable(words[commandIndex])) continue;
+
+    const invocation = parseGitInvocation(words.slice(commandIndex + 1), effectiveCwd);
+    if (invocation && subcommandMatches(invocation.subcommand)) return invocation;
+  }
+
+  return null;
+}
+
+function tokenizeShell(command: string): ShellToken[] {
+  const tokens: ShellToken[] = [];
+  let current = "";
+  let quote: "'" | '"' | null = null;
+
+  const pushWord = () => {
+    if (current.length > 0) {
+      tokens.push({ type: "word", value: current });
+      current = "";
+    }
+  };
+
+  for (let i = 0; i < command.length; i++) {
+    const char = command[i];
+
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+      } else if (quote === '"' && char === "\\" && i + 1 < command.length) {
+        current += command[++i];
+      } else {
+        current += char;
+      }
+      continue;
+    }
+
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+
+    if (char === "\\" && i + 1 < command.length) {
+      current += command[++i];
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      pushWord();
+      continue;
+    }
+
+    const next = command[i + 1];
+    if ((char === "&" && next === "&") || (char === "|" && next === "|")) {
+      pushWord();
+      tokens.push({ type: "operator", value: `${char}${next}` });
+      i++;
+      continue;
+    }
+
+    if (char === ";" || char === "|") {
+      pushWord();
+      tokens.push({ type: "operator", value: char });
+      continue;
+    }
+
+    current += char;
+  }
+
+  pushWord();
+  return tokens;
+}
+
+function splitShellSegments(tokens: ShellToken[]): ShellToken[][] {
+  const segments: ShellToken[][] = [];
+  let current: ShellToken[] = [];
+
+  for (const token of tokens) {
+    if (token.type === "operator") {
+      if (current.length > 0) {
+        segments.push(current);
+        current = [];
+      }
+    } else {
+      current.push(token);
+    }
+  }
+
+  if (current.length > 0) segments.push(current);
+  return segments;
+}
+
+function extractShellCommandString(words: string[]): string | null {
+  const command = path.basename(words[0] ?? "");
+  if (command !== "sh" && command !== "bash" && command !== "zsh") return null;
+
+  for (let i = 1; i < words.length; i++) {
+    const word = words[i];
+    if (word === "-c" || word.endsWith("c")) {
+      return words[i + 1] ?? null;
+    }
+  }
+
+  return null;
+}
+
+function getSimpleCdTarget(words: string[]): string | null {
+  if (words[0] !== "cd") return null;
+  const target = words[1] ?? os.homedir();
+  if (target.includes("$") || target.includes("*") || target.includes("?")) return null;
+  return target;
+}
+
+function getShellCommandIndex(words: string[]): number | null {
+  let index = 0;
+
+  if (words[index] === "env") {
+    index++;
+    while (index < words.length && (isEnvAssignment(words[index]) || words[index].startsWith("-"))) {
+      index++;
+    }
+  }
+
+  if (words[index] === "command") index++;
+
+  return index < words.length ? index : null;
+}
+
+function isEnvAssignment(word: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*=.*$/u.test(word);
+}
+
+function isGitExecutable(word: string): boolean {
+  return path.basename(word) === "git";
+}
+
+function parseGitInvocation(words: string[], cwd: string): GitInvocation | null {
+  let index = 0;
+  let effectiveCwd = cwd;
+  let explicitGitDir = false;
+
+  while (index < words.length) {
+    const word = words[index];
+
+    if (word === "-C") {
+      const target = words[index + 1];
+      if (!target) return null;
+      effectiveCwd = resolveShellPath(effectiveCwd, target);
+      index += 2;
+      continue;
+    }
+
+    if (word.startsWith("-C") && word.length > 2) {
+      effectiveCwd = resolveShellPath(effectiveCwd, word.slice(2));
+      index++;
+      continue;
+    }
+
+    if (word === "-c") {
+      index += 2;
+      continue;
+    }
+
+    if (word.startsWith("-c") && word.includes("=")) {
+      index++;
+      continue;
+    }
+
+    if (word === "--git-dir") {
+      explicitGitDir = true;
+      index += 2;
+      continue;
+    }
+
+    if (word.startsWith("--git-dir=")) {
+      explicitGitDir = true;
+      index++;
+      continue;
+    }
+
+    if (word === "--work-tree") {
+      const target = words[index + 1];
+      if (!target) return null;
+      effectiveCwd = resolveShellPath(effectiveCwd, target);
+      index += 2;
+      continue;
+    }
+
+    if (word.startsWith("--work-tree=")) {
+      effectiveCwd = resolveShellPath(effectiveCwd, word.slice("--work-tree=".length));
+      index++;
+      continue;
+    }
+
+    if (word.startsWith("--")) {
+      index++;
+      continue;
+    }
+
+    if (word.startsWith("-")) {
+      index++;
+      continue;
+    }
+
+    return { subcommand: word, cwd: effectiveCwd, explicitGitDir };
+  }
+
+  return null;
+}
+
+function resolveShellPath(cwd: string, target: string): string {
+  if (target === "~") return os.homedir();
+  if (target.startsWith("~/")) return path.join(os.homedir(), target.slice(2));
+  return path.resolve(cwd, target);
+}
+
+function isSimpleCdCommand(command: string): boolean {
+  const tokens = tokenizeShell(command);
+  if (tokens.some((token) => token.type === "operator")) return false;
+  const words = tokens.filter((token): token is ShellWord => token.type === "word").map((token) => token.value);
+  return words[0] === "cd" && words.length <= 2;
 }
 
 function formatGitRepositoryError(cwd: string): string {
@@ -613,7 +883,8 @@ export function getSandboxMutationBlockReason(command: string, settings: Sandbox
   const trimmed = command.trim();
   if (!trimmed) return null;
 
-  if (/\bgit\s+/.test(trimmed) && !/\bgit\s+(status|diff|log|show|rev-parse|grep|ls-files)\b/.test(trimmed)) {
+  const gitInvocation = findGitInvocation(trimmed, process.cwd(), () => true);
+  if (gitInvocation && !READ_ONLY_GIT_SUBCOMMANDS.has(gitInvocation.subcommand)) {
     return [
       "Sandbox mode blocks git commands that mutate repository state because Shuru guest-side workspace changes do not persist back to the host.",
       "Disable sandbox mode to run persistent git mutations on the real workspace.",

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -53,13 +53,10 @@ export class BashTool {
 
   async execute(command: string, timeout = 30_000, abortSignal?: AbortSignal): Promise<ToolResult> {
     try {
-      if (isSimpleCdCommand(command)) {
-        const dir = command
-          .substring(3)
-          .trim()
-          .replace(/^["']|["']$/g, "");
+      const cdTarget = getSimpleCdCommandTarget(command);
+      if (cdTarget !== null) {
         try {
-          const nextCwd = path.resolve(this.cwd, dir);
+          const nextCwd = path.resolve(this.cwd, cdTarget);
           const info = await stat(nextCwd);
           if (!info.isDirectory()) {
             return { success: false, error: `Cannot change directory: ${nextCwd} is not a directory` };
@@ -747,7 +744,7 @@ function extractShellCommandString(words: string[]): string | null {
 
   for (let i = 1; i < words.length; i++) {
     const word = words[i];
-    if (word === "-c" || word.endsWith("c")) {
+    if (isShellCommandOption(word)) {
       return words[i + 1] ?? null;
     }
   }
@@ -755,8 +752,15 @@ function extractShellCommandString(words: string[]): string | null {
   return null;
 }
 
+function isShellCommandOption(word: string): boolean {
+  if (word === "-c") return true;
+  if (!word.startsWith("-") || word.startsWith("--")) return false;
+  return word.slice(1).includes("c");
+}
+
 function getSimpleCdTarget(words: string[]): string | null {
   if (words[0] !== "cd") return null;
+  if (words.length > 2) return null;
   const target = words[1] ?? os.homedir();
   if (target.includes("$") || target.includes("*") || target.includes("?")) return null;
   return target;
@@ -765,16 +769,67 @@ function getSimpleCdTarget(words: string[]): string | null {
 function getShellCommandIndex(words: string[]): number | null {
   let index = 0;
 
+  index = skipEnvAssignments(words, index);
+
   if (words[index] === "env") {
-    index++;
-    while (index < words.length && (isEnvAssignment(words[index]) || words[index].startsWith("-"))) {
-      index++;
-    }
+    index = skipEnvCommandPrefix(words, index + 1);
   }
 
-  if (words[index] === "command") index++;
+  index = skipEnvAssignments(words, index);
+
+  if (words[index] === "command") {
+    index++;
+    index = skipEnvAssignments(words, index);
+  }
 
   return index < words.length ? index : null;
+}
+
+function skipEnvAssignments(words: string[], start: number): number {
+  let index = start;
+  while (index < words.length && isEnvAssignment(words[index])) index++;
+  return index;
+}
+
+function skipEnvCommandPrefix(words: string[], start: number): number {
+  let index = start;
+
+  while (index < words.length) {
+    const word = words[index];
+
+    if (word === "--") {
+      return index + 1;
+    }
+
+    if (isEnvAssignment(word)) {
+      index++;
+      continue;
+    }
+
+    if (word === "-i" || word === "-0" || word === "--ignore-environment" || word === "--null") {
+      index++;
+      continue;
+    }
+
+    if (word === "-u" || word === "--unset" || word === "-C" || word === "--chdir") {
+      index += 2;
+      continue;
+    }
+
+    if (word.startsWith("--unset=") || word.startsWith("--chdir=")) {
+      index++;
+      continue;
+    }
+
+    if (word.startsWith("-")) {
+      index++;
+      continue;
+    }
+
+    return index;
+  }
+
+  return index;
 }
 
 function isEnvAssignment(word: string): boolean {
@@ -865,11 +920,11 @@ function resolveShellPath(cwd: string, target: string): string {
   return path.resolve(cwd, target);
 }
 
-function isSimpleCdCommand(command: string): boolean {
+function getSimpleCdCommandTarget(command: string): string | null {
   const tokens = tokenizeShell(command);
-  if (tokens.some((token) => token.type === "operator")) return false;
+  if (tokens.some((token) => token.type === "operator")) return null;
   const words = tokens.filter((token): token is ShellWord => token.type === "word").map((token) => token.value);
-  return words[0] === "cd" && words.length <= 2;
+  return getSimpleCdTarget(words);
 }
 
 function formatGitRepositoryError(cwd: string): string {

--- a/src/utils/git-root.test.ts
+++ b/src/utils/git-root.test.ts
@@ -1,0 +1,57 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, describe, expect, it } from "vitest";
+import { findGitRoot } from "./git-root";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeValidGitDir(root: string): void {
+  fs.mkdirSync(path.join(root, ".git", "objects"), { recursive: true });
+  fs.mkdirSync(path.join(root, ".git", "refs"), { recursive: true });
+  fs.writeFileSync(path.join(root, ".git", "HEAD"), "ref: refs/heads/main\n");
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("findGitRoot", () => {
+  it("finds a parent with a valid git directory", () => {
+    const root = makeTempDir("grok-git-root-");
+    const nested = path.join(root, "packages", "app");
+    writeValidGitDir(root);
+    fs.mkdirSync(nested, { recursive: true });
+
+    expect(findGitRoot(nested)).toBe(root);
+  });
+
+  it("ignores empty .git directories that real git does not accept", () => {
+    const root = makeTempDir("grok-empty-git-root-");
+    const nested = path.join(root, "packages", "app");
+    fs.mkdirSync(path.join(root, ".git"), { recursive: true });
+    fs.mkdirSync(nested, { recursive: true });
+
+    expect(findGitRoot(nested)).toBeNull();
+  });
+
+  it("supports worktree-style .git files", () => {
+    const root = makeTempDir("grok-git-file-root-");
+    const gitDir = path.join(root, ".actual-git");
+    const nested = path.join(root, "packages", "app");
+    fs.mkdirSync(gitDir, { recursive: true });
+    fs.writeFileSync(path.join(gitDir, "HEAD"), "ref: refs/heads/main\n");
+    fs.writeFileSync(path.join(root, ".git"), "gitdir: .actual-git\n");
+    fs.mkdirSync(nested, { recursive: true });
+
+    expect(findGitRoot(nested)).toBe(root);
+  });
+});

--- a/src/utils/git-root.ts
+++ b/src/utils/git-root.ts
@@ -6,12 +6,39 @@ export function findGitRoot(start: string): string | null {
 
   while (true) {
     const gitPath = path.join(current, ".git");
-    if (fs.existsSync(gitPath)) {
+    if (isValidGitMarker(gitPath)) {
       return current;
     }
 
     const parent = path.dirname(current);
     if (parent === current) return null;
     current = parent;
+  }
+}
+
+function isValidGitMarker(gitPath: string): boolean {
+  try {
+    const stat = fs.statSync(gitPath);
+    if (stat.isDirectory()) return isValidGitDir(gitPath);
+    if (!stat.isFile()) return false;
+
+    const content = fs.readFileSync(gitPath, "utf8").trim();
+    const match = content.match(/^gitdir:\s*(.+)$/i);
+    if (!match?.[1]) return false;
+
+    const gitDir = path.resolve(path.dirname(gitPath), match[1]);
+    return isValidGitDir(gitDir);
+  } catch {
+    return false;
+  }
+}
+
+function isValidGitDir(gitDir: string): boolean {
+  try {
+    const headPath = path.join(gitDir, "HEAD");
+    if (!fs.statSync(headPath).isFile()) return false;
+    return fs.readFileSync(headPath, "utf8").trim().length > 0;
+  } catch {
+    return false;
   }
 }

--- a/src/utils/instructions.test.ts
+++ b/src/utils/instructions.test.ts
@@ -12,6 +12,12 @@ function writeFile(filePath: string, content: string): void {
   fs.writeFileSync(filePath, content);
 }
 
+function writeValidGitDir(root: string): void {
+  fs.mkdirSync(path.join(root, ".git", "objects"), { recursive: true });
+  fs.mkdirSync(path.join(root, ".git", "refs"), { recursive: true });
+  fs.writeFileSync(path.join(root, ".git", "HEAD"), "ref: refs/heads/main\n");
+}
+
 async function importLoadCustomInstructions(mockedHome?: string) {
   vi.resetModules();
   vi.doUnmock("os");
@@ -53,7 +59,7 @@ describe("loadCustomInstructions", () => {
     const home = makeTempDir("grok-home-");
     const repoRoot = makeTempDir("grok-repo-");
     const cwd = path.join(repoRoot, "pkg", "feature");
-    fs.mkdirSync(path.join(repoRoot, ".git"));
+    writeValidGitDir(repoRoot);
     fs.mkdirSync(cwd, { recursive: true });
 
     writeFile(path.join(home, ".grok", "AGENTS.md"), "global instructions");
@@ -71,7 +77,7 @@ describe("loadCustomInstructions", () => {
     const home = makeTempDir("grok-home-");
     const repoRoot = makeTempDir("grok-repo-");
     const cwd = path.join(repoRoot, "nested");
-    fs.mkdirSync(path.join(repoRoot, ".git"));
+    writeValidGitDir(repoRoot);
     fs.mkdirSync(cwd, { recursive: true });
 
     writeFile(path.join(repoRoot, "AGENTS.md"), "root instructions");

--- a/src/utils/skills.test.ts
+++ b/src/utils/skills.test.ts
@@ -22,6 +22,12 @@ function writeSkill(root: string, name: string, description: string): void {
   );
 }
 
+function writeValidGitDir(root: string): void {
+  fs.mkdirSync(path.join(root, ".git", "objects"), { recursive: true });
+  fs.mkdirSync(path.join(root, ".git", "refs"), { recursive: true });
+  fs.writeFileSync(path.join(root, ".git", "HEAD"), "ref: refs/heads/main\n");
+}
+
 afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
@@ -31,7 +37,7 @@ afterEach(() => {
 describe("discoverSkills", () => {
   it("discovers project skills from parent directories up to the git root", () => {
     const repoRoot = makeTempDir("grok-skills-root-");
-    fs.mkdirSync(path.join(repoRoot, ".git"));
+    writeValidGitDir(repoRoot);
     const nested = path.join(repoRoot, "tmp", "app");
     fs.mkdirSync(nested, { recursive: true });
 
@@ -44,7 +50,7 @@ describe("discoverSkills", () => {
 
   it("lets nearer project skills override parent project skills", () => {
     const repoRoot = makeTempDir("grok-skills-override-");
-    fs.mkdirSync(path.join(repoRoot, ".git"));
+    writeValidGitDir(repoRoot);
     const nested = path.join(repoRoot, "tmp", "app");
     fs.mkdirSync(nested, { recursive: true });
 


### PR DESCRIPTION
## Purpose

Make git inspection failures actionable when Grok is run outside a repository, without changing normal shell command behavior.

## Scope

- Adds validated `.git` root detection, including worktree-style `.git` files.
- Normalizes read-only git inspection failures (`status`, `diff`, `log`, `show`, `rev-parse`, `grep`, `ls-files`) into a clear non-repository message.
- Preserves mutating commands such as `git init`.
- Preserves unrelated command failures that only happen to print `fatal: not a git repository`.

## Review Notes

This is an independent PR against `main`.

Primary files:
- `src/utils/git-root.ts`
- `src/tools/bash.ts`
- `src/utils/git-root.test.ts`
- `src/tools/bash.test.ts`

## Risk

Low. The change is limited to BashTool error handling and git-root detection. It only rewrites output for commands containing read-only git inspection subcommands.

## Tested

- `bun run test -- src/tools/bash.test.ts src/utils/git-root.test.ts src/utils/instructions.test.ts src/utils/skills.test.ts` (47 tests)
- `git diff --check`
- `bun run typecheck`
- `bun run test` (44 files, 237 tests)
- `bun run lint` (passes with existing unrelated warnings)
- `bun run build`
- BashTool non-repo `git status` smoke returned the new actionable error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `BashTool` command handling and adds custom shell parsing to detect git invocations, which could misclassify edge-case commands and alter errors returned for some shell strings.
> 
> **Overview**
> Improves `BashTool` UX when running read-only git inspections (e.g. `status`, `diff`, `log`, `show`, `rev-parse`, `grep`, `ls-files`) outside a checkout by returning a consistent, actionable `Not a git repository` message instead of raw Git discovery output, including for compound commands and `cd`/`-C`/env-prefixed invocations.
> 
> Strengthens git-root detection to validate real git markers (including worktree-style `.git` files) and updates sandbox-mode git mutation blocking to use the same invocation parsing rather than regexes; adds targeted tests and updates existing tests to create valid `.git` structures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 597cc758ed1c240933e4d8a030799fa8d1fdb073. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->