### PR TITLE
feat: prompt for workspace sandbox trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,8 @@ Grok CLI can run shell commands inside a [Shuru](https://github.com/superhq-ai/s
 
 Enable it with `--sandbox` on the CLI, or toggle it from the TUI with `/sandbox`.
 
+On the first interactive run in a new directory, Grok asks whether to remember sandbox or host mode for that workspace and stores the choice in `~/.grok/workspace-trust.json`. Explicit `--sandbox` / `--no-sandbox` flags and non-interactive commands keep their current behavior.
+
 When sandbox mode is active you can configure:
 
 - **Network** — off by default; enable with `--allow-net`, restrict with `--allow-host`

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ import { runUpdate } from "./utils/update-checker";
 import {
   getWorkspaceTrustDecision,
   isShuruSandboxSupported,
+  resolveWorkspaceTrustPromptAnswer,
   saveWorkspaceTrustDecision,
 } from "./utils/workspace-trust";
 import { buildVerifyPrompt, getVerifyCliError } from "./verify/entrypoint";
@@ -188,15 +189,10 @@ function hasExplicitSandboxOption(options: CliOptions): boolean {
   return options.sandbox === true || options.sandbox === false;
 }
 
-interface WorkspaceTrustPromptDecision {
-  sandboxMode: SandboxMode;
-  remember: boolean;
-}
-
 async function promptWorkspaceTrust(
   cwd: string,
   sandboxSupported = isShuruSandboxSupported(),
-): Promise<WorkspaceTrustPromptDecision> {
+): Promise<ReturnType<typeof resolveWorkspaceTrustPromptAnswer>> {
   const message = sandboxSupported
     ? [
         "",
@@ -232,14 +228,7 @@ async function promptWorkspaceTrust(
     const answer = await new Promise<string>((resolve) => {
       rl.question(message, resolve);
     });
-    const normalized = answer.trim().toLowerCase();
-    if (normalized === "s" || normalized === "session") {
-      return { sandboxMode: sandboxSupported ? "shuru" : "off", remember: false };
-    }
-    if (sandboxSupported && (!normalized || normalized === "y" || normalized === "yes")) {
-      return { sandboxMode: "shuru", remember: true };
-    }
-    return { sandboxMode: "off", remember: true };
+    return resolveWorkspaceTrustPromptAnswer(answer, sandboxSupported);
   } finally {
     rl.close();
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 import { InvalidArgumentError, program } from "commander";
 import * as dotenv from "dotenv";
+import readline from "readline";
 import packageJson from "../package.json";
 import { Agent } from "./agent/agent";
 import { completeDelegation, failDelegation, loadDelegation } from "./agent/delegations";
@@ -29,6 +30,11 @@ import {
   saveUserSettings,
 } from "./utils/settings";
 import { runUpdate } from "./utils/update-checker";
+import {
+  getWorkspaceTrustDecision,
+  isShuruSandboxSupported,
+  saveWorkspaceTrustDecision,
+} from "./utils/workspace-trust";
 import { buildVerifyPrompt, getVerifyCliError } from "./verify/entrypoint";
 
 dotenv.config();
@@ -176,6 +182,81 @@ function resolveCliSandboxMode(value: string | boolean | undefined): SandboxMode
   if (value === true) return "shuru";
   if (value === false) return "off";
   return undefined;
+}
+
+function hasExplicitSandboxOption(options: CliOptions): boolean {
+  return options.sandbox === true || options.sandbox === false;
+}
+
+interface WorkspaceTrustPromptDecision {
+  sandboxMode: SandboxMode;
+  remember: boolean;
+}
+
+async function promptWorkspaceTrust(
+  cwd: string,
+  sandboxSupported = isShuruSandboxSupported(),
+): Promise<WorkspaceTrustPromptDecision> {
+  const message = sandboxSupported
+    ? [
+        "",
+        `Grok has not been run in ${cwd} before.`,
+        "",
+        "Sandbox mode isolates agent shell commands in a Shuru microVM so",
+        "untrusted repos cannot touch your host filesystem or network by default.",
+        "",
+        "Run grok in sandbox mode for this directory?",
+        "",
+        "  [Y] Yes, always in sandbox",
+        "  [n] No, run on host",
+        "  [s] Yes, this session only",
+        "",
+        "Choice [Y/n/s]: ",
+      ].join("\n")
+    : [
+        "",
+        `Grok has not been run in ${cwd} before.`,
+        "",
+        "Sandbox mode is only available on macOS Apple Silicon in this version.",
+        "",
+        "Run grok directly on the host for this directory?",
+        "",
+        "  [Y] Yes, remember host mode",
+        "  [s] Yes, this session only",
+        "",
+        "Choice [Y/s]: ",
+      ].join("\n");
+
+  const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    const answer = await new Promise<string>((resolve) => {
+      rl.question(message, resolve);
+    });
+    const normalized = answer.trim().toLowerCase();
+    if (normalized === "s" || normalized === "session") {
+      return { sandboxMode: sandboxSupported ? "shuru" : "off", remember: false };
+    }
+    if (sandboxSupported && (!normalized || normalized === "y" || normalized === "yes")) {
+      return { sandboxMode: "shuru", remember: true };
+    }
+    return { sandboxMode: "off", remember: true };
+  } finally {
+    rl.close();
+  }
+}
+
+async function resolveWorkspaceTrustSandboxMode(sandboxMode: SandboxMode, options: CliOptions): Promise<SandboxMode> {
+  if (sandboxMode === "shuru" || hasExplicitSandboxOption(options)) return sandboxMode;
+  if (process.env.GROK_TRUST_WORKSPACE) return sandboxMode;
+
+  const cwd = process.cwd();
+  const saved = getWorkspaceTrustDecision(cwd);
+  if (saved) return saved;
+  if (!process.stdin.isTTY || !process.stderr.isTTY) return sandboxMode;
+
+  const decision = await promptWorkspaceTrust(cwd);
+  if (decision.remember) saveWorkspaceTrustDecision(cwd, decision.sandboxMode);
+  return decision.sandboxMode;
 }
 
 async function runBackgroundDelegation(jobPath: string, options: CliOptions) {
@@ -353,6 +434,7 @@ program
     }
 
     const initialMessage = message.length > 0 ? message.join(" ") : undefined;
+    config.sandboxMode = await resolveWorkspaceTrustSandboxMode(config.sandboxMode, options);
     await startInteractive(
       config.apiKey,
       config.baseURL,

--- a/src/utils/workspace-trust.test.ts
+++ b/src/utils/workspace-trust.test.ts
@@ -1,0 +1,81 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getWorkspaceTrustDecision,
+  getWorkspaceTrustKey,
+  getWorkspaceTrustPath,
+  isShuruSandboxSupported,
+  loadWorkspaceTrustStore,
+  saveWorkspaceTrustDecision,
+  WORKSPACE_TRUST_FILENAME,
+} from "./workspace-trust";
+
+let tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs) fs.rmSync(dir, { recursive: true, force: true });
+  tempDirs = [];
+});
+
+function createTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("workspace trust settings", () => {
+  it("detects Shuru support only on macOS Apple Silicon", () => {
+    expect(isShuruSandboxSupported("darwin", "arm64")).toBe(true);
+    expect(isShuruSandboxSupported("darwin", "x64")).toBe(false);
+    expect(isShuruSandboxSupported("linux", "arm64")).toBe(false);
+    expect(isShuruSandboxSupported("win32", "x64")).toBe(false);
+  });
+
+  it("stores sandbox decisions by canonical workspace path", () => {
+    const homeDir = createTempDir("grok-trust-home-");
+    const workspace = createTempDir("grok-trust-workspace-");
+    const trustPath = getWorkspaceTrustPath(homeDir);
+
+    saveWorkspaceTrustDecision(workspace, "shuru", trustPath);
+
+    expect(getWorkspaceTrustDecision(workspace, trustPath)).toBe("shuru");
+    expect(loadWorkspaceTrustStore(trustPath).workspaces[getWorkspaceTrustKey(workspace)]?.sandboxMode).toBe("shuru");
+    expect(path.basename(trustPath)).toBe(WORKSPACE_TRUST_FILENAME);
+  });
+
+  it("preserves existing entries when saving another workspace", () => {
+    const homeDir = createTempDir("grok-trust-home-");
+    const firstWorkspace = createTempDir("grok-trust-first-");
+    const secondWorkspace = createTempDir("grok-trust-second-");
+    const trustPath = getWorkspaceTrustPath(homeDir);
+
+    saveWorkspaceTrustDecision(firstWorkspace, "shuru", trustPath);
+    saveWorkspaceTrustDecision(secondWorkspace, "off", trustPath);
+
+    expect(getWorkspaceTrustDecision(firstWorkspace, trustPath)).toBe("shuru");
+    expect(getWorkspaceTrustDecision(secondWorkspace, trustPath)).toBe("off");
+  });
+
+  it("ignores malformed files and entries", () => {
+    const homeDir = createTempDir("grok-trust-home-");
+    const workspace = createTempDir("grok-trust-workspace-");
+    const trustPath = getWorkspaceTrustPath(homeDir);
+    fs.mkdirSync(path.dirname(trustPath), { recursive: true });
+    fs.writeFileSync(
+      trustPath,
+      JSON.stringify({
+        workspaces: {
+          [getWorkspaceTrustKey(workspace)]: { sandboxMode: "invalid" },
+        },
+      }),
+    );
+
+    expect(getWorkspaceTrustDecision(workspace, trustPath)).toBeNull();
+    expect(loadWorkspaceTrustStore(path.join(homeDir, ".grok", "broken.json"))).toEqual({
+      version: 1,
+      workspaces: {},
+    });
+  });
+});

