### PR TITLE
feat: update Grok models and vision handling

### DIFF
--- a/.cursor/rules/development-workflow.mdc
+++ b/.cursor/rules/development-workflow.mdc
@@ -42,7 +42,7 @@ bun run start
 |----|----|----|
 | `GROK_API_KEY` | Yes | API key for xAI Grok |
 | `GROK_BASE_URL` | No | Custom API endpoint (default: `https://api.x.ai/v1`) |
-| `GROK_MODEL` | No | Model override (default: `grok-4-1-fast`) |
+| `GROK_MODEL` | No | Model override (default: `grok-4.3`) |
 | `GROK_MAX_TOKENS` | No | Max tokens per response (default: 16384) |
 
 Copy `.env.example` to `.env` and fill in your values.

--- a/.cursor/rules/project-overview.mdc
+++ b/.cursor/rules/project-overview.mdc
@@ -53,12 +53,11 @@ src/
 
 ## Latest Grok Models
 
-- grok-4-0709 (flagship reasoning)
-- grok-4.20-beta-0309 (multi-agent, 2M context)
-- grok-4-fast (fast reasoning, 2M context)
-- grok-4-1-fast (latest fast, 2M context)
-- grok-code-fast-1 (code optimized)
-- grok-3, grok-3-mini
+- grok-4.3 (recommended flagship reasoning)
+- grok-4.20-non-reasoning (recommended non-reasoning)
+- grok-4.20-multi-agent-0309 (multi-agent, 2M context)
+- grok-4.20-0309-reasoning (reasoning, 2M context)
+- grok-3-mini (compact model with reasoning effort controls)
 
 ## CI/CD
 

--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,8 @@ GROK_API_KEY=your_grok_api_key_here
 # Optional: Custom API base URL (default: https://api.x.ai/v1)
 # GROK_BASE_URL=https://api.x.ai/v1
 
-# Optional: Default model (default: grok-4-1-fast-reasoning)
-# GROK_MODEL=grok-4-1-fast-reasoning
+# Optional: Default model (default: grok-4.3)
+# GROK_MODEL=grok-4.3
 
 # Optional: Max tokens per response (default: 16384)
 # GROK_MAX_TOKENS=16384

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# grok-cli — an open-source coding agent for the Grok API
+# grok-cli: an open-source coding agent for the Grok API
 
