### PR TITLE
test: trigger Brin review comments

### DIFF
--- a/.github/workflows/brin-review-comments-test.yml
+++ b/.github/workflows/brin-review-comments-test.yml
@@ -1,0 +1,20 @@
+# DO NOT MERGE: intentionally unsafe workflow used to test Brin review comments.
+name: Brin Review Comments Test
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions: write-all
+
+jobs:
+  unsafe-test-fixture:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout untrusted PR code
+        uses: actions/checkout@main
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Interpolate untrusted PR title
+        run: echo "PR title: ${{ github.event.pull_request.title }}"


### PR DESCRIPTION
## Summary
- Adds an intentionally unsafe GitHub Actions workflow fixture to trigger Brin inline review comments.
- This PR is for scanner validation only and should not be merged.

## Test plan
- Confirm the Brin GitHub App receives the PR webhook.
- Confirm the PR scan emits inline review comments on changed lines.
- Close this PR after validation.