--- a/src/utils/workspace-trust.test.ts
+++ b/src/utils/workspace-trust.test.ts
@@ -8,6 +8,7 @@ import {
   getWorkspaceTrustPath,
   isShuruSandboxSupported,
   loadWorkspaceTrustStore,
+  resolveWorkspaceTrustPromptAnswer,
   saveWorkspaceTrustDecision,
   WORKSPACE_TRUST_FILENAME,
 } from "./workspace-trust";
@@ -31,6 +32,21 @@ describe("workspace trust settings", () => {
     expect(isShuruSandboxSupported("darwin", "x64")).toBe(false);
     expect(isShuruSandboxSupported("linux", "arm64")).toBe(false);
     expect(isShuruSandboxSupported("win32", "x64")).toBe(false);
+  });
+
+  it("only disables supported sandbox mode on explicit no answers", () => {
+    expect(resolveWorkspaceTrustPromptAnswer("", true)).toEqual({ sandboxMode: "shuru", remember: true });
+    expect(resolveWorkspaceTrustPromptAnswer("y", true)).toEqual({ sandboxMode: "shuru", remember: true });
+    expect(resolveWorkspaceTrustPromptAnswer("typo", true)).toEqual({ sandboxMode: "shuru", remember: true });
+    expect(resolveWorkspaceTrustPromptAnswer("n", true)).toEqual({ sandboxMode: "off", remember: true });
+    expect(resolveWorkspaceTrustPromptAnswer("no", true)).toEqual({ sandboxMode: "off", remember: true });
+    expect(resolveWorkspaceTrustPromptAnswer("s", true)).toEqual({ sandboxMode: "shuru", remember: false });
+  });
+
+  it("keeps unsupported sandbox prompt decisions in host mode", () => {
+    expect(resolveWorkspaceTrustPromptAnswer("", false)).toEqual({ sandboxMode: "off", remember: true });
+    expect(resolveWorkspaceTrustPromptAnswer("typo", false)).toEqual({ sandboxMode: "off", remember: true });
+    expect(resolveWorkspaceTrustPromptAnswer("s", false)).toEqual({ sandboxMode: "off", remember: false });
   });
 
   it("stores sandbox decisions by canonical workspace path", () => {

--- a/src/utils/workspace-trust.ts
+++ b/src/utils/workspace-trust.ts
@@ -1,0 +1,84 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import type { SandboxMode } from "./settings";
+
+interface WorkspaceTrustEntry {
+  sandboxMode: SandboxMode;
+  updatedAt: string;
+}
+
+interface WorkspaceTrustStore {
+  version: 1;
+  workspaces: Record<string, WorkspaceTrustEntry>;
+}
+
+export const WORKSPACE_TRUST_FILENAME = "workspace-trust.json";
+
+export function isShuruSandboxSupported(platform = process.platform, arch = process.arch): boolean {
+  return platform === "darwin" && arch === "arm64";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeTrustEntry(value: unknown): WorkspaceTrustEntry | null {
+  if (!isRecord(value)) return null;
+  const sandboxMode = value.sandboxMode === "shuru" ? "shuru" : value.sandboxMode === "off" ? "off" : null;
+  if (!sandboxMode) return null;
+  return {
+    sandboxMode,
+    updatedAt: typeof value.updatedAt === "string" ? value.updatedAt : "",
+  };
+}
+
+export function getWorkspaceTrustPath(homeDir = os.homedir()): string {
+  return path.join(homeDir, ".grok", WORKSPACE_TRUST_FILENAME);
+}
+
+export function getWorkspaceTrustKey(cwd = process.cwd()): string {
+  try {
+    return fs.realpathSync.native(cwd);
+  } catch {
+    return path.resolve(cwd);
+  }
+}
+
+export function loadWorkspaceTrustStore(trustPath = getWorkspaceTrustPath()): WorkspaceTrustStore {
+  try {
+    if (!fs.existsSync(trustPath)) return { version: 1, workspaces: {} };
+    const parsed = JSON.parse(fs.readFileSync(trustPath, "utf-8")) as unknown;
+    const rawWorkspaces = isRecord(parsed) && isRecord(parsed.workspaces) ? parsed.workspaces : {};
+    const workspaces: Record<string, WorkspaceTrustEntry> = {};
+    for (const [workspace, entry] of Object.entries(rawWorkspaces)) {
+      const normalized = normalizeTrustEntry(entry);
+      if (normalized) workspaces[workspace] = normalized;
+    }
+    return { version: 1, workspaces };
+  } catch {
+    return { version: 1, workspaces: {} };
+  }
+}
+
+export function getWorkspaceTrustDecision(
+  cwd = process.cwd(),
+  trustPath = getWorkspaceTrustPath(),
+): SandboxMode | null {
+  const store = loadWorkspaceTrustStore(trustPath);
+  return store.workspaces[getWorkspaceTrustKey(cwd)]?.sandboxMode ?? null;
+}
+
+export function saveWorkspaceTrustDecision(
+  cwd: string,
+  sandboxMode: SandboxMode,
+  trustPath = getWorkspaceTrustPath(),
+): void {
+  const store = loadWorkspaceTrustStore(trustPath);
+  store.workspaces[getWorkspaceTrustKey(cwd)] = {
+    sandboxMode,
+    updatedAt: new Date().toISOString(),
+  };
+  fs.mkdirSync(path.dirname(trustPath), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(trustPath, JSON.stringify(store, null, 2), { mode: 0o600 });
+}

--- a/src/utils/workspace-trust.ts
+++ b/src/utils/workspace-trust.ts
@@ -13,6 +13,11 @@ interface WorkspaceTrustStore {
   workspaces: Record<string, WorkspaceTrustEntry>;
 }
 
+export interface WorkspaceTrustPromptDecision {
+  sandboxMode: SandboxMode;
+  remember: boolean;
+}
+
 export const WORKSPACE_TRUST_FILENAME = "workspace-trust.json";
 
 export function isShuruSandboxSupported(platform = process.platform, arch = process.arch): boolean {
@@ -43,6 +48,25 @@ export function getWorkspaceTrustKey(cwd = process.cwd()): string {
   } catch {
     return path.resolve(cwd);
   }
+}
+
+export function resolveWorkspaceTrustPromptAnswer(
+  answer: string,
+  sandboxSupported: boolean,
+): WorkspaceTrustPromptDecision {
+  const normalized = answer.trim().toLowerCase();
+  if (normalized === "s" || normalized === "session") {
+    return { sandboxMode: sandboxSupported ? "shuru" : "off", remember: false };
+  }
+
+  if (sandboxSupported) {
+    if (normalized === "n" || normalized === "no") {
+      return { sandboxMode: "off", remember: true };
+    }
+    return { sandboxMode: "shuru", remember: true };
+  }
+
+  return { sandboxMode: "off", remember: true };
 }
 
 export function loadWorkspaceTrustStore(trustPath = getWorkspaceTrustPath()): WorkspaceTrustStore {


### PR DESCRIPTION
## Summary
- prompt interactive users once per new workspace to choose sandbox, host, or session-only sandbox mode
- persist remembered workspace decisions in `~/.grok/workspace-trust.json` using canonical workspace paths
- keep explicit `--sandbox` / `--no-sandbox`, non-interactive, and unsupported-platform flows non-blocking

Fixes #273

## Validation
- `npx vitest run src/utils/workspace-trust.test.ts`
- `npx tsc --noEmit`
- `npx biome check src/index.ts src/utils/workspace-trust.ts src/utils/workspace-trust.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new interactive prompt and persistence layer that changes how `sandboxMode` is selected for first-time interactive runs; risk is mainly around unexpected prompting or incorrect defaulting/persisted decisions affecting execution environment.
> 
> **Overview**
> Adds a *workspace trust* flow for sandboxing: on the first **interactive** run in a directory, the CLI prompts to run in Shuru sandbox, run on host, or use session-only behavior, and can remember the choice in `~/.grok/workspace-trust.json` keyed by canonical workspace paths.
> 
> Integrates this resolution into interactive startup only (headless/non-interactive runs and explicit `--sandbox`/`--no-sandbox` keep existing behavior), and includes platform gating for Shuru support plus tests and README docs for the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89147259b307e2f76d47df394d55cfe6c97d36f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->