### PR TITLE
feat: add Grok 4.5 and 4.6 models

### DIFF
--- a/src/grok/models.ts
+++ b/src/grok/models.ts
@@ -2,6 +2,25 @@ import type { ModelInfo, ReasoningEffort } from "../types/index";
 
 export const MODELS: ModelInfo[] = [
   {
+    id: "grok-4.6",
+    name: "Grok 4.6",
+    contextWindow: 500_000,
+    inputPrice: 2.0,
+    outputPrice: 6.0,
+    reasoning: true,
+    description: "Latest flagship reasoning model",
+  },
+  {
+    id: "grok-4.5",
+    name: "Grok 4.5",
+    contextWindow: 500_000,
+    inputPrice: 2.0,
+    outputPrice: 6.0,
+    reasoning: true,
+    description: "Flagship reasoning model",
+    aliases: ["grok-4.5-latest", "grok-build-latest"],
+  },
+  {
     id: "grok-4.3",
     name: "Grok 4.3",
     contextWindow: 1_000_000,


### PR DESCRIPTION
## Summary

Adds the newly released **Grok 4.5** and **Grok 4.6** models to the hardcoded model registry in `src/grok/models.ts`.

Currently the CLI only knows models up to Grok 4.3, so both Grok 4.5 and Grok 4.6 must be entered via `--model` and are not listed by `grok models`.

## Changes

- Add `grok-4.6` — the latest flagship reasoning model.
- Add `grok-4.5` — flagship reasoning model, including its `grok-4.5-latest` and `grok-build-latest` aliases.
- Pricing (`$2 in / $6 out` per 1M tokens) and context window (`500K`) taken directly from the [xAI Models](https://docs.x.ai/docs/models) API.

## Verification

- `grok models` lists both new models with correct metadata.
- `bun run build` succeeds.
- Existing model tests in `src/grok/models.test.ts` pass.

## Screenshot

```
  grok-4.6 — Grok 4.6 (reasoning)
    Latest flagship reasoning model | 500K context | $2/$6 per 1M tokens
  grok-4.5 — Grok 4.5 (reasoning)
    Flagship reasoning model | 500K context | $2/$6 per 1M tokens
    aliases: grok-4.5-latest, grok-build-latest
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static catalog metadata only; no runtime, auth, or API behavior changes.
> 
> **Overview**
> Registers **Grok 4.6** and **Grok 4.5** in the hardcoded `MODELS` list in `models.ts` so `grok models` and `--model` can use them without manual IDs.
> 
> Both entries are reasoning flagships with **500K** context and **$2 / $6** per 1M input/output tokens. **Grok 4.5** also maps aliases `grok-4.5-latest` and `grok-build-latest`. **`DEFAULT_MODEL`** remains **`grok-4.3`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f966380f65c87b5c1472cf1c7c2e596bd480dea. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->