-[![CI](https://github.com/superagent-ai/grok-cli/actions/workflows/typecheck.yml/badge.svg)](https://github.com/superagent-ai/grok-cli/actions/workflows/typecheck.yml)
-[![npm](https://img.shields.io/npm/v/grok-dev.svg)](https://www.npmjs.com/package/grok-dev)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5.9-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
-[![Bun](https://img.shields.io/badge/Bun-1.x-000000?logo=bun&logoColor=white)](https://bun.sh/)
+[CI](https://github.com/superagent-ai/grok-cli/actions/workflows/typecheck.yml)
+[npm](https://www.npmjs.com/package/grok-dev)
+[License: MIT](./LICENSE)
+[TypeScript](https://www.typescriptlang.org/)
+[Bun](https://bun.sh/)
 
 > **Disclaimer:** This project is community-built, open-source, and **not affiliated with, endorsed by, or sponsored by xAI Corp.** "Grok" is a trademark of xAI Corp. This tool uses the publicly available Grok API.
 
@@ -173,19 +173,19 @@ You keep using a text model for the session, and Grok saves generated media unde
 
 | Thing                             | What it means                                                                                                                                                                                                              |
 | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Built for the Grok API**        | Defaults tuned for the xAI API; models like `**grok-code-fast-1`**, `**grok-4-1-fast-reasoning**`, `**grok-4.20-multi-agent-0309**`, plus flagship and fast variants—run `grok models` for the full menu.                         |
-| **X + web search**                | `**search_x`** and `**search_web**` tools—live posts and docs without pretending the internet stopped in 2023.                                                                                                             |
-| **Media generation**              | Built-in `**generate_image`** and `**generate_video**` tools for text-to-image, image editing, text-to-video, and image-to-video flows. Generated files are saved locally so you can reuse them after the xAI URLs expire. |
-| **Sub-agents (default behavior)** | Foreground `**task`** delegation (e.g. explore, general, or computer) plus background `**delegate**` for read-only deep dives—parallelize like you mean it.                                                                |
-| **Verify**                        | `**/verify`** or `**--verify**` — inspects your app, builds, tests, boots it, and runs browser smoke checks in a sandboxed environment. Screenshots and video included.                                                    |
-| **Computer use**                  | Built-in `**computer`** sub-agent for host desktop automation via `**agent-desktop**`. It prefers semantic accessibility snapshots and stable refs, with screenshots saved under `**.grok/computer/**` when requested.     |
-| **Custom sub-agents**             | Define named agents with `**subAgents`** in `**~/.grok/user-settings.json**` and manage them from the TUI with `**/agents**`.                                                                                              |
+| **Built for the Grok API**        | Defaults tuned for the xAI API; models like `grok-4.3`, `grok-4.20-non-reasoning`, `grok-4.20-multi-agent-0309`, plus current flagship and multi-agent variants—run `grok models` for the full menu.                       |
+| **X + web search**                | `**search_x`** and `**search_web`** tools—live posts and docs without pretending the internet stopped in 2023.                                                                                                             |
+| **Media generation**              | Built-in `**generate_image`** and `**generate_video`** tools for text-to-image, image editing, text-to-video, and image-to-video flows. Generated files are saved locally so you can reuse them after the xAI URLs expire. |
+| **Sub-agents (default behavior)** | Foreground `**task`** delegation (e.g. explore, general, or computer) plus background `**delegate`** for read-only deep dives—parallelize like you mean it.                                                                |
+| **Verify**                        | `**/verify`** or `**--verify`** — inspects your app, builds, tests, boots it, and runs browser smoke checks in a sandboxed environment. Screenshots and video included.                                                    |
+| **Computer use**                  | Built-in `**computer`** sub-agent for host desktop automation via `**agent-desktop`**. It prefers semantic accessibility snapshots and stable refs, with screenshots saved under `**.grok/computer/**` when requested.     |
+| **Custom sub-agents**             | Define named agents with `**subAgents`** in `**~/.grok/user-settings.json`** and manage them from the TUI with `**/agents**`.                                                                                              |
 | **Remote control**                | Pair **Telegram** from the TUI (`/remote-control` → Telegram): DM your bot, `**/pair`**, approve the code in-terminal. Keep the CLI running while you ping it from your phone.                                             |
 | **No “mystery meat” UI**          | OpenTUI React terminal UI—fast, keyboard-driven, not whatever glitchy thing you’re thinking of.                                                                                                                            |
-| **Skills**                        | Agent Skills under `**.agents/skills/<name>/SKILL.md`** (project) or `**~/.agents/skills/**` (user). Use `**/skills**` in the TUI to list what’s installed.                                                                |
-| **MCPs**                          | Extend with Model Context Protocol servers—configure via `**/mcps`** in the TUI or `**.grok/settings.json**` (`mcpServers`).                                                                                               |
+| **Skills**                        | Agent Skills under `**.agents/skills/<name>/SKILL.md`** (project) or `**~/.agents/skills/`** (user). Use `**/skills**` in the TUI to list what’s installed.                                                                |
+| **MCPs**                          | Extend with Model Context Protocol servers—configure via `**/mcps`** in the TUI or `**.grok/settings.json`** (`mcpServers`).                                                                                               |
 | **Sessions**                      | Conversations persist; `**--session latest`** picks up where you left off.                                                                                                                                                 |
-| **Headless**                      | `**--prompt`** / `**-p**` for non-interactive runs—pipe it, script it, bench it.                                                                                                                                           |
+| **Headless**                      | `**--prompt`** / `**-p`** for non-interactive runs—pipe it, script it, bench it.                                                                                                                                           |
 | **Hackable**                      | TypeScript, clear agent loop, bash-first tools—fork it, shamelessly.                                                                                                                                                       |
 
 
@@ -228,7 +228,7 @@ Optional `**subAgents**` — custom foreground sub-agents. Each entry needs `**n
   "subAgents": [
     {
       "name": "security-review",
-      "model": "grok-code-fast-1",
+      "model": "grok-4.3",
       "instruction": "Prioritize security implications and suggest concrete fixes."
     }
   ]
@@ -320,7 +320,7 @@ Hook commands receive JSON on **stdin** (event details) and can return JSON on *
 
 ## Instructions & project brain
 
-- `**AGENTS.md**` — merged from git root down to your cwd (Codex-style; see repo docs). `**AGENTS.override.md**` wins per directory when present.
+- `**AGENTS.md`** — merged from git root down to your cwd (Codex-style; see repo docs). `**AGENTS.override.md**` wins per directory when present.
 
 ---
 
@@ -350,7 +350,7 @@ All settings are saved in `~/.grok/user-settings.json` (user) and `.grok/setting
 
 ### Verify
 
-Run `**/verify`** in the TUI or `**--verify**` on the CLI to verify your app locally:
+Run `**/verify`** in the TUI or `**--verify`** on the CLI to verify your app locally:
 
 ```bash
 grok --verify
@@ -370,6 +370,7 @@ Common issues and solutions:
 **Install script fails on macOS**
 
 Make sure you have a modern shell and `curl` available:
+
 ```bash
 # Verify curl is installed
 which curl
@@ -381,6 +382,7 @@ bash -c "$(curl -fsSL https://raw.githubusercontent.com/superagent-ai/grok-cli/m
 **Bun not found**
 
 The install script bundles Bun, but if you want to use your own:
+
 ```bash
 curl -fsSL https://bun.sh/install | bash
 bun add -g grok-dev
@@ -391,6 +393,7 @@ bun add -g grok-dev
 **"Missing GROK_API_KEY" error**
 
 Set your API key using one of these methods:
+
 ```bash
 # Environment variable
 export GROK_API_KEY=your_key_here
@@ -406,6 +409,7 @@ Get your API key from [x.ai](https://x.ai).
 **UI doesn't render correctly**
 
 Try a different terminal emulator. Recommended:
+
 - WezTerm (cross-platform)
 - Alacritty (cross-platform)
 - Ghostty (macOS/Linux)
@@ -439,7 +443,7 @@ If you're on Intel Mac or Linux, sandbox mode is not available. Use standard mod
 **Slow response times**
 
 - Check your network connection to x.ai API
-- Try `grok-code-fast-1` model for faster responses
+- Try `grok-4.20-non-reasoning` for non-reasoning workloads
 - Reduce `--max-tool-rounds` for headless runs
 
 **High memory usage**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grok-dev",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "An open-source AI coding agent powered by Grok, built with Bun and OpenTUI.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -99,8 +99,8 @@ import { containsEncryptedReasoning, sanitizeModelMessages } from "./reasoning";
 import { buildVisionUserMessages } from "./vision-input";
 
 const MAX_TOOL_ROUNDS = 400;
-const VISION_MODEL = "grok-4-1-fast-reasoning";
-const COMPUTER_MODEL = "grok-4.20-0309-reasoning";
+const VISION_MODEL = "grok-4.3";
+const COMPUTER_MODEL = "grok-4.3";
 
 interface AgentOptions {
   persistSession?: boolean;
@@ -1839,7 +1839,8 @@ export class Agent {
     await this.fireHook(promptInput, signal).catch(() => {});
 
     await this.consumeBackgroundNotifications();
-    const userModelMessage: ModelMessage = { role: "user", content: userMessage };
+    const userModelMessages = await buildVisionUserMessages(userMessage, this.bash.getCwd(), signal);
+    const userModelMessage = userModelMessages[0] ?? ({ role: "user", content: userMessage } satisfies ModelMessage);
     this.messages.push(userModelMessage);
     this.messageSeqs.push(null);
 

--- a/src/agent/batch-mode.test.ts
+++ b/src/agent/batch-mode.test.ts
@@ -109,7 +109,7 @@ describe("Agent batch mode", () => {
         childMessages: [{ role: "user", content: "Do the thing" }],
         childSystem: "system",
         childRuntime: {
-          modelId: "grok-4-1-fast-reasoning",
+          modelId: "grok-4.3",
           modelInfo: {
             supportsClientTools: false,
             supportsMaxOutputTokens: true,

--- a/src/agent/recap.test.ts
+++ b/src/agent/recap.test.ts
@@ -5,7 +5,7 @@ async function importAgentModuleWithRecapMocks() {
 
   const generateRecap = vi.fn(async () => ({
     recap: "Recovered the latest session state.",
-    modelId: "grok-4-1-fast-non-reasoning",
+    modelId: "grok-4.20-non-reasoning",
     usage: {
       inputTokens: 10,
       outputTokens: 4,
@@ -83,7 +83,7 @@ describe("Agent session recap", () => {
       workspaceId: "workspace-1",
       title: null,
       recap: null,
-      model: "grok-4-1-fast",
+      model: "grok-4.3",
       mode: "agent",
       cwdAtStart: process.cwd(),
       cwdLast: process.cwd(),

--- a/src/agent/vision-input.test.ts
+++ b/src/agent/vision-input.test.ts
@@ -38,9 +38,10 @@ describe("buildVisionUserMessages", () => {
   });
 
   it("recognizes shell-escaped screenshot paths", async () => {
-    const imagePath = path.join(tempDir, "Screenshot 2026-05-06 at 10.02.18.png");
+    const imageName = "Screenshot 2026-05-06 at 10.02.18.png";
+    const imagePath = path.join(tempDir, imageName);
     fs.writeFileSync(imagePath, Buffer.from([1, 2, 3, 4]));
-    const escapedPath = imagePath.replace(/ /g, "\\ ");
+    const escapedPath = path.join(tempDir, "Screenshot\\ 2026-05-06\\ at\\ 10.02.18.png");
 
     const messages = await buildVisionUserMessages(`${escapedPath}\nExplain this image`, tempDir);
 

--- a/src/agent/vision-input.test.ts
+++ b/src/agent/vision-input.test.ts
@@ -36,4 +36,23 @@ describe("buildVisionUserMessages", () => {
       text: `Validate the image at ${imagePath}`,
     });
   });
+
+  it("recognizes shell-escaped screenshot paths", async () => {
+    const imagePath = path.join(tempDir, "Screenshot 2026-05-06 at 10.02.18.png");
+    fs.writeFileSync(imagePath, Buffer.from([1, 2, 3, 4]));
+    const escapedPath = imagePath.replace(/ /g, "\\ ");
+
+    const messages = await buildVisionUserMessages(`${escapedPath}\nExplain this image`, tempDir);
+
+    const content = messages[0]?.content as Array<Record<string, unknown>>;
+    expect(content[0]).toMatchObject({
+      type: "file",
+      mediaType: "image/png",
+    });
+    expect(content[0]?.data).toBeInstanceOf(Uint8Array);
+    expect(content[1]).toMatchObject({
+      type: "text",
+      text: `${escapedPath}\nExplain this image`,
+    });
+  });
 });

--- a/src/grok/client.test.ts
+++ b/src/grok/client.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as settings from "../utils/settings";
 import { generateRecap, resolveModelRuntime } from "./client";
 
-const mockGenerateText = vi.fn();
+const mockGenerateText = vi.hoisted(() => vi.fn());
 
 vi.mock("ai", () => {
   return {
@@ -34,7 +34,7 @@ describe("client", () => {
 
       expect(result).toEqual({
         recap: "Wrapped up the parser fix. Next step is wiring the new recap banner.",
-        modelId: "grok-4-1-fast-non-reasoning",
+        modelId: "grok-4.20-non-reasoning",
         usage: { inputTokens: 11, outputTokens: 7, totalTokens: 18 },
       });
       expect(mockGenerateText).toHaveBeenCalledWith(
@@ -54,7 +54,7 @@ describe("client", () => {
 
       expect(result).toEqual({
         recap: "",
-        modelId: "grok-4-1-fast-non-reasoning",
+        modelId: "grok-4.20-non-reasoning",
       });
     });
   });
@@ -67,21 +67,21 @@ describe("client", () => {
         expect(runtime.providerOptions).toBeUndefined();
       });
 
-      it("does not include providerOptions for grok-4-0709 even though it has reasoning flag", () => {
+      it("normalizes retired flagship reasoning models to grok-4.3", () => {
         const runtime = resolveModelRuntime(mockProvider, "grok-4-0709");
-        expect(runtime.modelId).toBe("grok-4-0709");
+        expect(runtime.modelId).toBe("grok-4.3");
         expect(runtime.providerOptions).toBeUndefined();
       });
 
-      it("does not include providerOptions for grok-code-fast-1", () => {
+      it("normalizes retired code models to grok-4.3", () => {
         const runtime = resolveModelRuntime(mockProvider, "grok-code-fast-1");
-        expect(runtime.modelId).toBe("grok-code-fast-1");
+        expect(runtime.modelId).toBe("grok-4.3");
         expect(runtime.providerOptions).toBeUndefined();
       });
 
-      it("does not include providerOptions for grok-4-1-fast-reasoning", () => {
+      it("normalizes retired fast reasoning models to grok-4.3", () => {
         const runtime = resolveModelRuntime(mockProvider, "grok-4-1-fast-reasoning");
-        expect(runtime.modelId).toBe("grok-4-1-fast-reasoning");
+        expect(runtime.modelId).toBe("grok-4.3");
         expect(runtime.providerOptions).toBeUndefined();
       });
 
@@ -91,9 +91,9 @@ describe("client", () => {
         expect(runtime.providerOptions).toBeUndefined();
       });
 
-      it("does not include providerOptions for grok-3", () => {
+      it("normalizes retired non-reasoning models to grok-4.20-non-reasoning", () => {
         const runtime = resolveModelRuntime(mockProvider, "grok-3");
-        expect(runtime.modelId).toBe("grok-3");
+        expect(runtime.modelId).toBe("grok-4.20-non-reasoning");
         expect(runtime.providerOptions).toBeUndefined();
       });
     });
@@ -129,24 +129,24 @@ describe("client", () => {
         });
       });
 
-      it("does not include providerOptions for grok-4-0709 even when effort is configured", () => {
+      it("does not include providerOptions for retired reasoning aliases even when effort is configured", () => {
         vi.spyOn(settings, "getReasoningEffortForModel").mockReturnValue("high");
         const runtime = resolveModelRuntime(mockProvider, "grok-4-0709");
-        expect(runtime.modelId).toBe("grok-4-0709");
+        expect(runtime.modelId).toBe("grok-4.3");
         expect(runtime.providerOptions).toBeUndefined();
       });
 
-      it("does not include providerOptions for grok-code-fast-1 even when effort is configured", () => {
+      it("does not include providerOptions for retired code aliases even when effort is configured", () => {
         vi.spyOn(settings, "getReasoningEffortForModel").mockReturnValue("high");
         const runtime = resolveModelRuntime(mockProvider, "grok-code-fast-1");
-        expect(runtime.modelId).toBe("grok-code-fast-1");
+        expect(runtime.modelId).toBe("grok-4.3");
         expect(runtime.providerOptions).toBeUndefined();
       });
 
-      it("does not include providerOptions for grok-4-1-fast-reasoning even when effort is configured", () => {
+      it("does not include providerOptions for grok-4.3 even when effort is configured", () => {
         vi.spyOn(settings, "getReasoningEffortForModel").mockReturnValue("high");
-        const runtime = resolveModelRuntime(mockProvider, "grok-4-1-fast-reasoning");
-        expect(runtime.modelId).toBe("grok-4-1-fast-reasoning");
+        const runtime = resolveModelRuntime(mockProvider, "grok-4.3");
+        expect(runtime.modelId).toBe("grok-4.3");
         expect(runtime.providerOptions).toBeUndefined();
       });
     });

--- a/src/grok/client.ts
+++ b/src/grok/client.ts
@@ -9,8 +9,8 @@ export type XaiChatModel = ReturnType<XaiProvider>;
 export type XaiResponsesModel = ReturnType<XaiProvider["responses"]>;
 export type GrokRuntimeModel = XaiChatModel | XaiResponsesModel;
 
-const DEFAULT_TITLE_MODEL = "grok-4-1-fast-non-reasoning";
-const DEFAULT_RECAP_MODEL = "grok-4-1-fast-non-reasoning";
+const DEFAULT_TITLE_MODEL = "grok-4.20-non-reasoning";
+const DEFAULT_RECAP_MODEL = "grok-4.20-non-reasoning";
 
 interface GeneratedTextResult {
   modelId: string;

--- a/src/grok/models.test.ts
+++ b/src/grok/models.test.ts
@@ -9,18 +9,20 @@ import {
 
 describe("models", () => {
   it("keeps the default model on a canonical reasoning id", () => {
-    expect(DEFAULT_MODEL).toBe("grok-4-1-fast-reasoning");
+    expect(DEFAULT_MODEL).toBe("grok-4.3");
   });
 
-  it("normalizes current aliases to canonical ids", () => {
-    expect(normalizeModelId("grok-4-1-fast")).toBe("grok-4-1-fast-reasoning");
+  it("normalizes aliases to canonical ids", () => {
+    expect(normalizeModelId("grok-4-1-fast")).toBe("grok-4.3");
+    expect(normalizeModelId("xai/grok-code-fast-1")).toBe("grok-4.3");
+    expect(normalizeModelId("grok-4.20-0309-non-reasoning")).toBe("grok-4.20-non-reasoning");
+    expect(normalizeModelId("x-ai/grok-3")).toBe("grok-4.20-non-reasoning");
     expect(normalizeModelId("grok-4.20-multi-agent")).toBe("grok-4.20-multi-agent-0309");
     expect(normalizeModelId("x-ai/grok-4.20-multi-agent-beta")).toBe("grok-4.20-multi-agent-0309");
-    expect(normalizeModelId("xai/grok-code-fast-1")).toBe("grok-code-fast-1");
   });
 
   it("returns model metadata for aliased ids", () => {
-    expect(getModelInfo("grok-4-1-fast")?.id).toBe("grok-4-1-fast-reasoning");
+    expect(getModelInfo("grok-4-1-fast")?.id).toBe("grok-4.3");
     expect(getModelInfo("grok-4.20-multi-agent")?.responsesOnly).toBe(true);
     expect(getModelInfo("grok-4.20-multi-agent")?.supportsClientTools).toBe(false);
   });
@@ -28,10 +30,9 @@ describe("models", () => {
   it("reports supported reasoning-effort levels", () => {
     expect(getSupportedReasoningEfforts("grok-3-mini")).toEqual(["low", "high"]);
     expect(getSupportedReasoningEfforts("grok-4.20-multi-agent-0309")).toEqual([]);
-    expect(getSupportedReasoningEfforts("grok-4-1-fast-reasoning")).toEqual([]);
-    expect(getSupportedReasoningEfforts("grok-4-1-fast-non-reasoning")).toEqual([]);
+    expect(getSupportedReasoningEfforts("grok-4.3")).toEqual([]);
+    expect(getSupportedReasoningEfforts("grok-4.20-non-reasoning")).toEqual([]);
     expect(getSupportedReasoningEfforts("grok-code-fast-1")).toEqual([]);
-    expect(getSupportedReasoningEfforts("grok-4-0709")).toEqual([]);
     expect(getSupportedReasoningEfforts("grok-3")).toEqual([]);
   });
 
@@ -41,7 +42,7 @@ describe("models", () => {
     expect(getEffectiveReasoningEffort("grok-3-mini", "low")).toBe("low");
     expect(getEffectiveReasoningEffort("grok-4.20-multi-agent-0309")).toBeUndefined();
     expect(getEffectiveReasoningEffort("grok-4.20-multi-agent-0309", "high")).toBeUndefined();
-    expect(getEffectiveReasoningEffort("grok-4-1-fast-reasoning")).toBeUndefined();
+    expect(getEffectiveReasoningEffort("grok-4.3")).toBeUndefined();
     expect(getEffectiveReasoningEffort("grok-code-fast-1", "high")).toBeUndefined();
   });
 });

--- a/src/grok/models.ts
+++ b/src/grok/models.ts
@@ -2,6 +2,24 @@ import type { ModelInfo, ReasoningEffort } from "../types/index";
 
 export const MODELS: ModelInfo[] = [
   {
+    id: "grok-4.3",
+    name: "Grok 4.3",
+    contextWindow: 1_000_000,
+    inputPrice: 1.25,
+    outputPrice: 2.5,
+    reasoning: true,
+    description: "Recommended flagship reasoning model",
+    aliases: [
+      "grok-4-1-fast-reasoning",
+      "grok-4-1-fast",
+      "grok-4-fast-reasoning",
+      "grok-4-fast",
+      "grok-4-0709",
+      "grok-code-fast-1",
+      "grok-code-fast",
+    ],
+  },
+  {
     id: "grok-4.20-multi-agent-0309",
     name: "Grok 4.20 Multi-Agent",
     contextWindow: 2_000_000,
@@ -27,79 +45,14 @@ export const MODELS: ModelInfo[] = [
     aliases: ["grok-4.20-beta-0309", "grok-4.20-beta", "grok-beta"],
   },
   {
-    id: "grok-4.20-0309-non-reasoning",
+    id: "grok-4.20-non-reasoning",
     name: "Grok 4.20 Non-Reasoning",
     contextWindow: 2_000_000,
     inputPrice: 2.0,
     outputPrice: 6.0,
     reasoning: false,
-    description: "Grok 4.20 non-reasoning release",
-  },
-  {
-    id: "grok-4-1-fast-reasoning",
-    name: "Grok 4.1 Fast Reasoning",
-    contextWindow: 2_000_000,
-    inputPrice: 0.2,
-    outputPrice: 0.5,
-    reasoning: true,
-    description: "Fast reasoning model with 2M context",
-    aliases: ["grok-4-1-fast"],
-  },
-  {
-    id: "grok-4-1-fast-non-reasoning",
-    name: "Grok 4.1 Fast Non-Reasoning",
-    contextWindow: 2_000_000,
-    inputPrice: 0.2,
-    outputPrice: 0.5,
-    reasoning: false,
-    description: "Fast non-reasoning model with 2M context",
-  },
-  {
-    id: "grok-4-fast-reasoning",
-    name: "Grok 4 Fast Reasoning",
-    contextWindow: 2_000_000,
-    inputPrice: 0.2,
-    outputPrice: 0.5,
-    reasoning: true,
-    description: "Legacy fast reasoning model",
-    aliases: ["grok-4-fast"],
-  },
-  {
-    id: "grok-4-fast-non-reasoning",
-    name: "Grok 4 Fast Non-Reasoning",
-    contextWindow: 2_000_000,
-    inputPrice: 0.2,
-    outputPrice: 0.5,
-    reasoning: false,
-    description: "Legacy fast non-reasoning model",
-  },
-  {
-    id: "grok-4-0709",
-    name: "Grok 4",
-    contextWindow: 256_000,
-    inputPrice: 3.0,
-    outputPrice: 15.0,
-    reasoning: true,
-    description: "Flagship reasoning model",
-  },
-  {
-    id: "grok-code-fast-1",
-    name: "Grok Code Fast 1",
-    contextWindow: 256_000,
-    inputPrice: 0.2,
-    outputPrice: 1.5,
-    reasoning: true,
-    description: "Fast coding model with reasoning",
-    aliases: ["grok-code-fast"],
-  },
-  {
-    id: "grok-3",
-    name: "Grok 3",
-    contextWindow: 131_072,
-    inputPrice: 3.0,
-    outputPrice: 15.0,
-    reasoning: false,
-    description: "Grok 3 flagship",
+    description: "Recommended non-reasoning model",
+    aliases: ["grok-4.20-0309-non-reasoning", "grok-4-1-fast-non-reasoning", "grok-4-fast-non-reasoning", "grok-3"],
   },
   {
     id: "grok-3-mini",
@@ -124,8 +77,7 @@ for (const model of MODELS) {
   }
 }
 
-export const DEFAULT_MODEL =
-  MODELS.find((model) => model.id === "grok-4-1-fast-reasoning")?.id ?? MODELS[0]?.id ?? "grok-4-1-fast-reasoning";
+export const DEFAULT_MODEL = MODELS.find((model) => model.id === "grok-4.3")?.id ?? MODELS[0]?.id ?? "grok-4.3";
 
 export function normalizeModelId(modelId: string): string {
   const trimmed = modelId.trim();

--- a/src/grok/tools.ts
+++ b/src/grok/tools.ts
@@ -35,7 +35,7 @@ import {
   VIDEO_RESOLUTIONS,
 } from "./media";
 
-const RESPONSES_SEARCH_MODEL = "grok-4-1-fast-non-reasoning";
+const RESPONSES_SEARCH_MODEL = "grok-4.20-non-reasoning";
 
 interface CreateToolsOptions {
   runTask?: (request: TaskRequest, abortSignal?: AbortSignal) => Promise<ToolResult>;

--- a/src/storage/sessions.test.ts
+++ b/src/storage/sessions.test.ts
@@ -32,29 +32,29 @@ describe("SessionStore recap persistence", () => {
 
   it("stores and reloads the latest recap metadata with the session", () => {
     const store = new SessionStore(tempCwd);
-    const session = store.createSession("grok-4-1-fast", "agent", tempCwd);
+    const session = store.createSession("grok-4.3", "agent", tempCwd);
     const updatedAt = new Date("2026-04-22T15:00:00.000Z");
 
     store.setRecap(session.id, {
       text: "Migrated billing sessions to the new schema. Next step is wiring the prompt banner.",
-      model: "grok-4-1-fast-non-reasoning",
+      model: "grok-4.20-non-reasoning",
       updatedAt,
     });
 
     expect(store.getRequiredSession(session.id).recap).toEqual({
       text: "Migrated billing sessions to the new schema. Next step is wiring the prompt banner.",
-      model: "grok-4-1-fast-non-reasoning",
+      model: "grok-4.20-non-reasoning",
       updatedAt,
     });
   });
 
   it("clears recap metadata when the recap is removed", () => {
     const store = new SessionStore(tempCwd);
-    const session = store.createSession("grok-4-1-fast", "agent", tempCwd);
+    const session = store.createSession("grok-4.3", "agent", tempCwd);
 
     store.setRecap(session.id, {
       text: "Temporary recap",
-      model: "grok-4-1-fast-non-reasoning",
+      model: "grok-4.20-non-reasoning",
       updatedAt: new Date("2026-04-22T15:00:00.000Z"),
     });
     store.setRecap(session.id, null);

--- a/src/ui/app.tsx
+++ b/src/ui/app.tsx
@@ -82,6 +82,7 @@ import {
   PlanView,
 } from "./plan";
 import { buildScheduleBrowseRows, ScheduleBrowserModal } from "./schedule-modal";
+import { filterSlashMenuItems, SLASH_MENU_ITEMS, type SlashMenuItem } from "./slash-menu";
 import {
   buildAssistantEntry,
   buildToolResultEntry,
@@ -289,32 +290,6 @@ const _LINE = {
   leftT: "━",
   rightT: "━",
 };
-
-interface SlashMenuItem {
-  id: string;
-  label: string;
-  description: string;
-}
-
-const SLASH_MENU_ITEMS: SlashMenuItem[] = [
-  { id: "exit", label: "exit", description: "Quit the CLI" },
-  { id: "help", label: "help", description: "Show available commands" },
-  { id: "remote-control", label: "remote-control", description: "Remote control" },
-  { id: "agents", label: "agents", description: "Manage custom sub-agents" },
-  { id: "schedule", label: "schedule", description: "View scheduled runs" },
-  { id: "mcp", label: "mcp", description: "Manage MCP servers" },
-  { id: "sandbox", label: "sandbox", description: "Select shell sandbox mode" },
-  { id: "wallet", label: "wallet", description: "Wallet and payment settings" },
-  { id: "models", label: "models", description: "Select a model" },
-  { id: "new", label: "new session", description: "Start a new session" },
-  { id: "commit-push", label: "commit & push", description: "Commit and push" },
-  { id: "commit-pr", label: "commit & pr", description: "Commit and open PR" },
-  { id: "review", label: "review", description: "Review recent changes" },
-  { id: "verify", label: "verify", description: "Run local verification" },
-  { id: "skills", label: "skills", description: "Manage skills" },
-  { id: "btw", label: "btw", description: "Ask a side question without interrupting" },
-  { id: "update", label: "update", description: "Update grok to the latest version" },
-];
 
 const REVIEW_PROMPT = `Review all current changes in this repository. Follow these steps:
 
@@ -830,13 +805,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
       )
     : MODELS;
   const filteredModelIds = filteredModels.map((m) => m.id);
-  const filteredSlashItems = slashSearchQuery
-    ? SLASH_MENU_ITEMS.filter(
-        (item) =>
-          item.label.toLowerCase().includes(slashSearchQuery.toLowerCase()) ||
-          item.description.toLowerCase().includes(slashSearchQuery.toLowerCase()),
-      )
-    : SLASH_MENU_ITEMS;
+  const filteredSlashItems = filterSlashMenuItems(SLASH_MENU_ITEMS, slashSearchQuery);
   const mcpRows = buildMcpBrowseRows(mcpServers, POPULAR_MCP_CATALOG, mcpSearchQuery);
   const mcpEditorFields = mcpEditorDraft.transport === "stdio" ? MCP_STDIO_FIELDS : MCP_REMOTE_FIELDS;
   const agentRows = useMemo(

--- a/src/ui/slash-menu.test.ts
+++ b/src/ui/slash-menu.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { filterSlashMenuItems, SLASH_MENU_ITEMS } from "./slash-menu";
+
+describe("filterSlashMenuItems", () => {
+  it("finds the models command when searching with the full slash command", () => {
+    expect(filterSlashMenuItems(SLASH_MENU_ITEMS, "/models")[0]?.id).toBe("models");
+  });
+
+  it("finds the models command from model and mode prefixes before description matches", () => {
+    expect(filterSlashMenuItems(SLASH_MENU_ITEMS, "model")[0]?.id).toBe("models");
+    expect(filterSlashMenuItems(SLASH_MENU_ITEMS, "mode")[0]?.id).toBe("models");
+  });
+
+  it("still includes description matches after stronger command matches", () => {
+    const ids = filterSlashMenuItems(SLASH_MENU_ITEMS, "mode").map((item) => item.id);
+    expect(ids).toContain("models");
+    expect(ids).toContain("sandbox");
+    expect(ids.indexOf("models")).toBeLessThan(ids.indexOf("sandbox"));
+  });
+});

--- a/src/ui/slash-menu.ts
+++ b/src/ui/slash-menu.ts
@@ -1,0 +1,69 @@
+export interface SlashMenuItem {
+  id: string;
+  label: string;
+  description: string;
+  aliases?: string[];
+}
+
+export const SLASH_MENU_ITEMS: SlashMenuItem[] = [
+  { id: "exit", label: "exit", description: "Quit the CLI" },
+  { id: "help", label: "help", description: "Show available commands" },
+  { id: "remote-control", label: "remote-control", description: "Remote control" },
+  { id: "agents", label: "agents", description: "Manage custom sub-agents" },
+  { id: "schedule", label: "schedule", description: "View scheduled runs" },
+  { id: "mcp", label: "mcp", description: "Manage MCP servers" },
+  { id: "sandbox", label: "sandbox", description: "Select shell sandbox mode" },
+  { id: "wallet", label: "wallet", description: "Wallet and payment settings" },
+  { id: "models", label: "models", description: "Select a model", aliases: ["model", "mode"] },
+  { id: "new", label: "new session", description: "Start a new session" },
+  { id: "commit-push", label: "commit & push", description: "Commit and push" },
+  { id: "commit-pr", label: "commit & pr", description: "Commit and open PR" },
+  { id: "review", label: "review", description: "Review recent changes" },
+  { id: "verify", label: "verify", description: "Run local verification" },
+  { id: "skills", label: "skills", description: "Manage skills" },
+  { id: "btw", label: "btw", description: "Ask a side question without interrupting" },
+  { id: "update", label: "update", description: "Update grok to the latest version" },
+];
+
+export function filterSlashMenuItems(items: SlashMenuItem[], query: string): SlashMenuItem[] {
+  const normalized = normalizeSlashSearchQuery(query);
+  if (!normalized) return items;
+
+  return items
+    .map((item, index) => ({ item, index, score: scoreSlashMenuItem(item, normalized) }))
+    .filter((entry) => entry.score !== Number.POSITIVE_INFINITY)
+    .sort((a, b) => a.score - b.score || a.index - b.index)
+    .map((entry) => entry.item);
+}
+
+function normalizeSlashSearchQuery(query: string): string {
+  return query.trim().replace(/^\/+/, "").toLowerCase();
+}
+
+function scoreSlashMenuItem(item: SlashMenuItem, query: string): number {
+  const commandFields = [item.id, item.label, ...(item.aliases ?? [])].flatMap(tokenizeSearchText);
+  const descriptionFields = tokenizeSearchText(item.description);
+
+  const commandScore = scoreFields(commandFields, query, 0);
+  const descriptionScore = scoreFields(descriptionFields, query, 3);
+  return Math.min(commandScore, descriptionScore);
+}
+
+function scoreFields(fields: string[], query: string, offset: number): number {
+  for (const field of fields) {
+    if (field === query || `/${field}` === query) return offset;
+  }
+  for (const field of fields) {
+    if (field.startsWith(query) || `/${field}`.startsWith(query)) return offset + 1;
+  }
+  for (const field of fields) {
+    if (field.includes(query) || `/${field}`.includes(query)) return offset + 2;
+  }
+  return Number.POSITIVE_INFINITY;
+}
+
+function tokenizeSearchText(value: string): string[] {
+  const normalized = value.toLowerCase();
+  const tokens = normalized.split(/[^a-z0-9]+/).filter(Boolean);
+  return [normalized, ...tokens];
+}

--- a/src/utils/subagents-settings.test.ts
+++ b/src/utils/subagents-settings.test.ts
@@ -1,6 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import type { AgentMode } from "../types/index";
-import { getCurrentModel, loadUserSettings, parseSubAgentsRawList } from "./settings";
+import { getCurrentModel, parseSubAgentsRawList } from "./settings";
 
 describe("parseSubAgentsRawList", () => {
   it("returns empty for non-array or missing", () => {
@@ -11,13 +11,11 @@ describe("parseSubAgentsRawList", () => {
 
   it("keeps valid entries with known model ids", () => {
     expect(
-      parseSubAgentsRawList([
-        { name: "docs", model: "grok-4-1-fast-reasoning", instruction: "Focus on documentation." },
-      ]),
-    ).toEqual([{ name: "docs", model: "grok-4-1-fast-reasoning", instruction: "Focus on documentation." }]);
+      parseSubAgentsRawList([{ name: "docs", model: "grok-4.3", instruction: "Focus on documentation." }]),
+    ).toEqual([{ name: "docs", model: "grok-4.3", instruction: "Focus on documentation." }]);
   });
 
-  it("normalizes legacy aliases to canonical ids", () => {
+  it("normalizes aliases to canonical ids", () => {
     expect(
       parseSubAgentsRawList([
         { name: "research", model: "x-ai/grok-4.20-multi-agent-beta", instruction: "Focus on research." },
@@ -32,13 +30,13 @@ describe("parseSubAgentsRawList", () => {
   it("skips reserved and empty names", () => {
     expect(
       parseSubAgentsRawList([
-        { name: "general", model: "grok-4-1-fast-reasoning", instruction: "x" },
-        { name: "Explore", model: "grok-4-1-fast-reasoning", instruction: "x" },
-        { name: "vision", model: "grok-4-1-fast-reasoning", instruction: "x" },
-        { name: "Verify", model: "grok-4-1-fast-reasoning", instruction: "x" },
-        { name: "computer", model: "grok-4-1-fast-reasoning", instruction: "x" },
-        { name: "", model: "grok-4-1-fast-reasoning", instruction: "x" },
-        { name: "  ", model: "grok-4-1-fast-reasoning", instruction: "x" },
+        { name: "general", model: "grok-4.3", instruction: "x" },
+        { name: "Explore", model: "grok-4.3", instruction: "x" },
+        { name: "vision", model: "grok-4.3", instruction: "x" },
+        { name: "Verify", model: "grok-4.3", instruction: "x" },
+        { name: "computer", model: "grok-4.3", instruction: "x" },
+        { name: "", model: "grok-4.3", instruction: "x" },
+        { name: "  ", model: "grok-4.3", instruction: "x" },
       ]),
     ).toEqual([]);
   });
@@ -49,7 +47,7 @@ describe("parseSubAgentsRawList", () => {
         { name: "Docs", model: "grok-4-1-fast", instruction: "first" },
         { name: "docs", model: "grok-code-fast-1", instruction: "second" },
       ]),
-    ).toEqual([{ name: "Docs", model: "grok-4-1-fast-reasoning", instruction: "first" }]);
+    ).toEqual([{ name: "Docs", model: "grok-4.3", instruction: "first" }]);
   });
 
   it("ignores non-object rows", () => {


### PR DESCRIPTION
## What does this PR do?

- Migrates retired Grok model defaults to `grok-4.3` and `grok-4.20-non-reasoning`, while preserving legacy IDs as aliases for existing settings and subagents.
- Sends local image paths in normal chat prompts as multimodal inputs so screenshot/image recognition works outside the vision subagent.
- Adds tested slash-menu filtering so `/models`, `/model`, and `mode` surface the model picker command.

Fixes #282 #288 

## Checklist

- [x] I tested my changes
- [x] I reviewed my own code