### PR TITLE
test: verify Superagent flagged label color

### DIFF
--- a/.github/workflows/superagent-label-color-check.yml
+++ b/.github/workflows/superagent-label-color-check.yml
@@ -1,0 +1,17 @@
+# DO NOT MERGE: intentionally unsafe workflow used to verify Superagent label colors.
+name: Superagent Label Color Check
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions: write-all
+
+jobs:
+  unsafe-test-fixture:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout untrusted PR code
+        uses: actions/checkout@main
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## Summary
- Adds an intentionally unsafe workflow fixture to verify Superagent flagged label color.
- Expected result: Security scan should fail and apply `pr:flagged` with color `#b0237d`.

## Test plan
- Confirm Superagent receives the webhook.
- Confirm `pr:flagged` is applied with the new color.
- Close this PR after validation.