### PR TITLE
feat: add recaps toggle

### DIFF
--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -75,6 +75,7 @@ import {
   getCurrentModel,
   getModeSpecificModel,
   loadMcpServers,
+  loadRecapsEnabled,
   loadValidSubAgents,
   type SandboxMode,
   type SandboxSettings,
@@ -553,6 +554,7 @@ export class Agent {
   private sendTelegramFile: ((filePath: string) => Promise<ToolResult>) | null = null;
   private batchApi = false;
   private sessionStartHookFired = false;
+  private recapsEnabled = true;
 
   constructor(
     apiKey: string | undefined,
@@ -581,6 +583,7 @@ export class Agent {
     const envMax = Number(process.env.GROK_MAX_TOKENS);
     this.maxTokens = Number.isFinite(envMax) && envMax > 0 ? envMax : 16_384;
     this.batchApi = options.batchApi ?? false;
+    this.recapsEnabled = loadRecapsEnabled();
 
     if (options.persistSession !== false) {
       this.sessionStore = new SessionStore(this.bash.getCwd());
@@ -722,7 +725,15 @@ export class Agent {
   }
 
   getSessionRecap(): string | null {
-    return this.session?.recap?.text || null;
+    return this.recapsEnabled ? this.session?.recap?.text || null : null;
+  }
+
+  getRecapsEnabled(): boolean {
+    return this.recapsEnabled;
+  }
+
+  setRecapsEnabled(enabled: boolean): void {
+    this.recapsEnabled = enabled;
   }
 
   async askSideQuestion(question: string, signal?: AbortSignal): Promise<SideQuestionResult> {
@@ -859,7 +870,7 @@ export class Agent {
   }
 
   private async refreshSessionRecap(signal?: AbortSignal): Promise<void> {
-    if (!this.provider || !this.sessionStore || !this.session) {
+    if (!this.recapsEnabled || !this.provider || !this.sessionStore || !this.session) {
       return;
     }
 

--- a/src/agent/recap.test.ts
+++ b/src/agent/recap.test.ts
@@ -115,4 +115,44 @@ describe("Agent session recap", () => {
     expect(mocks.generateRecap).toHaveBeenCalled();
     expect(sessionStore.setRecap).toHaveBeenCalled();
   });
+
+  it("skips recap generation when recaps are disabled", async () => {
+    const { Agent, mocks } = await importAgentModuleWithRecapMocks();
+    const agent = new Agent(undefined, undefined, undefined, undefined, {
+      persistSession: false,
+    });
+    const session = {
+      id: "session-1",
+      workspaceId: "workspace-1",
+      title: null,
+      recap: null,
+      model: "grok-4.3",
+      mode: "agent",
+      cwdAtStart: process.cwd(),
+      cwdLast: process.cwd(),
+      status: "active",
+      createdAt: new Date("2026-04-22T15:00:00.000Z"),
+      updatedAt: new Date("2026-04-22T15:00:00.000Z"),
+    };
+    const sessionStore = {
+      setRecap: vi.fn(),
+      getRequiredSession: vi.fn(() => session),
+    };
+
+    agent.setRecapsEnabled(false);
+    Object.assign(agent as object, {
+      provider: {},
+      session,
+      sessionStore,
+    });
+
+    await (
+      agent as unknown as {
+        refreshSessionRecap: (signal?: AbortSignal) => Promise<void>;
+      }
+    ).refreshSessionRecap();
+
+    expect(mocks.generateRecap).not.toHaveBeenCalled();
+    expect(sessionStore.setRecap).not.toHaveBeenCalled();
+  });
 });

--- a/src/ui/app.tsx
+++ b/src/ui/app.tsx
@@ -55,6 +55,7 @@ import {
   saveMcpServers,
   savePaymentSettings,
   saveProjectSettings,
+  saveRecapsEnabled,
   saveUserSettings,
 } from "../utils/settings";
 import { discoverSkills, formatSkillsForChat } from "../utils/skills";
@@ -332,6 +333,8 @@ const BUILTIN_TYPED_SLASH_COMMANDS = new Set([
   "/model",
   "/models",
   "/sandbox",
+  "/recap",
+  "/recaps",
   "/remote-control",
   "/mcp",
   "/mcps",
@@ -447,6 +450,12 @@ const SANDBOX_ROWS: SandboxRow[] = [
 
 function getSandboxVisibleRows(mode: SandboxMode): SandboxRow[] {
   return mode === "shuru" ? SANDBOX_ROWS : SANDBOX_ROWS.slice(0, 1);
+}
+
+const RECAP_OPTIONS = ["Off", "On"] as const;
+
+function formatRecapsEnabled(enabled: boolean): (typeof RECAP_OPTIONS)[number] {
+  return enabled ? "On" : "Off";
 }
 
 interface WalletDisplayInfo {
@@ -606,6 +615,8 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
   const [sandboxSettingsFocusIndex, setSandboxSettingsFocusIndex] = useState(0);
   const [sandboxSettingsEditing, setSandboxSettingsEditing] = useState<string | null>(null);
   const [sandboxSettingsEditBuffer, setSandboxSettingsEditBuffer] = useState("");
+  const [showRecapPicker, setShowRecapPicker] = useState(false);
+  const [recapsEnabled, setRecapsEnabledState] = useState(() => agent.getRecapsEnabled());
   const [showWalletPicker, setShowWalletPicker] = useState(false);
   const [walletSettings, setWalletSettings] = useState<Required<PaymentSettings>>(() => loadPaymentSettings());
   const [walletFocusIndex, setWalletFocusIndex] = useState(0);
@@ -853,6 +864,23 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
     setSandboxSettingsEditing(null);
     setSandboxSettingsEditBuffer("");
     setShowSandboxPicker(true);
+  }, []);
+
+  const applyRecapsEnabled = useCallback(
+    (enabled: boolean) => {
+      agent.setRecapsEnabled(enabled);
+      for (const telegramAgent of telegramAgentsRef.current.values()) {
+        telegramAgent.setRecapsEnabled(enabled);
+      }
+      setRecapsEnabledState(enabled);
+      saveRecapsEnabled(enabled);
+      setSessionRecap(agent.getSessionRecap());
+    },
+    [agent],
+  );
+
+  const openRecapPicker = useCallback(() => {
+    setShowRecapPicker(true);
   }, []);
 
   const applyWalletSettings = useCallback((next: Required<PaymentSettings>) => {
@@ -2007,7 +2035,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
     clearLiveTurnUi();
     setSessionTitle(snapshot?.session.title ?? null);
     setSessionId(snapshot?.session.id ?? agent.getSessionId());
-    setSessionRecap(snapshot?.session.recap?.text ?? agent.getSessionRecap());
+    setSessionRecap(agent.getSessionRecap());
     setActivePlan(null);
     setPqs(initialPlanQuestionsState());
     replacePasteBlocks([]);
@@ -2201,6 +2229,10 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
         openSandboxPicker();
         return true;
       }
+      if (c === "/recap" || c === "/recaps") {
+        openRecapPicker();
+        return true;
+      }
       if (c === "/wallet") {
         openWalletPicker();
         return true;
@@ -2298,6 +2330,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
       handleExit,
       openAgentsModal,
       openMcpModal,
+      openRecapPicker,
       openSandboxPicker,
       openWalletPicker,
       openScheduleModal,
@@ -2322,6 +2355,9 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
           break;
         case "sandbox":
           openSandboxPicker();
+          break;
+        case "recaps":
+          openRecapPicker();
           break;
         case "wallet":
           openWalletPicker();
@@ -2393,6 +2429,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
       handleExit,
       openAgentsModal,
       openMcpModal,
+      openRecapPicker,
       openSandboxPicker,
       openWalletPicker,
       openScheduleModal,
@@ -2408,6 +2445,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
     showTelegramPairModal ||
     showMcpModal ||
     showSandboxPicker ||
+    showRecapPicker ||
     showWalletPicker ||
     !!pendingPaymentApproval ||
     showScheduleModal ||
@@ -2979,6 +3017,29 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
         }
         return;
       }
+      if (showRecapPicker) {
+        if (isEscapeKey(key)) {
+          setShowRecapPicker(false);
+          return;
+        }
+        if (key.name === "left" || key.name === "right") {
+          const current = formatRecapsEnabled(recapsEnabled);
+          const idx = RECAP_OPTIONS.indexOf(current);
+          const next =
+            key.name === "right"
+              ? RECAP_OPTIONS[Math.min(RECAP_OPTIONS.length - 1, idx + 1)]
+              : RECAP_OPTIONS[Math.max(0, idx - 1)];
+          if (next && next !== current) {
+            applyRecapsEnabled(next === "On");
+          }
+          return;
+        }
+        if (key.name === "return") {
+          applyRecapsEnabled(!recapsEnabled);
+          return;
+        }
+        return;
+      }
       if (showWalletPicker) {
         if (isEscapeKey(key)) {
           setShowWalletPicker(false);
@@ -3248,8 +3309,10 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
       planTabCount,
       pqs,
       removeEditingSubagent,
+      applyRecapsEnabled,
       applySandboxMode,
       applySandboxSettings,
+      recapsEnabled,
       sandboxSettings,
       sandboxSettingsEditing,
       sandboxSettingsEditBuffer,
@@ -3257,6 +3320,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
       sandboxMode,
       showModelPicker,
       showPlanPanel,
+      showRecapPicker,
       showSandboxPicker,
       pendingPaymentApproval,
       processMessage,
@@ -3640,6 +3704,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
           height={height}
         />
       )}
+      {showRecapPicker && <RecapPickerModal t={t} enabled={recapsEnabled} width={width} height={height} />}
       {showSandboxPicker && (
         <SandboxPickerModal
           t={t}
@@ -5454,6 +5519,67 @@ function SandboxPickerModal({
               ? "type value  enter confirm  esc cancel"
               : "arrows navigate  left/right toggle  enter edit  esc close"}
           </text>
+        </box>
+      </box>
+    </box>
+  );
+}
+
+function RecapPickerModal({
+  t,
+  enabled,
+  width,
+  height,
+}: {
+  t: Theme;
+  enabled: boolean;
+  width: number;
+  height: number;
+}) {
+  const panelHeight = Math.min(7, Math.floor(height * 0.6));
+  const top = bottomAlignedModalTop(height, panelHeight);
+  const overlayBg = "#000000cc" as string;
+  const display = formatRecapsEnabled(enabled);
+
+  return (
+    <box
+      position="absolute"
+      left={0}
+      top={0}
+      width={width}
+      height={height}
+      alignItems="center"
+      paddingTop={top}
+      backgroundColor={overlayBg}
+    >
+      <box
+        width={Math.min(64, width - 6)}
+        height={panelHeight}
+        backgroundColor={t.backgroundPanel}
+        paddingTop={1}
+        paddingBottom={1}
+        flexDirection="column"
+      >
+        <box flexShrink={0} flexDirection="row" justifyContent="space-between" paddingLeft={2} paddingRight={2}>
+          <text fg={t.primary}>
+            <b>{"Recap settings"}</b>
+          </text>
+          <text fg={t.textMuted}>{"esc"}</text>
+        </box>
+        <box flexGrow={1} minHeight={0}>
+          <box backgroundColor={t.selectedBg} paddingLeft={2} paddingRight={2} width="100%">
+            <box width="100%" flexDirection="row" justifyContent="space-between">
+              <text fg={t.selected}>{"Recaps"}</text>
+              <text fg={t.primary}>
+                {"< "}
+                {display}
+                {" >"}
+              </text>
+            </box>
+          </box>
+        </box>
+        <box flexShrink={0} paddingLeft={2} paddingRight={2} paddingTop={1}>
+          <text fg={t.textMuted}>{"left/right toggle  enter cycle  esc close"}</text>
         </box>
       </box>
     </box>

--- a/src/ui/slash-menu.test.ts
+++ b/src/ui/slash-menu.test.ts
@@ -17,4 +17,8 @@ describe("filterSlashMenuItems", () => {
     expect(ids).toContain("sandbox");
     expect(ids.indexOf("models")).toBeLessThan(ids.indexOf("sandbox"));
   });
+
+  it("finds the recaps command from singular aliases", () => {
+    expect(filterSlashMenuItems(SLASH_MENU_ITEMS, "recap")[0]?.id).toBe("recaps");
+  });
 });

--- a/src/ui/slash-menu.ts
+++ b/src/ui/slash-menu.ts
@@ -15,6 +15,7 @@ export const SLASH_MENU_ITEMS: SlashMenuItem[] = [
   { id: "sandbox", label: "sandbox", description: "Select shell sandbox mode" },
   { id: "wallet", label: "wallet", description: "Wallet and payment settings" },
   { id: "models", label: "models", description: "Select a model", aliases: ["model", "mode"] },
+  { id: "recaps", label: "recaps", description: "Turn session recaps on/off", aliases: ["recap", "summary"] },
   { id: "new", label: "new session", description: "Start a new session" },
   { id: "commit-push", label: "commit & push", description: "Commit and push" },
   { id: "commit-pr", label: "commit & pr", description: "Commit and open PR" },

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -162,6 +162,7 @@ export function loadValidSubAgents(): CustomSubagentConfig[] {
 export interface UserSettings {
   apiKey?: string;
   defaultModel?: string;
+  recapsEnabled?: boolean;
   sandboxMode?: SandboxMode;
   sandbox?: SandboxSettings;
   lsp?: LspSettings;
@@ -593,6 +594,14 @@ export function getReasoningEffortForModel(modelId: string): ReasoningEffort | u
     savedEfforts[normalizedModelId] ??
     Object.entries(savedEfforts).find(([savedModelId]) => normalizeModelId(savedModelId) === normalizedModelId)?.[1];
   return getEffectiveReasoningEffort(normalizedModelId, effort);
+}
+
+export function loadRecapsEnabled(): boolean {
+  return loadUserSettings().recapsEnabled !== false;
+}
+
+export function saveRecapsEnabled(enabled: boolean): void {
+  saveUserSettings({ recapsEnabled: enabled });
 }
 
 export function getTelegramBotToken(): string | undefined {


### PR DESCRIPTION
## What does this PR do?

Adds a `/recaps` settings menu so users can turn session recaps on or off from the TUI. When recaps are disabled, the agent skips recap generation and hides the recap banner, while persisting the preference in user settings.

Fixes #

## Checklist

- [x] I tested my changes
- [x] I reviewed my own code

## Test plan

- `bun run typecheck`
- `bun run test src/agent/recap.test.ts`
- `bun run test src/ui/slash-menu.test.ts`
- `bunx biome check src/ui/app.tsx src/ui/slash-menu.ts src/ui/slash-menu.test.ts src/agent/agent.ts src/agent/recap.test.ts src/utils/settings.ts`