### PR TITLE
Fix durable payment receipts

### DIFF
--- a/src/payments/history.ts
+++ b/src/payments/history.ts
@@ -1,17 +1,38 @@
 import * as fs from "fs";
-import * as os from "os";
 import * as path from "path";
+import { getCodesurfConfigDir } from "../utils/config-dir";
 import type { PaymentAuditRecord } from "./types";
+
+function syncDirectory(dirPath: string): void {
+  const fd = fs.openSync(dirPath, "r");
+  try {
+    fs.fsyncSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
+}
 
 export class PaymentHistory {
   static getLogPath(): string {
-    return path.join(os.homedir(), ".grok", "payment_log.jsonl");
+    return path.join(getCodesurfConfigDir(), "payment_log.jsonl");
   }
 
   record(entry: PaymentAuditRecord): void {
     const logPath = PaymentHistory.getLogPath();
-    fs.mkdirSync(path.dirname(logPath), { recursive: true, mode: 0o700 });
-    fs.appendFileSync(logPath, `${JSON.stringify(entry)}\n`, { encoding: "utf-8", mode: 0o600, flag: "a" });
+    try {
+      fs.mkdirSync(path.dirname(logPath), { recursive: true, mode: 0o700 });
+      const fd = fs.openSync(logPath, "a", 0o600);
+      try {
+        fs.writeFileSync(fd, `${JSON.stringify(entry)}\n`, { encoding: "utf-8" });
+        fs.fsyncSync(fd);
+      } finally {
+        fs.closeSync(fd);
+      }
+      syncDirectory(path.dirname(logPath));
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`Failed to persist payment receipt at ${logPath}: ${msg}`, { cause: err });
+    }
   }
 
   list(limit = 20): PaymentAuditRecord[] {

--- a/src/payments/service.test.ts
+++ b/src/payments/service.test.ts
@@ -1,0 +1,170 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PaymentAuditRecord } from "./types";
+
+const originalCodesurfConfigDir = process.env.CODESURF_CONFIG_DIR;
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  vi.doUnmock("../utils/settings");
+  vi.doUnmock("../wallet/manager");
+  vi.doUnmock("./agentkit-loader");
+  vi.doUnmock("./brin");
+  vi.doUnmock("./history");
+  vi.resetModules();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  if (originalCodesurfConfigDir === undefined) delete process.env.CODESURF_CONFIG_DIR;
+  else process.env.CODESURF_CONFIG_DIR = originalCodesurfConfigDir;
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function base64Json(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), "utf-8").toString("base64");
+}
+
+function paymentTermsHeader(): string {
+  return base64Json({
+    accepts: [
+      {
+        scheme: "exact",
+        network: "base-sepolia",
+        asset: "USDC",
+        amount: "0.01",
+      },
+    ],
+  });
+}
+
+async function importServiceWithMocks(options: {
+  paidResponse: Response;
+  record?: (entry: PaymentAuditRecord) => void;
+}) {
+  vi.resetModules();
+  const recordMock = vi.fn<(entry: PaymentAuditRecord) => void>(options.record ?? (() => {}));
+  const x402Fetch = vi.fn(async () => options.paidResponse);
+  const fetchMock = vi.fn(async () => {
+    return new Response("payment required", {
+      status: 402,
+      headers: { "payment-required": paymentTermsHeader() },
+    });
+  });
+
+  vi.stubGlobal("fetch", fetchMock);
+  vi.doMock("../utils/settings", () => ({
+    loadPaymentSettings: () => ({
+      enabled: true,
+      chain: "base-sepolia",
+      approval: { autoApprove: true },
+    }),
+  }));
+  vi.doMock("../wallet/manager", () => ({
+    WalletManager: class {
+      static exists(): boolean {
+        return true;
+      }
+
+      getStoredWallet(): { privateKey: `0x${string}`; address: string; chain: "base-sepolia"; createdAt: string } {
+        return {
+          privateKey: `0x${"1".repeat(64)}` as `0x${string}`,
+          address: "0xwallet",
+          chain: "base-sepolia",
+          createdAt: "2026-06-14T00:00:00.000Z",
+        };
+      }
+    },
+  }));
+  vi.doMock("./brin", () => ({
+    scanUrl: vi.fn(async () => null),
+  }));
+  vi.doMock("./agentkit-loader", () => ({
+    createX402Fetch: vi.fn(async () => x402Fetch),
+  }));
+  vi.doMock("./history", () => ({
+    PaymentHistory: class {
+      static getLogPath(): string {
+        return "/tmp/payment_log.jsonl";
+      }
+
+      record(entry: PaymentAuditRecord): void {
+        recordMock(entry);
+      }
+    },
+  }));
+
+  const { X402Service } = await import("./service");
+  return { service: new X402Service(), recordMock };
+}
+
+describe("X402Service.paidRequest receipt handling", () => {
+  it("surfaces an unparseable proof on a successful payment instead of recording txHash=null", async () => {
+    const malformedProof = Buffer.from("{not-json", "utf-8").toString("base64");
+    const { service, recordMock } = await importServiceWithMocks({
+      paidResponse: new Response("paid body", {
+        status: 200,
+        headers: { "payment-response": malformedProof },
+      }),
+    });
+
+    await expect(service.paidRequest({ url: "https://merchant.test/paid" })).rejects.toThrow(
+      /Payment succeeded, but the payment proof header could not be parsed/,
+    );
+    expect(recordMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces receipt write failures after a successful payment with transaction context", async () => {
+    const { service, recordMock } = await importServiceWithMocks({
+      paidResponse: new Response("paid body", {
+        status: 200,
+        headers: { "payment-response": base64Json({ transaction: "0xabc123" }) },
+      }),
+      record: () => {
+        throw new Error("disk full");
+      },
+    });
+
+    await expect(service.paidRequest({ url: "https://merchant.test/paid" })).rejects.toThrow(
+      /Payment succeeded but the receipt could not be persisted .*tx=0xabc123.*disk full/,
+    );
+    expect(recordMock).toHaveBeenCalledTimes(1);
+    expect(recordMock.mock.calls[0]?.[0]).toMatchObject({
+      status: "success",
+      txHash: "0xabc123",
+    });
+  });
+});
+
+describe("PaymentHistory", () => {
+  it("stores receipts in the Codesurf config directory", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "codesurf-payment-history-test-"));
+    tempDirs.push(tempDir);
+    process.env.CODESURF_CONFIG_DIR = tempDir;
+    vi.resetModules();
+    vi.doUnmock("./history");
+
+    const { PaymentHistory } = await import("./history");
+    const logPath = path.join(tempDir, "payment_log.jsonl");
+    expect(PaymentHistory.getLogPath()).toBe(logPath);
+
+    new PaymentHistory().record({
+      id: "receipt-1",
+      sessionId: null,
+      url: "https://merchant.test/paid",
+      domain: "merchant.test",
+      method: "GET",
+      chain: "base-sepolia",
+      network: "base-sepolia",
+      asset: "USDC",
+      amount: "0.01",
+      txHash: "0xabc123",
+      status: "success",
+      createdAt: "2026-06-14T00:00:00.000Z",
+    });
+
+    expect(fs.readFileSync(logPath, "utf-8")).toContain('"txHash":"0xabc123"');
+  });
+});

