### PR TITLE
test: trigger Brin inline annotations

### DIFF
--- a/.github/workflows/brin-inline-annotations-test-2.yml
+++ b/.github/workflows/brin-inline-annotations-test-2.yml
@@ -1,0 +1,20 @@
+# DO NOT MERGE: intentionally unsafe workflow used to test Brin inline annotations.
+name: Brin Inline Annotation Test 2
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions: write-all
+
+jobs:
+  unsafe-test-fixture:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout untrusted PR code
+        uses: actions/checkout@main
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Interpolate untrusted PR title
+        run: echo "PR title: ${{ github.event.pull_request.title }}"


### PR DESCRIPTION
## Summary
- Adds an intentionally unsafe GitHub Actions workflow fixture to trigger Brin inline check annotations.
- This PR is for scanner validation only and should not be merged.

## Test plan
- Confirm the Brin GitHub App receives the PR webhook.
- Confirm the PR scan emits inline check annotations instead of a large marker comment.
- Close this PR after validation.