### PR TITLE
Test PR scan sandbox dedup on rapid commits

### DIFF
--- a/.github/workflows/superagent-pr-scan-dedup-test.yml
+++ b/.github/workflows/superagent-pr-scan-dedup-test.yml
@@ -11,3 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Echo PR metadata
+        if: github.event_name == 'pull_request'
+        run: echo "PR title is ${{ github.event.pull_request.title }}"

--- a/.github/workflows/superagent-pr-scan-dedup-test.yml
+++ b/.github/workflows/superagent-pr-scan-dedup-test.yml
@@ -1,0 +1,13 @@
+name: Superagent PR scan dedup test
+
+on:
+  pull_request:
+    branches: [main, develop]
+
+permissions: write-all
+
+jobs:
+  dedup-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Validates that back-to-back PR commits do not collide on Daytona sandbox names during Superagent Security Scan.

**Do not merge.** Close after both scans complete without `Sandbox with name ... already exists` errors.

## Test plan

- [ ] First commit triggers Superagent Security Scan successfully
- [ ] Second commit triggers another scan on the same PR without sandbox name collision
- [ ] Close PR without merging