### PR TITLE
Test contributor trust threshold

### DIFF
--- a/.github/superagent.yml
+++ b/.github/superagent.yml
@@ -1,0 +1,2 @@
+contributorTrust:
+  blockBelowScore: 95

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # grok-cli: an open-source coding agent for the Grok API
 
+Contributor trust threshold test PR.
+
 [![CI](https://github.com/superagent-ai/grok-cli/actions/workflows/typecheck.yml/badge.svg)](https://github.com/superagent-ai/grok-cli/actions/workflows/typecheck.yml)
 [![npm](https://img.shields.io/npm/v/grok-dev.svg)](https://www.npmjs.com/package/grok-dev)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)


### PR DESCRIPTION
## Summary
- Add a temporary Superagent contributor trust threshold of 95 for debugging.
- Add a small README marker so the PR has a visible content diff.

## Test plan
- This PR is intended to trigger the Superagent GitHub app contributor trust flow for inspection in GitHub.