### PR TITLE
fix: stop chronic iTerm2 flicker by pinning non-blinking default cursor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,12 @@ async function startInteractive(
     },
   });
 
+  // iTerm2 reacts to the cursor hide/show pair OpenTUI emits each frame by flashing
+  // the window. Pinning a non-blinking, terminal-default cursor lets the renderer's
+  // dedup logic (anomalyco/opentui#287) short-circuit those writes after the first
+  // frame, eliminating the chronic blink reported in superagent-ai/grok-cli#292.
+  renderer.setCursorStyle({ style: "default", blinking: false });
+
   const onExit = () => {
     void agent.cleanup().finally(() => {
       renderer.destroy();


### PR DESCRIPTION
## Summary
- Closes #292 (chronic blinking in iTerm2 on macOS).
- On startup, set the renderer's cursor to the terminal-default, non-blinking style so OpenTUI's per-frame cursor-state dedup (anomalyco/opentui#287) can suppress redundant hide/show writes.

## Root cause
OpenTUI emits a cursor hide → draw → cursor show pair every frame. With the default block + (implicitly) blinking cursor, iTerm2 treats those writes as state changes and repaints the window, which the user perceives as a full-window flash on each keystroke and at the cursor blink rate (~1 Hz) while waiting for a response. Same family of bug as sst/opencode#3780.

## Fix
After `createCliRenderer(...)`, call:
```ts
renderer.setCursorStyle({ style: "default", blinking: false });
```
With the cursor pinned, OpenTUI's dedup short-circuits the per-frame cursor ANSI writes after the first frame.

## Test plan
- [x] `bun run typecheck`
- [x] Manual: launch `bun run src/index.ts` in iTerm2 on macOS — confirmed no flicker on keystrokes and no per-second flicker while awaiting a response. Verified the same flicker occurred on `main` immediately prior.
- [ ] Verify on Kitty / WezTerm / Terminal.app that no cursor regression appears (no flicker was present there originally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small startup-time TUI renderer setting change that only affects cursor appearance/ANSI output behavior.
> 
> **Overview**
> Sets the interactive TUI renderer cursor style to `default` with `blinking: false` immediately after `createCliRenderer()` to prevent iTerm2 from flashing on OpenTUI’s per-frame cursor hide/show sequence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28fcbdaa652fec66807072a31c599756b1c9beb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->