### PR TITLE
fix: load bun:sqlite at runtime with node:sqlite fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ Grok CLI (`@vibe-kit/grok-cli`) is a single-package TypeScript CLI tool — no d
 - **Bun** must be installed (not pre-installed on Cloud VMs). The update script handles this.
 - `GROK_API_KEY` environment variable is required for API calls. Set it as a secret.
 - `src/storage/db.ts` runtime-loads `bun:sqlite` and falls back to `node:sqlite` when unavailable, so the storage layer also works under Node. Note `bun run test` (`bunx vitest run`) still executes under the Bun runtime; to actually exercise the Node fallback path, run `node node_modules/.bin/vitest run`.
+- The `node:sqlite` fallback must call `statement.setAllowBareNamedParameters(true)` (see `prepareWithBareNamedParameters` in `db.ts`) to match Bun's `strict: true` binding of bare named params (e.g. `{ id }` against `@id`). Per Node's own docs the unprefixed form is not guaranteed without this call, and `node:sqlite` is still experimental — don't remove the call just because a given Node build happens to work without it.
 
 ## Maintaining this file
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,3 +28,11 @@ Grok CLI (`@vibe-kit/grok-cli`) is a single-package TypeScript CLI tool — no d
 
 - **Bun** must be installed (not pre-installed on Cloud VMs). The update script handles this.
 - `GROK_API_KEY` environment variable is required for API calls. Set it as a secret.
+- `src/storage/db.ts` runtime-loads `bun:sqlite` and falls back to `node:sqlite` when unavailable, so the storage layer also works under Node. Note `bun run test` (`bunx vitest run`) still executes under the Bun runtime; to actually exercise the Node fallback path, run `node node_modules/.bin/vitest run`.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/storage/db.test.ts
+++ b/src/storage/db.test.ts
@@ -1,10 +1,21 @@
 import fs from "fs";
+import { createRequire } from "module";
 import os from "os";
 import path from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { closeDatabase, getDatabase, withTransaction } from "./db";
 
+const require = createRequire(import.meta.url);
 const originalHome = process.env.HOME;
