### PR TITLE
test: trigger Brin PR scanner

### DIFF
--- a/.github/workflows/brin-security-scanner-test.yml
+++ b/.github/workflows/brin-security-scanner-test.yml
@@ -1,0 +1,20 @@
+# DO NOT MERGE: intentionally unsafe workflow used to test the Brin PR scanner.
+name: Brin Security Scanner Test
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions: write-all
+
+jobs:
+  unsafe-test-fixture:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout untrusted PR code
+        uses: actions/checkout@main
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Interpolate untrusted PR title
+        run: echo "PR title: ${{ github.event.pull_request.title }}"


### PR DESCRIPTION
## Summary
- Adds an intentionally unsafe GitHub Actions workflow fixture to trigger the Brin PR scanner.
- This PR is for scanner validation only and should not be merged.

## Test plan
- Confirm the Brin GitHub App receives the PR webhook.
- Confirm the PR scan flags the workflow with actionable CI/CD findings.
- Close this PR after validation.