--- a/src/payments/service.ts
+++ b/src/payments/service.ts
@@ -3,7 +3,7 @@ import { WalletManager } from "../wallet/manager";
 import { createX402Fetch } from "./agentkit-loader";
 import { type BrinScanResult, scanUrl } from "./brin";
 import { PaymentHistory } from "./history";
-import type { PaymentInspectionResult, PaymentOption } from "./types";
+import type { PaymentAuditRecord, PaymentInspectionResult, PaymentOption } from "./types";
 
 interface RequestArgs {
   url: string;
@@ -24,6 +24,16 @@ function getDomain(url: string): string {
 
 function getAmountLabel(option: PaymentOption): string {
   return option.amount ?? option.maxAmountRequired ?? option.price ?? "0";
+}
+
+function getErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function parsePaymentResponseTxHash(header: string): string | null {
+  const proof = JSON.parse(Buffer.from(header, "base64").toString("utf-8")) as Record<string, unknown>;
+  const txHash = proof.transaction ?? proof.txHash ?? proof.tx_hash ?? proof.hash;
+  return typeof txHash === "string" && txHash.trim().length > 0 ? txHash : null;
 }
 
 function parsePaymentTerms(response: Response): {
@@ -168,14 +178,30 @@ export class X402Service {
     let txHash: string | null = null;
     if (paymentResponseHeader) {
       try {
-        const proof = JSON.parse(Buffer.from(paymentResponseHeader, "base64").toString("utf-8"));
-        txHash = proof.transaction ?? proof.txHash ?? proof.tx_hash ?? proof.hash ?? null;
-      } catch {
-        // ignore
+        txHash = parsePaymentResponseTxHash(paymentResponseHeader);
+      } catch (err: unknown) {
+        if (success) {
+          throw new Error(
+            `Payment succeeded, but the payment proof header could not be parsed. Receipt was not recorded as a clean success without a transaction hash. Original error: ${getErrorMessage(err)}`,
+            { cause: err },
+          );
+        }
       }
     }
 
-    this.history.record({
+    if (success && !paymentResponseHeader) {
+      throw new Error(
+        "Payment succeeded, but no payment proof header was returned. Receipt was not recorded as a clean success without a transaction hash.",
+      );
+    }
+
+    if (success && !txHash) {
+      throw new Error(
+        "Payment succeeded, but the payment proof did not include a transaction hash. Receipt was not recorded as a clean success without a transaction hash.",
+      );
+    }
+
+    const auditRecord: PaymentAuditRecord = {
       id: crypto.randomUUID(),
       sessionId: sessionId ?? null,
       url: args.url,
@@ -188,7 +214,17 @@ export class X402Service {
       txHash,
       status: success ? "success" : "failed",
       createdAt: new Date().toISOString(),
-    });
+    };
+
+    try {
+      this.history.record(auditRecord);
+    } catch (err: unknown) {
+      const txPart = txHash ? ` tx=${txHash}` : "";
+      throw new Error(
+        `Payment ${success ? "succeeded" : "completed"} but the receipt could not be persisted (${method} ${args.url}, ${amount} ${selected.asset} on ${selected.network}${txPart}). Original error: ${getErrorMessage(err)}`,
+        { cause: err },
+      );
+    }
 
     const lines = [responseText];
     if (txHash) {


### PR DESCRIPTION
## Summary
- make payment history writes fsync-backed and config-dir aware
- surface successful payments with malformed/missing proof instead of recording clean success with txHash=null
- add regression coverage for proof parse failure, receipt write failure, and Codesurf config-dir history path

## Validation
- bunx vitest run src/payments/service.test.ts
- bun run typecheck
- bun run test
- bunx biome check src/payments/service.ts src/payments/history.ts src/payments/service.test.ts

Note: full `bun run lint` is blocked by pre-existing Biome diagnostics outside src/payments in this worktree. The requested remote base `codesurf` does not exist on GitHub; `main` is the available remote base.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes post-payment error handling and audit logging for real money flows; happy-path behavior is preserved but new throws can surface after funds move if proof or disk I/O fails.
> 
> **Overview**
> Payment audit logs now live under the **Codesurf config directory** (via `getCodesurfConfigDir`) instead of a hard-coded `~/.grok` path, and each receipt append **fsyncs the log file and parent directory** so entries are less likely to be lost on crash. Write failures raise explicit errors from `PaymentHistory.record`.
> 
> For **successful** x402 payments, `paidRequest` no longer records a clean success when the `payment-response` header is missing, unparseable, or lacks a transaction hash—it **throws** with a clear message and skips persisting a misleading `txHash=null` receipt. Receipt persistence failures after payment are also surfaced with URL, amount, and `tx` context.
> 
> Adds **`service.test.ts`** coverage for malformed proof headers, disk-full receipt writes, and config-dir log path behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c8d8b36dbada4ed90d2b035fa4ed59433731158. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->