### PR TITLE
feat(ui): add keyboard prompt navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,3 +28,10 @@ Grok CLI (`@vibe-kit/grok-cli`) is a single-package TypeScript CLI tool — no d
 
 - **Bun** must be installed (not pre-installed on Cloud VMs). The update script handles this.
 - `GROK_API_KEY` environment variable is required for API calls. Set it as a secret.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ grok uninstall --keep-config
 grok
 ```
 
+While reviewing the transcript, use `Ctrl+P` and `Ctrl+N` to move to the previous or next user prompt.
+
 ### Supported terminals
 
 For the most reliable interactive OpenTUI experience, use a modern terminal emulator. We currently document and recommend:

--- a/src/ui/app.tsx
+++ b/src/ui/app.tsx
@@ -669,7 +669,6 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
   /** Incremented on each successful TUI copy; drives a brief "Copied" banner. */
   const [copyFlashId, setCopyFlashId] = useState(0);
   const [promptFlashMessageIndex, setPromptFlashMessageIndex] = useState<number | null>(null);
-  const [isReviewingPrompts, setIsReviewingPrompts] = useState(false);
   const [expandedMessages, setExpandedMessages] = useState<Set<number>>(() => new Set());
   const [activeSubagent, setActiveSubagent] = useState<SubagentStatus | null>(null);
   const [pqs, setPqs] = useState<PlanQuestionsState>(initialPlanQuestionsState());
@@ -1105,7 +1104,6 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
         .getScheduleDaemonStatus()
         .then((status) => {
           isReviewingPromptsRef.current = false;
-          setIsReviewingPrompts(false);
           setMessages((prev) => [...prev, buildAssistantEntry(formatScheduleDetails(schedule, status))]);
           setShowScheduleModal(false);
           setScheduleSearchQuery("");
@@ -1133,7 +1131,6 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
           const latest = await agent.listSchedules();
           setSchedules(latest);
           isReviewingPromptsRef.current = false;
-          setIsReviewingPrompts(false);
           setScheduleModalIndex((index) => Math.max(0, Math.min(index, Math.max(0, latest.length - 1))));
           setMessages((prev) => [...prev, buildAssistantEntry(message)]);
           setTimeout(() => {
@@ -1394,7 +1391,6 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
 
   const setPromptReviewing = useCallback((reviewing: boolean) => {
     isReviewingPromptsRef.current = reviewing;
-    setIsReviewingPrompts(reviewing);
   }, []);
 
   const isAtTranscriptBottom = useCallback((scrollBox: ScrollBoxRenderable) => {
@@ -1404,11 +1400,11 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
 
   const syncPromptReview = useCallback(() => {
     const scrollBox = scrollRef.current;
-    if (!scrollBox || (!isReviewingPromptsRef.current && !isReviewingPrompts)) return;
+    if (!scrollBox || !isReviewingPromptsRef.current) return;
     if (isAtTranscriptBottom(scrollBox)) {
       setPromptReviewing(false);
     }
-  }, [isAtTranscriptBottom, isReviewingPrompts, setPromptReviewing]);
+  }, [isAtTranscriptBottom, setPromptReviewing]);
 
   const schedulePromptReviewSync = useCallback(() => {
     if (!isReviewingPromptsRef.current) return;
@@ -1419,7 +1415,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
     try {
       const scrollBox = scrollRef.current;
       if (!scrollBox) return;
-      if (isReviewingPromptsRef.current || isReviewingPrompts) {
+      if (isReviewingPromptsRef.current) {
         if (!isAtTranscriptBottom(scrollBox)) return;
         setPromptReviewing(false);
       }
@@ -1427,7 +1423,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
     } catch {
       /* */
     }
-  }, [isAtTranscriptBottom, isReviewingPrompts, setPromptReviewing]);
+  }, [isAtTranscriptBottom, setPromptReviewing]);
 
   const flashPrompt = useCallback((messageIndex: number) => {
     if (promptFlashTimeoutRef.current) {

--- a/src/ui/app.tsx
+++ b/src/ui/app.tsx
@@ -669,6 +669,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
   /** Incremented on each successful TUI copy; drives a brief "Copied" banner. */
   const [copyFlashId, setCopyFlashId] = useState(0);
   const [promptFlashMessageIndex, setPromptFlashMessageIndex] = useState<number | null>(null);
+  const [isReviewingPrompts, setIsReviewingPrompts] = useState(false);
   const [expandedMessages, setExpandedMessages] = useState<Set<number>>(() => new Set());
   const [activeSubagent, setActiveSubagent] = useState<SubagentStatus | null>(null);
   const [pqs, setPqs] = useState<PlanQuestionsState>(initialPlanQuestionsState());
@@ -678,6 +679,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
   const inputRef = useRef<TextareaRenderable>(null);
   const scrollRef = useRef<ScrollBoxRenderable>(null);
   const promptFlashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isReviewingPromptsRef = useRef(false);
   const { width, height } = useTerminalDimensions();
   const processedInitial = useRef(false);
   const contentAccRef = useRef("");
@@ -1102,6 +1104,8 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
       void agent
         .getScheduleDaemonStatus()
         .then((status) => {
+          isReviewingPromptsRef.current = false;
+          setIsReviewingPrompts(false);
           setMessages((prev) => [...prev, buildAssistantEntry(formatScheduleDetails(schedule, status))]);
           setShowScheduleModal(false);
           setScheduleSearchQuery("");
@@ -1128,6 +1132,8 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
         .then(async (message) => {
           const latest = await agent.listSchedules();
           setSchedules(latest);
+          isReviewingPromptsRef.current = false;
+          setIsReviewingPrompts(false);
           setScheduleModalIndex((index) => Math.max(0, Math.min(index, Math.max(0, latest.length - 1))));
           setMessages((prev) => [...prev, buildAssistantEntry(message)]);
           setTimeout(() => {
@@ -1386,13 +1392,42 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
 
   const userPromptIndex = useMemo(() => deriveUserPromptIndex(messages), [messages]);
 
+  const setPromptReviewing = useCallback((reviewing: boolean) => {
+    isReviewingPromptsRef.current = reviewing;
+    setIsReviewingPrompts(reviewing);
+  }, []);
+
+  const isAtTranscriptBottom = useCallback((scrollBox: ScrollBoxRenderable) => {
+    const maxScrollTop = Math.max(0, scrollBox.scrollHeight - scrollBox.viewport.height);
+    return scrollBox.scrollTop >= maxScrollTop;
+  }, []);
+
+  const syncPromptReview = useCallback(() => {
+    const scrollBox = scrollRef.current;
+    if (!scrollBox || (!isReviewingPromptsRef.current && !isReviewingPrompts)) return;
+    if (isAtTranscriptBottom(scrollBox)) {
+      setPromptReviewing(false);
+    }
+  }, [isAtTranscriptBottom, isReviewingPrompts, setPromptReviewing]);
+
+  const schedulePromptReviewSync = useCallback(() => {
+    if (!isReviewingPromptsRef.current) return;
+    setTimeout(syncPromptReview, 0);
+  }, [syncPromptReview]);
+
   const scrollToBottom = useCallback(() => {
     try {
-      scrollRef.current?.scrollTo(scrollRef.current?.scrollHeight ?? 99999);
+      const scrollBox = scrollRef.current;
+      if (!scrollBox) return;
+      if (isReviewingPromptsRef.current || isReviewingPrompts) {
+        if (!isAtTranscriptBottom(scrollBox)) return;
+        setPromptReviewing(false);
+      }
+      scrollBox.scrollTo(scrollBox.scrollHeight ?? 99999);
     } catch {
       /* */
     }
-  }, []);
+  }, [isAtTranscriptBottom, isReviewingPrompts, setPromptReviewing]);
 
   const flashPrompt = useCallback((messageIndex: number) => {
     if (promptFlashTimeoutRef.current) {
@@ -2059,6 +2094,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
   }, [interruptActiveRun, renderer]);
 
   const resetToNewSession = useCallback(() => {
+    setPromptReviewing(false);
     const snapshot = agent.startNewSession();
     setMessages(snapshot?.entries ?? []);
     setExpandedMessages(new Set());
@@ -2072,11 +2108,12 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
     replacePasteBlocks([]);
     queuedMessagesRef.current = [];
     setQueuedMessages([]);
-  }, [agent, clearLiveTurnUi, replacePasteBlocks]);
+  }, [agent, clearLiveTurnUi, replacePasteBlocks, setPromptReviewing]);
 
   const processMessage = useCallback(
     async (text: string, displayText?: string) => {
       if (!text.trim() || isProcessingRef.current) return;
+      setPromptReviewing(false);
       const runId = ++activeRunIdRef.current;
       const isStale = () => activeRunIdRef.current !== runId;
       isProcessingRef.current = true;
@@ -2187,6 +2224,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
       finalizeActiveTurn,
       scrollToBottom,
       sessionTitle,
+      setPromptReviewing,
       showLiveToolCalls,
     ],
   );
@@ -2573,10 +2611,11 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
       const target = findNearestPrompt(anchors, currentScrollTop, direction);
       if (!target) return;
 
+      setPromptReviewing(true);
       scrollBox.scrollTo(target.offset);
       flashPrompt(target.messageIndex);
     },
-    [flashPrompt, userPromptIndex],
+    [flashPrompt, setPromptReviewing, userPromptIndex],
   );
 
   // Intercept the raw control bytes before OpenTUI routes them to the focused
@@ -2600,6 +2639,9 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
 
   const handleKey = useCallback(
     (key: KeyEvent) => {
+      if (isReviewingPromptsRef.current) {
+        schedulePromptReviewSync();
+      }
       if (btwState) {
         if (isEscapeKey(key) || key.name === "return") {
           dismissBtw();
@@ -3260,14 +3302,6 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
         }
       }
 
-      const promptNavigationDirection = getPromptNavigationDirection(key);
-      if (promptNavigationDirection) {
-        navigateToPrompt(promptNavigationDirection);
-        key.preventDefault();
-        key.stopPropagation();
-        return;
-      }
-
       if (key.name === "e" && key.ctrl) {
         let lastUserIdx = -1;
         for (let i = messages.length - 1; i >= 0; i--) {
@@ -3369,6 +3403,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
       handlePlanSelect,
       handleSlashMenuSelect,
       interruptActiveRun,
+      schedulePromptReviewSync,
       isPlanConfirmTab,
       isProcessing,
       isSinglePlan,
@@ -3409,7 +3444,6 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
       showSandboxPicker,
       pendingPaymentApproval,
       processMessage,
-      navigateToPrompt,
       showWalletPicker,
       walletSettings,
       walletFocusIndex,
@@ -3483,6 +3517,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
       message = message.replace(getFileMentionToken(block), `@${block.path}`);
     }
     if (!message.trim()) return;
+    setPromptReviewing(false);
     if (!hasApiKeyRef.current) {
       openApiKeyModal();
       return;
@@ -3496,7 +3531,16 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
       return;
     }
     processMessage(enhancedMessage, displayText);
-  }, [agent, clearLiveTurnUi, handleCommand, openApiKeyModal, processMessage, replacePasteBlocks, scrollToBottom]);
+  }, [
+    agent,
+    clearLiveTurnUi,
+    handleCommand,
+    openApiKeyModal,
+    processMessage,
+    replacePasteBlocks,
+    scrollToBottom,
+    setPromptReviewing,
+  ]);
 
   const hasMessages = messages.length > 0 || streamContent || isProcessing;
 
@@ -3515,8 +3559,13 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
           <SessionHeader t={t} modeInfo={modeInfo} sessionTitle={sessionTitle} sessionId={sessionId} />
           <box flexGrow={1} paddingBottom={1} paddingTop={1} paddingLeft={2} paddingRight={2} gap={1}>
             {/* Scrollable messages */}
-            {/* biome-ignore lint/suspicious/noExplicitAny: OpenTUI type mismatch for stickyStart */}
-            <scrollbox ref={scrollRef} flexGrow={1} stickyScroll={true} stickyStart={"bottom" as any}>
+            <scrollbox
+              ref={scrollRef}
+              flexGrow={1}
+              stickyScroll={true}
+              stickyStart="bottom"
+              onMouseScroll={schedulePromptReviewSync}
+            >
               {messages.map((msg, i) => (
                 <MessageView
                   key={`${msg.timestamp.getTime()}-${msg.type}-${msg.remoteKey ?? ""}-${msg.content.slice(0, 24)}`}

--- a/src/ui/app.tsx
+++ b/src/ui/app.tsx
@@ -82,6 +82,13 @@ import {
   type PlanQuestionsState,
   PlanView,
 } from "./plan";
+import {
+  deriveUserPromptIndex,
+  findNearestPrompt,
+  getPromptNavigationDirection,
+  type PromptAnchor,
+  type PromptNavigationDirection,
+} from "./prompt-navigation";
 import { buildScheduleBrowseRows, ScheduleBrowserModal } from "./schedule-modal";
 import { filterSlashMenuItems, SLASH_MENU_ITEMS, type SlashMenuItem } from "./slash-menu";
 import {
@@ -661,6 +668,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
   const [activePlan, setActivePlan] = useState<Plan | null>(null);
   /** Incremented on each successful TUI copy; drives a brief "Copied" banner. */
   const [copyFlashId, setCopyFlashId] = useState(0);
+  const [promptFlashMessageIndex, setPromptFlashMessageIndex] = useState<number | null>(null);
   const [expandedMessages, setExpandedMessages] = useState<Set<number>>(() => new Set());
   const [activeSubagent, setActiveSubagent] = useState<SubagentStatus | null>(null);
   const [pqs, setPqs] = useState<PlanQuestionsState>(initialPlanQuestionsState());
@@ -669,6 +677,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
   const apiKeyInputRef = useRef<TextareaRenderable>(null);
   const inputRef = useRef<TextareaRenderable>(null);
   const scrollRef = useRef<ScrollBoxRenderable>(null);
+  const promptFlashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const { width, height } = useTerminalDimensions();
   const processedInitial = useRef(false);
   const contentAccRef = useRef("");
@@ -1375,12 +1384,34 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
     setScheduleModalIndex((idx) => Math.max(0, Math.min(idx, Math.max(0, scheduleRows.length - 1))));
   }, [scheduleRows.length]);
 
+  const userPromptIndex = useMemo(() => deriveUserPromptIndex(messages), [messages]);
+
   const scrollToBottom = useCallback(() => {
     try {
       scrollRef.current?.scrollTo(scrollRef.current?.scrollHeight ?? 99999);
     } catch {
       /* */
     }
+  }, []);
+
+  const flashPrompt = useCallback((messageIndex: number) => {
+    if (promptFlashTimeoutRef.current) {
+      clearTimeout(promptFlashTimeoutRef.current);
+    }
+
+    setPromptFlashMessageIndex(messageIndex);
+    promptFlashTimeoutRef.current = setTimeout(() => {
+      setPromptFlashMessageIndex(null);
+      promptFlashTimeoutRef.current = null;
+    }, 600);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (promptFlashTimeoutRef.current) {
+        clearTimeout(promptFlashTimeoutRef.current);
+      }
+    };
   }, []);
 
   const clearLiveTurnUi = useCallback(() => {
@@ -1464,7 +1495,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
   const applyTelegramAssistantPreview = useCallback(
     (fullContent: string) => {
       const activeTurn = activeTurnRef.current;
-      if (!activeTurn || activeTurn.kind !== "telegram") return;
+      if (activeTurn?.kind !== "telegram") return;
 
       activeTurn.latestAssistantText = fullContent;
       contentAccRef.current = getUnflushedTelegramAssistantContent(fullContent, activeTurn.flushedAssistantChars);
@@ -2521,6 +2552,52 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
     setBtwState(null);
   }, []);
 
+  const navigateToPrompt = useCallback(
+    (direction: PromptNavigationDirection) => {
+      const scrollBox = scrollRef.current;
+      if (!scrollBox) return;
+
+      const currentScrollTop = scrollBox.scrollTop;
+      const children = scrollBox.getChildren();
+      const anchors = userPromptIndex.flatMap<PromptAnchor>((messageIndex) => {
+        const child = children[messageIndex];
+        if (!child) return [];
+
+        return [
+          {
+            messageIndex,
+            offset: currentScrollTop + child.y - scrollBox.viewport.y,
+          },
+        ];
+      });
+      const target = findNearestPrompt(anchors, currentScrollTop, direction);
+      if (!target) return;
+
+      scrollBox.scrollTo(target.offset);
+      flashPrompt(target.messageIndex);
+    },
+    [flashPrompt, userPromptIndex],
+  );
+
+  // Intercept the raw control bytes before OpenTUI routes them to the focused
+  // textarea or scrollbox. This keeps prompt navigation separate from
+  // composer history and ordinary arrow movement.
+  useEffect(() => {
+    const onRawPromptNavigation = (sequence: string) => {
+      const parsed = parseKeypress(sequence, { useKittyKeyboard: renderer.useKittyKeyboard });
+      const direction = parsed ? getPromptNavigationDirection(parsed) : null;
+      if (!direction) return false;
+
+      navigateToPrompt(direction);
+      return true;
+    };
+
+    renderer.prependInputHandler(onRawPromptNavigation);
+    return () => {
+      renderer.removeInputHandler(onRawPromptNavigation);
+    };
+  }, [navigateToPrompt, renderer]);
+
   const handleKey = useCallback(
     (key: KeyEvent) => {
       if (btwState) {
@@ -3183,6 +3260,14 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
         }
       }
 
+      const promptNavigationDirection = getPromptNavigationDirection(key);
+      if (promptNavigationDirection) {
+        navigateToPrompt(promptNavigationDirection);
+        key.preventDefault();
+        key.stopPropagation();
+        return;
+      }
+
       if (key.name === "e" && key.ctrl) {
         let lastUserIdx = -1;
         for (let i = messages.length - 1; i >= 0; i--) {
@@ -3324,6 +3409,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
       showSandboxPicker,
       pendingPaymentApproval,
       processMessage,
+      navigateToPrompt,
       showWalletPicker,
       walletSettings,
       walletFocusIndex,
@@ -3439,6 +3525,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
                   t={t}
                   modeColor={modeInfo.color}
                   expandedMessages={expandedMessages}
+                  highlightedPrompt={promptFlashMessageIndex === i}
                 />
               ))}
               {liveTurnSourceLabel && (activeToolCalls.length > 0 || streamContent || isProcessing) && (
@@ -4235,12 +4322,14 @@ function MessageView({
   t,
   modeColor,
   expandedMessages,
+  highlightedPrompt,
 }: {
   entry: ChatEntry;
   index: number;
   t: Theme;
   modeColor: string;
   expandedMessages?: Set<number>;
+  highlightedPrompt?: boolean;
 }) {
   switch (entry.type) {
     case "user":
@@ -4248,7 +4337,7 @@ function MessageView({
         <box
           border={["left"]}
           customBorderChars={SPLIT}
-          borderColor={entry.modeColor || modeColor}
+          borderColor={highlightedPrompt ? t.accent : entry.modeColor || modeColor}
           marginTop={index === 0 ? 0 : 1}
           marginBottom={1}
         >
@@ -4256,7 +4345,7 @@ function MessageView({
             paddingTop={1}
             paddingBottom={1}
             paddingLeft={2}
-            backgroundColor={t.backgroundPanel}
+            backgroundColor={highlightedPrompt ? t.selectedBg : t.backgroundPanel}
             flexShrink={0}
             flexDirection="column"
           >

--- a/src/ui/prompt-navigation.test.ts
+++ b/src/ui/prompt-navigation.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveUserPromptIndex,
+  findNearestPrompt,
+  getPromptNavigationDirection,
+  type PromptAnchor,
+} from "./prompt-navigation";
+
+describe("deriveUserPromptIndex", () => {
+  it("returns the positions of user chat entries from the existing entry list", () => {
+    expect(
+      deriveUserPromptIndex([{ type: "assistant" }, { type: "user" }, { type: "tool_result" }, { type: "user" }]),
+    ).toEqual([1, 3]);
+  });
+
+  it("also recognizes transcript messages by role", () => {
+    expect(deriveUserPromptIndex([{ role: "system" }, { role: "user" }, { role: "assistant" }])).toEqual([1]);
+  });
+});
+
+describe("findNearestPrompt", () => {
+  const anchors: PromptAnchor[] = [
+    { messageIndex: 1, offset: 10 },
+    { messageIndex: 4, offset: 80 },
+    { messageIndex: 7, offset: 160 },
+  ];
+
+  it("finds the nearest previous prompt relative to the current scroll", () => {
+    expect(findNearestPrompt(anchors, 120, "previous")).toEqual(anchors[1]);
+  });
+
+  it("finds the nearest next prompt relative to the current scroll", () => {
+    expect(findNearestPrompt(anchors, 80, "next")).toEqual(anchors[2]);
+  });
+
+  it("stops at both boundaries without wrapping", () => {
+    expect(findNearestPrompt(anchors, 0, "previous")).toBeNull();
+    expect(findNearestPrompt(anchors, 160, "next")).toBeNull();
+  });
+});
+
+describe("getPromptNavigationDirection", () => {
+  it("maps the unambiguous control-letter events to navigation actions", () => {
+    expect(getPromptNavigationDirection({ name: "p", ctrl: true, sequence: "\u0010" })).toBe("previous");
+    expect(getPromptNavigationDirection({ name: "n", ctrl: true, sequence: "\u000e" })).toBe("next");
+  });
+
+  it("does not treat terminal control-bracket bytes or arrow events as navigation", () => {
+    expect(getPromptNavigationDirection({ name: "escape", sequence: "\u001b" })).toBeNull();
+    expect(getPromptNavigationDirection({ name: "\u001d", sequence: "\u001d" })).toBeNull();
+    expect(getPromptNavigationDirection({ name: "up", ctrl: true })).toBeNull();
+    expect(getPromptNavigationDirection({ name: "down", ctrl: true })).toBeNull();
+  });
+});

--- a/src/ui/prompt-navigation.ts
+++ b/src/ui/prompt-navigation.ts
@@ -1,0 +1,66 @@
+export type PromptSourceEntry = {
+  role?: string;
+  type?: string;
+};
+
+export type PromptNavigationDirection = "previous" | "next";
+
+export type PromptNavigationKey = {
+  name?: string;
+  sequence?: string;
+  ctrl?: boolean;
+  shift?: boolean;
+  option?: boolean;
+  meta?: boolean;
+  super?: boolean;
+};
+
+export interface PromptAnchor {
+  messageIndex: number;
+  offset: number;
+}
+
+/**
+ * Map terminal-safe control-letter events to navigation actions. Control
+ * letters have unambiguous single-byte encodings and cannot be consumed as
+ * ordinary arrow movement by a focused textarea or scrollbox.
+ */
+export function getPromptNavigationDirection(key: PromptNavigationKey): PromptNavigationDirection | null {
+  if (key.ctrl && !key.shift && !key.option && !key.meta && !key.super) {
+    if (key.name === "p") return "previous";
+    if (key.name === "n") return "next";
+  }
+  return null;
+}
+
+/**
+ * Chat entries are derived from transcript messages. Keep prompt navigation
+ * derived from those entries so it cannot drift into a second message index.
+ */
+export function deriveUserPromptIndex(entries: readonly PromptSourceEntry[]): number[] {
+  return entries.flatMap((entry, index) => (entry.role === "user" || entry.type === "user" ? [index] : []));
+}
+
+/**
+ * Find the closest prompt strictly before or after the current scroll top.
+ * Strict comparisons make a prompt already at the top count as the current
+ * prompt, so navigation never wraps at either boundary.
+ */
+export function findNearestPrompt(
+  anchors: readonly PromptAnchor[],
+  currentScrollTop: number,
+  direction: PromptNavigationDirection,
+): PromptAnchor | null {
+  if (direction === "previous") {
+    for (let index = anchors.length - 1; index >= 0; index -= 1) {
+      const anchor = anchors[index];
+      if (anchor && anchor.offset < currentScrollTop) return anchor;
+    }
+    return null;
+  }
+
+  for (const anchor of anchors) {
+    if (anchor.offset > currentScrollTop) return anchor;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- Add read-only keyboard navigation through user prompts derived from existing transcript entries.
- Bind Ctrl+P to previous prompt and Ctrl+N to next prompt through the raw input path, avoiding composer history recall.
- Keep the transcript at the selected prompt while streaming and flash the target briefly.
- Suppress streaming auto-follow while prompt review is active, clearing the review lock when the user returns to the bottom or sends a new message.
- Keep Ctrl+P/Ctrl+N in exactly one handler so one keypress advances one prompt.

## Testing
- [x] bun run format
- [x] bun run typecheck
- [x] bun run lint (passes with five pre-existing unrelated warnings)
- [x] bun test src/ui/prompt-navigation.test.ts (7 tests)
- [x] Manually verified in the real bun run dev TUI with a local streaming API stub: after sending two prompts, one Ctrl+P while the composer was focused moved to the previous prompt, left composer text unchanged, flashed the target, and later stream chunks did not return the view to the bottom.
- [x] Verified the prompt-navigation binding is installed only through prependInputHandler; the duplicate handleKey path is removed.
- [x] No GIF or upstream merge performed.

Closes #345

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized TUI scroll and input behavior with dedicated tests; no auth, API, or data-path changes.
> 
> **Overview**
> Adds **read-only transcript navigation** between user prompts with **Ctrl+P** (previous) and **Ctrl+N** (next), documented in the README.
> 
> Bindings are handled via **`prependInputHandler`** on raw input so they do not fight composer history or normal arrow keys. A small **`prompt-navigation`** helper derives user-message indices from chat entries and picks the nearest scroll anchor without wrapping.
> 
> While you are reviewing a prompt, **streaming auto-follow is paused** until you scroll back to the bottom, send a message, clear the session, or similar; the selected user message gets a **brief accent flash**. Unit tests cover index derivation, nearest-prompt lookup, and key mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f62622c67d6c2a86514a63a67ebde7b8d455a55. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->