### PR TITLE
Test Superagent CI/CD workflow review comments

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -6,12 +6,18 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions: write-all
+
 jobs:
   ci:
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
+
+    - name: Echo PR metadata
+      if: github.event_name == 'pull_request'
+      run: echo "PR title is ${{ github.event.pull_request.title }}"
 
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary

Intentional workflow hardening test for Superagent PR security scanning. This PR modifies `.github/workflows/typecheck.yml` with patterns the CI/CD scanner should flag so we can verify inline review comments on workflow files.

**Do not merge.** Close after validating Superagent comments/checks.

## Changes

- Adds broad `permissions: write-all` at workflow scope
- Adds a `run` step that interpolates `${{ github.event.pull_request.title }}` directly in shell

## Test plan

- [ ] Confirm **Superagent Security Scan** check runs on this PR
- [ ] Confirm inline review comment(s) appear on `.github/workflows/typecheck.yml` with `ci_cd` findings
- [ ] Close PR without merging