+
+function isBunSqliteAvailable(): boolean {
+  try {
+    require("bun:sqlite");
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 describe("storage database", () => {
   const tempRoot = path.join(process.cwd(), ".tmp-db-tests");
@@ -42,6 +53,56 @@ describe("storage database", () => {
     };
 
     expect(row.value).toBe("hello world");
+  });
+
+  it("binds bare named parameters (e.g. { id } against @id) and persists the value", () => {
+    const db = getDatabase();
+
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS storage_named_param_test (
+        id INTEGER PRIMARY KEY,
+        value TEXT NOT NULL
+      ) STRICT;
+    `);
+
+    db.prepare("INSERT INTO storage_named_param_test (id, value) VALUES (@id, @value)").run({
+      id: 3,
+      value: "named param value",
+    });
+
+    const row = db.prepare("SELECT value FROM storage_named_param_test WHERE id = @id").get({ id: 3 }) as {
+      value: string | null;
+    };
+
+    expect(row).toBeDefined();
+    expect(row.value).not.toBeNull();
+    expect(row.value).toBe("named param value");
+  });
+
+  it("enables bare named parameters on node:sqlite prepared statements", async () => {
+    if (isBunSqliteAvailable()) {
+      // bun:sqlite is opened with strict: true and never goes through the
+      // node:sqlite fallback, so there is nothing to spy on in this runtime.
+      return;
+    }
+
+    const { StatementSync } = (await import("node:sqlite")) as typeof import("node:sqlite");
+    const spy = vi.spyOn(StatementSync.prototype, "setAllowBareNamedParameters");
+
+    const db = getDatabase();
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS storage_named_param_spy_test (
+        id INTEGER PRIMARY KEY,
+        value TEXT NOT NULL
+      ) STRICT;
+    `);
+
+    db.prepare("INSERT INTO storage_named_param_spy_test (id, value) VALUES (@id, @value)").run({
+      id: 1,
+      value: "spied value",
+    });
+
+    expect(spy).toHaveBeenCalledWith(true);
   });
 
   it("commits writes made inside a transaction", () => {

--- a/src/storage/db.test.ts
+++ b/src/storage/db.test.ts
@@ -1,0 +1,65 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { closeDatabase, getDatabase, withTransaction } from "./db";
+
+const originalHome = process.env.HOME;
+
+describe("storage database", () => {
+  const tempRoot = path.join(process.cwd(), ".tmp-db-tests");
+  let tempHome = "";
+
+  beforeEach(() => {
+    fs.mkdirSync(tempRoot, { recursive: true });
+    tempHome = fs.mkdtempSync(path.join(tempRoot, "grok-db-home-"));
+    process.env.HOME = tempHome;
+    vi.spyOn(os, "homedir").mockReturnValue(tempHome);
+    closeDatabase();
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    vi.restoreAllMocks();
+    process.env.HOME = originalHome;
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it("initializes and round-trips a write/read", () => {
+    const db = getDatabase();
+
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS storage_smoke_test (
+        id INTEGER PRIMARY KEY,
+        value TEXT NOT NULL
+      ) STRICT;
+    `);
+
+    db.prepare("INSERT INTO storage_smoke_test (id, value) VALUES (?, ?)").run(1, "hello world");
+
+    const row = db.prepare("SELECT value FROM storage_smoke_test WHERE id = ?").get(1) as {
+      value: string;
+    };
+
+    expect(row.value).toBe("hello world");
+  });
+
+  it("commits writes made inside a transaction", () => {
+    getDatabase().exec(`
+      CREATE TABLE IF NOT EXISTS storage_smoke_test (
+        id INTEGER PRIMARY KEY,
+        value TEXT NOT NULL
+      ) STRICT;
+    `);
+
+    withTransaction((db) => {
+      db.prepare("INSERT INTO storage_smoke_test (id, value) VALUES (?, ?)").run(2, "in transaction");
+    });
+
+    const row = getDatabase().prepare("SELECT value FROM storage_smoke_test WHERE id = ?").get(2) as {
+      value: string;
+    };
+
+    expect(row.value).toBe("in transaction");
+  });
+});

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -1,8 +1,11 @@
-import { Database } from "bun:sqlite";
+import type { DatabaseSync } from "node:sqlite";
 import fs from "fs";
+import { createRequire } from "module";
 import os from "os";
 import path from "path";
 import { applyMigrations } from "./migrations";
+
+const require = createRequire(import.meta.url);
 
 export interface SQLiteStatement {
   run(...params: unknown[]): unknown;
@@ -53,7 +56,10 @@ class BunSqliteDatabase implements SQLiteDatabase {
   private readonly db: Database;
 
   constructor(filename: string) {
-    this.db = new Database(filename, { create: true, strict: true });
+    const BunDatabase = loadBunDatabase();
+    this.db = BunDatabase
+      ? new BunDatabase(filename, { create: true, strict: true })
+      : new NodeSqliteDatabase(filename);
   }
 
   exec(sql: string): void {
@@ -82,6 +88,76 @@ class BunSqliteDatabase implements SQLiteDatabase {
 
   transaction<T>(fn: () => T): () => T {
     return this.db.transaction(fn);
+  }
+
+  close(): void {
+    this.db.close();
+  }
+}
+
+type Database = {
+  exec(sql: string): void;
+  run(sql: string, params?: unknown): unknown;
+  query(sql: string): { get(params?: unknown): unknown; all(params?: unknown): unknown[] };
+  transaction<T>(fn: () => T): () => T;
+  close(): void;
+};
+
+function loadBunDatabase(): (new (filename: string, options: { create: boolean; strict: boolean }) => Database) | null {
+  try {
+    return require("bun:sqlite").Database as new (
+      filename: string,
+      options: { create: boolean; strict: boolean },
+    ) => Database;
+  } catch {
+    return null;
+  }
+}
+
+class NodeSqliteDatabase implements Database {
+  private readonly db: DatabaseSync;
+
+  constructor(filename: string) {
+    const { DatabaseSync } = require("node:sqlite") as typeof import("node:sqlite");
+    this.db = new DatabaseSync(filename);
+  }
+
+  exec(sql: string): void {
+    this.db.exec(sql);
+  }
+
+  run(sql: string, params?: unknown): unknown {
+    const statement = this.db.prepare(sql);
+    if (params === undefined) return statement.run();
+    return Array.isArray(params) ? statement.run(...(params as never[])) : statement.run(params as never);
+  }
+
+  query(sql: string): { get(params?: unknown): unknown; all(params?: unknown): unknown[] } {
+    const statement = this.db.prepare(sql);
+    return {
+      get: (params?: unknown) => {
+        if (params === undefined) return statement.get();
+        return Array.isArray(params) ? statement.get(...(params as never[])) : statement.get(params as never);
+      },
+      all: (params?: unknown) => {
+        if (params === undefined) return statement.all();
+        return Array.isArray(params) ? statement.all(...(params as never[])) : statement.all(params as never);
+      },
+    };
+  }
+
+  transaction<T>(fn: () => T): () => T {
+    return () => {
+      this.db.exec("BEGIN");
+      try {
+        const result = fn();
+        this.db.exec("COMMIT");
+        return result;
+      } catch (error) {
+        this.db.exec("ROLLBACK");
+        throw error;
+      }
+    };
   }
 
   close(): void {

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -127,13 +127,13 @@ class NodeSqliteDatabase implements Database {
   }
 
   run(sql: string, params?: unknown): unknown {
-    const statement = this.db.prepare(sql);
+    const statement = this.prepareWithBareNamedParameters(sql);
     if (params === undefined) return statement.run();
     return Array.isArray(params) ? statement.run(...(params as never[])) : statement.run(params as never);
   }
 
   query(sql: string): { get(params?: unknown): unknown; all(params?: unknown): unknown[] } {
-    const statement = this.db.prepare(sql);
+    const statement = this.prepareWithBareNamedParameters(sql);
     return {
       get: (params?: unknown) => {
         if (params === undefined) return statement.get();
@@ -144,6 +144,12 @@ class NodeSqliteDatabase implements Database {
         return Array.isArray(params) ? statement.all(...(params as never[])) : statement.all(params as never);
       },
     };
+  }
+
+  private prepareWithBareNamedParameters(sql: string): ReturnType<DatabaseSync["prepare"]> {
+    const statement = this.db.prepare(sql);
+    statement.setAllowBareNamedParameters?.(true);
+    return statement;
   }
 
   transaction<T>(fn: () => T): () => T {


### PR DESCRIPTION
## Summary
- `src/storage/db.ts` statically imported `bun:sqlite`, which only resolves under the Bun runtime. This blocked running storage tests under plain Node (e.g. `node node_modules/.bin/vitest run`), since `bunx vitest run` itself still executes under Bun.
- Loads `bun:sqlite` lazily via `createRequire` and falls back to Node's built-in `node:sqlite` (`DatabaseSync`) when Bun isn't available. Both backends satisfy the same internal `Database` shape, so the public `SQLiteDatabase` interface and all callers are unchanged.
- Adds `src/storage/db.test.ts`, a regression test that initializes the database and round-trips a write/read (including inside `withTransaction`), proving the storage layer now works under Node/Vitest.

Fixes #346

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run format`
- [x] `bunx vitest run` (Bun runtime) — 250/250 tests pass
- [x] `node node_modules/.bin/vitest run` (plain Node runtime) — 250/250 tests pass, confirming the `node:sqlite` fallback path works end-to-end

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core persistence and parameter binding on experimental node:sqlite; behavior must stay aligned with Bun’s strict mode for all existing callers.
> 
> **Overview**
> **Storage SQLite** no longer statically imports `bun:sqlite`, so Vitest and other tooling can run under plain Node. `db.ts` loads Bun’s driver via `createRequire` when available and otherwise uses `node:sqlite` (`DatabaseSync`) behind the same internal `Database` shape, leaving the public `SQLiteDatabase` API unchanged.
> 
> The Node path enables **bare named parameter** binding (`{ id }` → `@id`) via `setAllowBareNamedParameters(true)` and implements transactions with explicit `BEGIN`/`COMMIT`/`ROLLBACK`. New **`src/storage/db.test.ts`** covers init/read-write, named params, the Node-only spy on `setAllowBareNamedParameters`, and `withTransaction`. **`AGENTS.md`** documents the dual-runtime behavior and test commands; **`CLAUDE.md`** points agents at `AGENTS.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e221bced3fc90ab3f5f160e1cbe539b1411d27a8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->