### PR TITLE
fix: keep local runtime state out of npm packages

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -55,6 +55,7 @@ tests/
 *.spec.ts
 dist/**/*.test.*
 dist/**/*.spec.*
+dist/grok-standalone*
 coverage/
 .nyc_output/
 

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,9 @@
 # Source files (only include built dist/)
 src/
 tsconfig.json
+vitest.config.ts
+biome.json
+test-vertex-integration.ts
 
 # Lock files from other package managers
 yarn.lock
@@ -50,6 +53,8 @@ tests/
 *.test.ts
 *.spec.js
 *.spec.ts
+dist/**/*.test.*
+dist/**/*.spec.*
 coverage/
 .nyc_output/
 
@@ -61,6 +66,15 @@ docs/
 # Git files
 .git/
 .gitignore
+
+# Local development, agent, and editor runtime state
+.cursor/
+.omx/
+.codex/
+.agents/
+.claude/
+.grok/
+.husky/
 
 # CI/CD files
 .github/

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   },
   "scripts": {
     "dev": "bun run src/index.ts",
-    "build": "tsc",
+    "clean:dist": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
+    "build": "bun run clean:dist && tsc",
     "build:binary": "bun build --compile --outfile dist/grok-standalone ./src/index.ts",
     "start": "bun run dist/index.js",
     "typecheck": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,10 @@
   },
   "scripts": {
     "dev": "bun run src/index.ts",
-    "clean:dist": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
+    "clean:dist": "bun -e \"import { rmSync } from 'node:fs'; rmSync('dist', { recursive: true, force: true })\"",
     "build": "bun run clean:dist && tsc",
     "build:binary": "bun build --compile --outfile dist/grok-standalone ./src/index.ts",
+    "prepack": "bun run build",
     "start": "bun run dist/index.js",
     "typecheck": "tsc --noEmit",
     "test": "bunx vitest run",


### PR DESCRIPTION
## Purpose

Keep npm package contents clean and deterministic when packing or installing from a developer checkout.

## Scope

- Excludes local runtime/editor/agent state from npm tarballs.
- Excludes generated test/spec artifacts and dev-only config files from package contents.
- Keeps package contents focused on built `dist/`, `package.json`, README, license, and install script.
- Adds `clean:dist` and runs it before `tsc` so stale build outputs from another branch cannot be packed.

## Review Notes

This is an independent PR against `main`.

Primary files:
- `.npmignore`
- `package.json`

## Risk

Low. This changes package/build hygiene only. Runtime code is not changed.

## Tested

- `git diff --check`
- `bun run build`
- `npm pack --dry-run --json`

Pack result on this branch:
- 286 files
- 327 KB package size
- zero matches for `.omx`, `.cursor`, `.codex`, `.agents`, `.husky`, test/spec artifacts, or stale Vertex build outputs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes npm packaging/build hygiene (ignore patterns and prepack/build scripts) and does not touch runtime code paths.
> 
> **Overview**
> Keeps published npm tarballs deterministic by expanding `.npmignore` to exclude dev-only configs, generated test/spec artifacts under `dist/`, standalone binary outputs, and local editor/agent runtime directories.
> 
> Updates `package.json` to add `clean:dist`, run it before `tsc` in `build`, and run `build` on `prepack` to prevent stale `dist/` outputs from being packed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 307e638a0d98513b349fcb01dac81056cfc8d7b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->