### PR TITLE
feat: port next-prompt suggester from pi-prompt-suggester

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 ### Overview
 
-Grok CLI (`@vibe-kit/grok-cli`) is a single-package TypeScript CLI tool — no databases, Docker, or background services. See `README.md` for full documentation and usage.
+grok-kev is a personal fork of Grok CLI — a single-package TypeScript CLI tool — no databases, Docker, or background services. See `README.md` for full documentation and usage.
 
 ### Quick reference
 
@@ -14,15 +14,15 @@ Grok CLI (`@vibe-kit/grok-cli`) is a single-package TypeScript CLI tool — no d
 | Install deps  | `bun install` (installs Husky; pre-commit runs Biome on staged files) |
 | Typecheck     | `bun run typecheck`                                                   |
 | Build         | `bun run build`                                                       |
-| Run built CLI | `node dist/index.js`                                                  |
-| Headless mode | `node dist/index.js --prompt "..." --max-tool-rounds N`               |
-| CLI help      | `node dist/index.js --help`                                           |
+| Run CLI       | `bun bin/grok.js` (auto-rebuilds stale `dist/`)                       |
+| Headless mode | `bun bin/grok.js --prompt "..." --max-tool-rounds N`                  |
+| CLI help      | `bun bin/grok.js --help`                                              |
 
 
 ### Known issues
 
 - **ESLint config is broken**: The repo has `.eslintrc.js` (legacy format) but uses ESLint 9 (`^9.31.0`) + `@typescript-eslint` v8, which require flat config (`eslint.config.js`). Additionally, `.eslintrc.js` uses `module.exports` (CJS) but `package.json` has `"type": "module"` (ESM). Running `bun run lint` will fail. Use `bun run typecheck` as the primary code quality check (this is also what CI enforces).
-- **Dev mode (`bun run dev` / `bun run dev:node`) fails at runtime**: `src/utils/model-config.ts` imports TypeScript interfaces (`UserSettings`, `ProjectSettings`) as value imports from `settings-manager.ts`. These type-only exports are erased at runtime by Bun and tsx, causing `SyntaxError: export '...' not found`. The fix is to use `import type` syntax, but this is a pre-existing repo issue. **Workaround**: build first (`bun run build`), then run the compiled version (`node dist/index.js`).
+- **Dev mode (`bun run dev` / `bun run dev:node`) fails at runtime**: `src/utils/model-config.ts` imports TypeScript interfaces (`UserSettings`, `ProjectSettings`) as value imports from `settings-manager.ts`. These type-only exports are erased at runtime by Bun and tsx, causing `SyntaxError: export '...' not found`. The fix is to use `import type` syntax, but this is a pre-existing repo issue. **Workaround**: run `bun bin/grok.js` (or `grok` / `grok-kev`), which rebuilds `dist/` when source is newer.
 
 ### Environment
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Dedicated grep tool powered by npm ripgrep WASM (#263)
 - `/btw` command for side questions (#264)
+- `/resume` command to switch to a saved workspace session from the TUI
+- Splash screen shows upstream updates; `ctrl+u` / `/update` installs them
 
 ### Changed
+- Renamed the `grok-dev` CLI command to `grok-kev`
+- Branded this checkout as `grok-kev`
+- `grok` / `grok-kev` rebuild a source checkout automatically when `dist/` is stale
 - Switched Telegram voice/audio transcription from whisper.cpp to Grok STT (`/v1/stt`); removed `whisper-cli`, `ffmpeg`, and model-download requirements (#266, #265)
 - Install script warns when auto-resolving to a pre-release version (#269)
 - Release workflow publishes Sigstore build-provenance attestations (#271)

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,6 +1,20 @@
-MIT License
+# Third-party notices
 
-Copyright (c) [year] [copyright holders]
+## pi-prompt-suggester
+
+The next-prompt suggester in `src/suggester/` is a Grok CLI port of
+[pi-prompt-suggester](https://github.com/guwidoe/pi-prompt-suggester)
+by **Guido Witt-Dörring**.
+
+Copyright (c) 2026 Guido Witt-Dörring
+
+Licensed under the MIT License. A copy of that license is included below.
+The original design, two-stage seed + suggestion pipeline, steering
+classifications, and several prompt templates were adapted from that
+project. This port reimplements the product for Grok CLI / OpenTUI; it
+is not a drop-in of the Pi extension.
+
+### MIT License (pi-prompt-suggester)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -9,20 +23,13 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission statement shall be included in all
+The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+LIABILITY, WHETHER IN ANY ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
----
-
-This repository includes a port of pi-prompt-suggester
-(https://github.com/guwidoe/pi-prompt-suggester),
-Copyright (c) 2026 Guido Witt-Dörring, licensed under the MIT License.
-See NOTICE.md.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -2,7 +2,7 @@
 
 ## pi-prompt-suggester
 
-The next-prompt suggester in `src/suggester/` is a Grok CLI port of
+The next-prompt suggester plugin in `src/suggester/` is a Grok CLI port of
 [pi-prompt-suggester](https://github.com/guwidoe/pi-prompt-suggester)
 by **Guido Witt-Dörring**.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-# grok-cli: an open-source coding agent for the Grok API
+# grok-kev
 
-[![CI](https://github.com/superagent-ai/grok-cli/actions/workflows/typecheck.yml/badge.svg)](https://github.com/superagent-ai/grok-cli/actions/workflows/typecheck.yml)
-[![npm](https://img.shields.io/npm/v/grok-dev.svg)](https://www.npmjs.com/package/grok-dev)
+Personal fork of [superagent-ai/grok-cli](https://github.com/superagent-ai/grok-cli).
+The local command is `grok-kev`. Stock `grok` / `grok-dev` stay untouched.
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.9-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![Bun](https://img.shields.io/badge/Bun-1.x-000000?logo=bun&logoColor=white)](https://bun.sh/)
@@ -44,7 +45,7 @@ grok uninstall --keep-config
 **Interactive (default)** — launches the OpenTUI coding agent:
 
 ```bash
-grok
+grok-kev
 ```
 
 ### Supported terminals
@@ -86,7 +87,9 @@ grok --session latest
 grok -s <session-id>
 ```
 
-Works in interactive mode too—same flag.
+Works in interactive mode too—same flag. Inside the TUI, `/resume` opens a
+searchable picker of this workspace's sessions. `/resume latest` and
+`/resume <session-id>` switch immediately.
 
 **Structured headless output:**
 
@@ -142,17 +145,43 @@ Use `/schedule` in the TUI to browse saved schedules. One-time schedules start
 immediately in the background; recurring schedules keep running as long as the
 daemon is active.
 
-**Next-prompt suggestions** — after each interactive turn, the TUI may ghost a
-likely next user prompt and inserts it into the empty editor. It also keeps a
-background project-intent seed and learns if you accept or rewrite suggestions.
-`Esc` clears an untouched fill. It never auto-sends. `/suggester reseed`
-refreshes the seed; `/suggester instruction set ...` adds a preference;
-`/suggester ghost` goes back to dim placeholder + `Space`. Headless `--prompt`
-mode is unchanged.
+**Next-prompt suggestions** — bundled plugin, off until you install it:
 
-This suggester is a port of
+```text
+/install suggester
+```
+
+After each interactive turn, the TUI may ghost a likely next user prompt
+into the empty editor. It also keeps a background project-intent seed and
+learns if you accept or rewrite suggestions. `Esc` clears an untouched fill.
+It never auto-sends. `/suggester reseed` refreshes the seed;
+`/suggester instruction set ...` adds a preference; `/suggester ghost` goes
+back to dim placeholder + `Space`. `/uninstall suggester` removes it.
+Headless `--prompt` mode is unchanged.
+
+The suggester is a complete Grok CLI port of
 [pi-prompt-suggester](https://github.com/guwidoe/pi-prompt-suggester)
 by **Guido Witt-Dörring** (MIT). See [`NOTICE.md`](./NOTICE.md).
+
+**GitHub plugins** — `/install owner/repo[@ref]` fetches `plugin.json` plus a
+relative `.js` entry from GitHub and loads it into the current TUI session.
+HTTPS GitHub only. The repo needs:
+
+```json
+{
+  "id": "weather",
+  "name": "Weather",
+  "description": "Look up the weather",
+  "version": "1.0.0",
+  "entry": "index.js",
+  "commands": ["weather"]
+}
+```
+
+`index.js` must export `createPlugin()` and return a plugin object with `id`
+and optional `handleCommand`. Files land in `~/.grok/plugins/`.
+`/uninstall weather` removes them. This is an in-process JS loader, not a
+sandbox. Only install repos you trust.
 
 **List Grok models and pricing hints:**
 
@@ -193,7 +222,7 @@ You keep using a text model for the session, and Grok saves generated media unde
 | **Computer use**                  | Built-in `**computer`** sub-agent for host desktop automation via `**agent-desktop`**. It prefers semantic accessibility snapshots and stable refs, with screenshots saved under `**.grok/computer/**` when requested.     |
 | **Custom sub-agents**             | Define named agents with `**subAgents`** in `**~/.grok/user-settings.json`** and manage them from the TUI with `**/agents**`.                                                                                              |
 | **Remote control**                | Pair **Telegram** from the TUI (`/remote-control` → Telegram): DM your bot, `**/pair`**, approve the code in-terminal. Keep the CLI running while you ping it from your phone.                                             |
-| **Next-prompt suggestions**       | After each interactive turn, the TUI inserts a likely next user prompt using conversation context plus a background project-intent seed. `**/suggester**` for status/reseed/instruction. Never auto-sends.                 |
+| **Next-prompt suggestions**       | Bundled plugin. `/install suggester`, then the TUI ghosts a likely next prompt after each turn. `/suggester` for status/reseed/instruction. Never auto-sends.                                                               |
 | **No “mystery meat” UI**          | OpenTUI React terminal UI—fast, keyboard-driven, not whatever glitchy thing you’re thinking of.                                                                                                                            |
 | **Skills**                        | Agent Skills under `**.agents/skills/<name>/SKILL.md`** (project) or `**~/.agents/skills/`** (user). Use `**/skills**` in the TUI to list what’s installed.                                                                |
 | **MCPs**                          | Extend with Model Context Protocol servers—configure via `**/mcps`** in the TUI or `**.grok/settings.json`** (`mcpServers`).                                                                                               |
@@ -234,7 +263,8 @@ grok -k your_key_here
 { "apiKey": "your_key_here" }
 ```
 
-Optional `**suggester**` — next-prompt ghosts after each interactive turn (`enabled` defaults to `true`):
+Optional `**suggester**` — next-prompt ghosts after `/install suggester`.
+`enabled` still defaults to `true` once the plugin is installed:
 
 ```json
 {
@@ -495,14 +525,16 @@ From a clone:
 
 ```bash
 bun install
-bun run build
 bun run start
-# or: node dist/index.js
+# or: grok-kev / grok after bun link
 ```
+
+`grok` and `grok-kev` rebuild `dist/` automatically when source files are newer. Skip that with `GROK_SKIP_REBUILD=1`.
 
 Other useful commands:
 
 ```bash
+bun run build
 bun run dev      # run from source (Bun)
 bun run typecheck
 bun run lint

--- a/README.md
+++ b/README.md
@@ -142,6 +142,18 @@ Use `/schedule` in the TUI to browse saved schedules. One-time schedules start
 immediately in the background; recurring schedules keep running as long as the
 daemon is active.
 
+**Next-prompt suggestions** — after each interactive turn, the TUI may ghost a
+likely next user prompt and inserts it into the empty editor. It also keeps a
+background project-intent seed and learns if you accept or rewrite suggestions.
+`Esc` clears an untouched fill. It never auto-sends. `/suggester reseed`
+refreshes the seed; `/suggester instruction set ...` adds a preference;
+`/suggester ghost` goes back to dim placeholder + `Space`. Headless `--prompt`
+mode is unchanged.
+
+This suggester is a port of
+[pi-prompt-suggester](https://github.com/guwidoe/pi-prompt-suggester)
+by **Guido Witt-Dörring** (MIT). See [`NOTICE.md`](./NOTICE.md).
+
 **List Grok models and pricing hints:**
 
 ```bash
@@ -181,6 +193,7 @@ You keep using a text model for the session, and Grok saves generated media unde
 | **Computer use**                  | Built-in `**computer`** sub-agent for host desktop automation via `**agent-desktop`**. It prefers semantic accessibility snapshots and stable refs, with screenshots saved under `**.grok/computer/**` when requested.     |
 | **Custom sub-agents**             | Define named agents with `**subAgents`** in `**~/.grok/user-settings.json`** and manage them from the TUI with `**/agents**`.                                                                                              |
 | **Remote control**                | Pair **Telegram** from the TUI (`/remote-control` → Telegram): DM your bot, `**/pair`**, approve the code in-terminal. Keep the CLI running while you ping it from your phone.                                             |
+| **Next-prompt suggestions**       | After each interactive turn, the TUI inserts a likely next user prompt using conversation context plus a background project-intent seed. `**/suggester**` for status/reseed/instruction. Never auto-sends.                 |
 | **No “mystery meat” UI**          | OpenTUI React terminal UI—fast, keyboard-driven, not whatever glitchy thing you’re thinking of.                                                                                                                            |
 | **Skills**                        | Agent Skills under `**.agents/skills/<name>/SKILL.md`** (project) or `**~/.agents/skills/`** (user). Use `**/skills**` in the TUI to list what’s installed.                                                                |
 | **MCPs**                          | Extend with Model Context Protocol servers—configure via `**/mcps`** in the TUI or `**.grok/settings.json`** (`mcpServers`).                                                                                               |
@@ -219,6 +232,18 @@ grok -k your_key_here
 
 ```json
 { "apiKey": "your_key_here" }
+```
+
+Optional `**suggester**` — next-prompt ghosts after each interactive turn (`enabled` defaults to `true`):
+
+```json
+{
+  "suggester": {
+    "enabled": true,
+    "model": "grok-3-mini",
+    "maxSuggestionChars": 200
+  }
+}
 ```
 
 Optional `**subAgents**` — custom foreground sub-agents. Each entry needs `**name**`, `**model**`, and `**instruction**`:

--- a/bin/ensure-built.d.ts
+++ b/bin/ensure-built.d.ts
@@ -1,0 +1,13 @@
+export function isSourceCheckout(root: string): boolean;
+
+export function findLocalTsc(root: string): string | null;
+
+export function shouldRebuild(root: string, options?: { env?: NodeJS.ProcessEnv }): { needed: boolean; reason: string };
+
+export function ensureBuilt(
+  root: string,
+  options?: {
+    env?: NodeJS.ProcessEnv;
+    runBuild?: (root: string) => { status?: number | null };
+  },
+): { rebuilt: boolean; reason: string; status: number };

--- a/bin/ensure-built.js
+++ b/bin/ensure-built.js
@@ -1,0 +1,106 @@
+import { spawnSync } from "child_process";
+import fs from "fs";
+import path from "path";
+
+const SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".json"]);
+const TEST_SUFFIXES = [".test.ts", ".test.tsx", ".spec.ts", ".spec.tsx", ".test.js", ".spec.js"];
+
+export function isSourceCheckout(root) {
+  return fs.existsSync(path.join(root, "src", "index.ts")) && fs.existsSync(path.join(root, "tsconfig.json"));
+}
+
+export function findLocalTsc(root) {
+  const candidate = path.join(root, "node_modules", "typescript", "bin", "tsc");
+  return fs.existsSync(candidate) ? candidate : null;
+}
+
+export function shouldRebuild(root, options = {}) {
+  const env = options.env ?? process.env;
+  if (env.GROK_SKIP_REBUILD) {
+    return { needed: false, reason: "GROK_SKIP_REBUILD is set" };
+  }
+  if (!isSourceCheckout(root)) {
+    return { needed: false, reason: "not a source checkout" };
+  }
+
+  const distIndex = path.join(root, "dist", "index.js");
+  if (!fs.existsSync(distIndex)) {
+    return { needed: true, reason: "dist/index.js is missing" };
+  }
+
+  const distMtime = fs.statSync(distIndex).mtimeMs;
+  const watched = [
+    path.join(root, "package.json"),
+    path.join(root, "tsconfig.json"),
+    ...listSourceFiles(path.join(root, "src")),
+  ];
+
+  for (const file of watched) {
+    if (!fs.existsSync(file)) continue;
+    if (fs.statSync(file).mtimeMs > distMtime) {
+      return { needed: true, reason: `${toPosix(path.relative(root, file))} is newer than dist` };
+    }
+  }
+
+  return { needed: false, reason: "dist is up to date" };
+}
+
+export function ensureBuilt(root, options = {}) {
+  const decision = shouldRebuild(root, options);
+  if (!decision.needed) {
+    return { rebuilt: false, reason: decision.reason, status: 0 };
+  }
+
+  const runBuild = options.runBuild ?? defaultRunBuild;
+  const result = runBuild(root);
+  const status = typeof result?.status === "number" ? result.status : 1;
+  if (status === 0) {
+    return { rebuilt: true, reason: decision.reason, status: 0 };
+  }
+
+  const hasDist = fs.existsSync(path.join(root, "dist", "index.js"));
+  return {
+    rebuilt: false,
+    reason: decision.reason,
+    status: hasDist ? 0 : status,
+  };
+}
+
+function defaultRunBuild(root) {
+  const tsc = findLocalTsc(root);
+  if (!tsc) {
+    console.error("Cannot rebuild: TypeScript is not installed. Run `bun install` first.");
+    return { status: 1 };
+  }
+
+  return spawnSync(process.execPath, [tsc, "-p", "tsconfig.json"], {
+    cwd: root,
+    stdio: "inherit",
+  });
+}
+
+function listSourceFiles(dir, files = []) {
+  if (!fs.existsSync(dir)) return files;
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name === "dist") continue;
+
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      listSourceFiles(full, files);
+      continue;
+    }
+    if (isTestFile(entry.name)) continue;
+    if (SOURCE_EXTENSIONS.has(path.extname(entry.name))) files.push(full);
+  }
+
+  return files;
+}
+
+function isTestFile(name) {
+  return TEST_SUFFIXES.some((suffix) => name.endsWith(suffix));
+}
+
+function toPosix(filePath) {
+  return filePath.split(path.sep).join("/");
+}

--- a/bin/grok.js
+++ b/bin/grok.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env bun
+import path from "path";
+import { fileURLToPath, pathToFileURL } from "url";
+import { ensureBuilt } from "./ensure-built.js";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const result = ensureBuilt(root);
+
+if (result.status !== 0) {
+  process.exit(result.status);
+}
+
+if (result.rebuilt) {
+  process.stderr.write(`Rebuilt CLI (${result.reason}).\n`);
+} else if (result.reason.includes("newer than dist")) {
+  process.stderr.write(`Using last good dist (${result.reason}; rebuild failed).\n`);
+}
+
+await import(pathToFileURL(path.join(root, "dist", "index.js")).href);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     }
   },
   "bin": {
-    "grok": "dist/index.js"
+    "grok": "dist/index.js",
+    "grok-dev": "dist/index.js"
   },
   "scripts": {
     "dev": "bun run src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "grok-dev",
+  "name": "grok-kev",
   "version": "1.1.7",
-  "description": "An open-source AI coding agent powered by Grok, built with Bun and OpenTUI.",
+  "description": "Personal grok-kev fork of the Grok CLI coding agent.",
   "type": "module",
   "main": "dist/index.js",
   "exports": {
@@ -11,14 +11,14 @@
     }
   },
   "bin": {
-    "grok": "dist/index.js",
-    "grok-dev": "dist/index.js"
+    "grok": "bin/grok.js",
+    "grok-kev": "bin/grok.js"
   },
   "scripts": {
     "dev": "bun run src/index.ts",
     "build": "tsc",
     "build:binary": "bun build --compile --outfile dist/grok-standalone ./src/index.ts",
-    "start": "bun run dist/index.js",
+    "start": "bun bin/grok.js",
     "typecheck": "tsc --noEmit",
     "test": "bunx vitest run",
     "test:watch": "bunx vitest",

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -1,6 +1,8 @@
 import { APICallError } from "@ai-sdk/provider";
 import { convertToBase64 } from "@ai-sdk/provider-utils";
 import { type ModelMessage, stepCountIs, streamText, type ToolSet } from "ai";
+import { existsSync, readFileSync } from "fs";
+import { resolve } from "path";
 import {
   addBatchRequests,
   type BatchChatCompletionRequest,
@@ -324,6 +326,24 @@ function formatCustomSubagentsPromptSection(subagents: CustomSubagentConfig[]): 
   return `\n\nCUSTOM SUB-AGENTS:\nUser-defined foreground sub-agents from ~/.grok/user-settings.json. When one matches the task, call the task tool with agent set to the exact name.\n\n${lines.join("\n\n")}\n`;
 }
 
+function loadSystemPrompt(): string | null {
+  const candidates = [
+    resolve(process.cwd(), "SYSTEM.md"),
+    resolve(__dirname, "../../../SYSTEM.md"),
+    resolve(__dirname, "../../../../SYSTEM.md"),
+  ];
+  for (const p of candidates) {
+    if (existsSync(p)) {
+      try {
+        return readFileSync(p, "utf8").trim();
+      } catch {
+        return null;
+      }
+    }
+  }
+  return null;
+}
+
 function buildSystemPrompt(
   cwd: string,
   mode: AgentMode,
@@ -346,7 +366,10 @@ function buildSystemPrompt(
     ? `\n\nAPPROVED PLAN:\nThe following plan has been approved by the user. Execute it now.\n${planContext}\n`
     : "";
 
-  return `${MODE_PROMPTS[mode]}${sandboxSection}${customSection}${skillsSection}${subagentsSection}${planSection}
+  const systemMd = loadSystemPrompt();
+  const systemSection = systemMd ? `\n\n${systemMd}\n\nFollow the above alongside standard instructions.\n` : "";
+
+  return `${systemSection}${MODE_PROMPTS[mode]}${sandboxSection}${customSection}${skillsSection}${subagentsSection}${planSection}
 
 Current working directory: ${cwd}`;
 }
@@ -795,16 +818,19 @@ export class Agent {
     this.startNewSession();
   }
 
+  private endCurrentSessionHook(): void {
+    if (!this.sessionStartHookFired) return;
+    const endInput: SessionEndHookInput = {
+      hook_event_name: "SessionEnd",
+      session_id: this.session?.id,
+      cwd: this.bash.getCwd(),
+    };
+    this.fireHook(endInput).catch(() => {});
+    this.sessionStartHookFired = false;
+  }
+
   startNewSession(): SessionSnapshot | null {
-    if (this.sessionStartHookFired) {
-      const endInput: SessionEndHookInput = {
-        hook_event_name: "SessionEnd",
-        session_id: this.session?.id,
-        cwd: this.bash.getCwd(),
-      };
-      this.fireHook(endInput).catch(() => {});
-      this.sessionStartHookFired = false;
-    }
+    this.endCurrentSessionHook();
 
     if (!this.sessionStore) {
       this.messages = [];
@@ -817,6 +843,56 @@ export class Agent {
     this.session = this.sessionStore.createSession(this.modelId, this.mode, this.bash.getCwd());
     this.messages = [];
     this.messageSeqs = [];
+    this.planContext = null;
+    return this.getSessionSnapshot();
+  }
+
+  listSessions(options: { limit?: number } = {}): SessionInfo[] {
+    if (!this.sessionStore) return [];
+    return this.sessionStore.listSessions(options);
+  }
+
+  private resolveSessionSelector(selector: string): SessionInfo | null {
+    if (!this.sessionStore) return null;
+    if (selector.toLowerCase() === "latest") {
+      return (
+        this.sessionStore.listSessions().find((session) => session.id !== this.session?.id) ??
+        this.sessionStore.getLatestSession()
+      );
+    }
+    return this.sessionStore.getSessionById(selector);
+  }
+
+  resumeSession(selector: string): SessionSnapshot | null {
+    if (!this.sessionStore) {
+      return null;
+    }
+
+    const trimmed = selector.trim();
+    if (!trimmed) {
+      throw new Error("Session selector is required.");
+    }
+
+    const target = this.resolveSessionSelector(trimmed);
+    if (!target) {
+      throw new Error(`Session "${trimmed}" was not found.`);
+    }
+
+    if (this.session?.id === target.id) {
+      return this.getSessionSnapshot();
+    }
+
+    this.endCurrentSessionHook();
+    this.sessionStore.touchSession(target.id, this.bash.getCwd());
+    this.session = this.sessionStore.getRequiredSession(target.id);
+    this.mode = this.session.mode;
+    if (this.session.model) {
+      this.modelId = normalizeModelId(this.session.model);
+    }
+    const transcript = loadTranscriptState(this.session.id);
+    this.messages = transcript.messages;
+    this.messageSeqs = transcript.seqs;
+    this.planContext = null;
     return this.getSessionSnapshot();
   }
 
@@ -2123,7 +2199,7 @@ export class Agent {
             const response = await result.response;
             if (!signal.aborted) {
               this.appendCompletedTurn(userModelMessage, sanitizeModelMessages(response.messages));
-              await this.refreshSessionRecap(signal);
+              void this.refreshSessionRecap(signal);
               streamOk = true;
             }
           } catch (responseError: unknown) {
@@ -2146,7 +2222,7 @@ export class Agent {
 
           if (!streamOk && assistantText.trim()) {
             this.appendCompletedTurn(userModelMessage, [{ role: "assistant", content: assistantText }]);
-            await this.refreshSessionRecap(signal);
+            void this.refreshSessionRecap(signal);
           }
 
           const stopInput: StopHookInput = {

--- a/src/agent/resume.test.ts
+++ b/src/agent/resume.test.ts
@@ -1,0 +1,106 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { closeDatabase } from "../storage/db";
+import { appendMessages, SessionStore } from "../storage/index";
+import { Agent } from "./agent";
+
+const originalHome = process.env.HOME;
+const originalCwd = process.cwd();
+
+describe("Agent.resumeSession", () => {
+  const tempRoot = path.join(os.tmpdir(), "grok-resume-tests");
+  let tempHome = "";
+  let tempCwd = "";
+
+  beforeEach(() => {
+    fs.mkdirSync(tempRoot, { recursive: true });
+    tempHome = fs.mkdtempSync(path.join(tempRoot, "grok-resume-home-"));
+    tempCwd = fs.mkdtempSync(path.join(tempRoot, "grok-resume-cwd-"));
+    process.env.HOME = tempHome;
+    vi.spyOn(os, "homedir").mockReturnValue(tempHome);
+    process.chdir(tempCwd);
+    closeDatabase();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    closeDatabase();
+    vi.restoreAllMocks();
+    process.env.HOME = originalHome;
+    fs.rmSync(tempHome, { recursive: true, force: true });
+    fs.rmSync(tempCwd, { recursive: true, force: true });
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it("returns null when session persistence is disabled", () => {
+    const agent = new Agent(undefined, undefined, undefined, undefined, {
+      persistSession: false,
+    });
+    expect(agent.resumeSession("latest")).toBeNull();
+    expect(agent.listSessions()).toEqual([]);
+  });
+
+  it("reloads the saved transcript, model, and mode", () => {
+    const store = new SessionStore(tempCwd);
+    const saved = store.createSession("grok-4.20-non-reasoning", "plan", tempCwd);
+    store.setTitle(saved.id, "Billing recap");
+    appendMessages(saved.id, [{ role: "user", content: "continue the billing work" }]);
+
+    const agent = new Agent(undefined, undefined, "grok-4.3", undefined, {
+      persistSession: true,
+    });
+    expect(agent.getSessionId()).not.toBe(saved.id);
+    expect(agent.getMode()).toBe("agent");
+
+    Object.assign(agent as object, { sessionStartHookFired: true });
+    const snapshot = agent.resumeSession(saved.id);
+
+    expect(snapshot?.session.id).toBe(saved.id);
+    expect(snapshot?.session.title).toBe("Billing recap");
+    expect(agent.getMode()).toBe("plan");
+    expect(agent.getModel()).toBe("grok-4.20-non-reasoning");
+    expect(snapshot?.entries.map((entry) => entry.content)).toContain("continue the billing work");
+    expect((agent as unknown as { sessionStartHookFired: boolean }).sessionStartHookFired).toBe(false);
+  });
+
+  it("is a no-op when the selector is the current session", () => {
+    const agent = new Agent(undefined, undefined, undefined, undefined, {
+      persistSession: true,
+    });
+    const currentId = agent.getSessionId();
+    expect(currentId).toBeTruthy();
+    Object.assign(agent as object, { sessionStartHookFired: true });
+
+    const snapshot = agent.resumeSession(currentId!);
+    expect(snapshot?.session.id).toBe(currentId);
+    expect((agent as unknown as { sessionStartHookFired: boolean }).sessionStartHookFired).toBe(true);
+  });
+
+  it("skips the current session when latest is requested", () => {
+    const store = new SessionStore(tempCwd);
+    const previous = store.createSession("grok-4.20-non-reasoning", "ask", tempCwd);
+    appendMessages(previous.id, [{ role: "user", content: "previous ask work" }]);
+
+    const agent = new Agent(undefined, undefined, "grok-4.3", undefined, {
+      persistSession: true,
+    });
+    const currentId = agent.getSessionId();
+    expect(currentId).toBeTruthy();
+    expect(currentId).not.toBe(previous.id);
+
+    const snapshot = agent.resumeSession("LATEST");
+    expect(snapshot?.session.id).toBe(previous.id);
+    expect(snapshot?.session.id).not.toBe(currentId);
+    expect(agent.getMode()).toBe("ask");
+    expect(snapshot?.entries.map((entry) => entry.content)).toContain("previous ask work");
+  });
+
+  it("throws when the session does not exist", () => {
+    const agent = new Agent(undefined, undefined, undefined, undefined, {
+      persistSession: true,
+    });
+    expect(() => agent.resumeSession("missing-session")).toThrow('Session "missing-session" was not found.');
+  });
+});

--- a/src/grok/models.test.ts
+++ b/src/grok/models.test.ts
@@ -9,7 +9,7 @@ import {
 
 describe("models", () => {
   it("keeps the default model on a canonical reasoning id", () => {
-    expect(DEFAULT_MODEL).toBe("grok-4.3");
+    expect(DEFAULT_MODEL).toBe("grok-4.6");
   });
 
   it("normalizes aliases to canonical ids", () => {
@@ -19,10 +19,14 @@ describe("models", () => {
     expect(normalizeModelId("x-ai/grok-3")).toBe("grok-4.20-non-reasoning");
     expect(normalizeModelId("grok-4.20-multi-agent")).toBe("grok-4.20-multi-agent-0309");
     expect(normalizeModelId("x-ai/grok-4.20-multi-agent-beta")).toBe("grok-4.20-multi-agent-0309");
+    expect(normalizeModelId("grok-4.6")).toBe("grok-4.6");
+    expect(normalizeModelId("grok-4.5-latest")).toBe("grok-4.5");
   });
 
   it("returns model metadata for aliased ids", () => {
     expect(getModelInfo("grok-4-1-fast")?.id).toBe("grok-4.3");
+    expect(getModelInfo("grok-4.6")?.id).toBe("grok-4.6");
+    expect(getModelInfo("grok-4.5-latest")?.id).toBe("grok-4.5");
     expect(getModelInfo("grok-4.20-multi-agent")?.responsesOnly).toBe(true);
     expect(getModelInfo("grok-4.20-multi-agent")?.supportsClientTools).toBe(false);
   });

--- a/src/grok/models.ts
+++ b/src/grok/models.ts
@@ -2,13 +2,33 @@ import type { ModelInfo, ReasoningEffort } from "../types/index";
 
 export const MODELS: ModelInfo[] = [
   {
+    id: "grok-4.6",
+    name: "Grok 4.6",
+    contextWindow: 500_000,
+    inputPrice: 2.0,
+    outputPrice: 6.0,
+    reasoning: true,
+    description: "Current flagship — long-horizon agents, self-verification, polished apps",
+    aliases: ["grok-4.6-latest", "grok-4-6"],
+  },
+  {
+    id: "grok-4.5",
+    name: "Grok 4.5",
+    contextWindow: 500_000,
+    inputPrice: 2.0,
+    outputPrice: 6.0,
+    reasoning: true,
+    description: "Strong coding/agentic model (Cursor-trained)",
+    aliases: ["grok-4.5-latest", "grok-4-5"],
+  },
+  {
     id: "grok-4.3",
     name: "Grok 4.3",
     contextWindow: 1_000_000,
     inputPrice: 1.25,
     outputPrice: 2.5,
     reasoning: true,
-    description: "Recommended flagship reasoning model",
+    description: "Legacy flagship reasoning model",
     aliases: [
       "grok-4-1-fast-reasoning",
       "grok-4-1-fast",
@@ -77,7 +97,7 @@ for (const model of MODELS) {
   }
 }
 
-export const DEFAULT_MODEL = MODELS.find((model) => model.id === "grok-4.3")?.id ?? MODELS[0]?.id ?? "grok-4.3";
+export const DEFAULT_MODEL = MODELS.find((model) => model.id === "grok-4.6")?.id ?? MODELS[0]?.id ?? "grok-4.6";
 
 export function normalizeModelId(modelId: string): string {
   const trimmed = modelId.trim();

--- a/src/index.ts
+++ b/src/index.ts
@@ -256,7 +256,9 @@ async function runBackgroundDelegation(jobPath: string, options: CliOptions) {
     const delegation = await loadDelegation(jobPath);
     const apiKey = stringOption(options.apiKey) || getApiKey();
     if (!apiKey) {
-      throw new Error("API key required. Set GROK_API_KEY, use --api-key, or save it to ~/.grok/user-settings.json.");
+      throw new Error(
+        "API key required. Set GROK_API_KEY, use --api-key, save it to ~/.grok/user-settings.json, or sign in with official Grok Build (`grok login`).",
+      );
     }
 
     const baseURL = stringOption(options.baseUrl) || getBaseURL();
@@ -329,7 +331,7 @@ function resolveConfig(options: CliOptions) {
 function requireApiKey(apiKey: string | undefined): string {
   if (!apiKey) {
     console.error(
-      "Error: API key required. Set GROK_API_KEY env var, use --api-key, or save to ~/.grok/user-settings.json",
+      "Error: API key required. Set GROK_API_KEY env var, use --api-key, save to ~/.grok/user-settings.json, or sign in with official Grok Build (`grok login`).",
     );
     process.exit(1);
   }
@@ -346,8 +348,8 @@ function parseHeadlessOutputFormat(value: string): HeadlessOutputFormat {
 }
 
 program
-  .name("grok")
-  .description("AI coding agent powered by Grok — built with Bun and OpenTUI")
+  .name("grok-kev")
+  .description("Personal grok-kev fork of the Grok CLI coding agent")
   .version(packageJson.version)
   .argument("[message...]", "Initial message to send")
   .option("-k, --api-key <key>", "Grok API key")

--- a/src/plugins/README.md
+++ b/src/plugins/README.md
@@ -1,0 +1,40 @@
+# Plugins
+
+Bundled plugins (`/install suggester`) and GitHub plugins
+(`/install owner/repo[@ref]`) share the same host.
+
+## GitHub plugin contract
+
+The repo root, or an optional subdir (`/install owner/repo/plugins/weather`),
+must contain `plugin.json`:
+
+```json
+{
+  "id": "weather",
+  "name": "Weather",
+  "description": "Look up the weather",
+  "version": "1.0.0",
+  "entry": "index.js",
+  "commands": ["weather"]
+}
+```
+
+`entry` must be a relative `.js` file. `id` and commands cannot collide with
+built-in slash commands.
+
+```js
+export function createPlugin() {
+  return {
+    id: "weather",
+    slashCommands: [{ id: "weather", description: "Look up the weather" }],
+    handleCommand(cmd, ctx) {
+      if (!cmd.startsWith("/weather")) return false;
+      ctx.reply("sunny");
+      return true;
+    },
+  };
+}
+```
+
+Installs are stored under `~/.grok/plugins/`. This loader runs in-process.
+Only install code you trust.

--- a/src/plugins/catalog.ts
+++ b/src/plugins/catalog.ts
@@ -1,0 +1,30 @@
+export interface PluginManifest {
+  id: string;
+  name: string;
+  description: string;
+  version: string;
+  commands: string[];
+}
+
+export const BUNDLED_PLUGINS: PluginManifest[] = [
+  {
+    id: "suggester",
+    name: "Prompt suggester",
+    description: "Ghost a likely next prompt after each interactive turn",
+    version: "1.0.0",
+    commands: ["suggester"],
+  },
+];
+
+export function getBundledPlugin(id: string): PluginManifest | undefined {
+  const normalized = id.trim().toLowerCase();
+  return BUNDLED_PLUGINS.find((plugin) => plugin.id === normalized);
+}
+
+export function bundledPluginIds(): string[] {
+  return BUNDLED_PLUGINS.map((plugin) => plugin.id);
+}
+
+export function reservedPluginCommands(): string[] {
+  return BUNDLED_PLUGINS.flatMap((plugin) => plugin.commands);
+}

--- a/src/plugins/command.test.ts
+++ b/src/plugins/command.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { formatPluginList, parsePluginCommand, runPluginCommand } from "./command.js";
+
+describe("parsePluginCommand", () => {
+  it("parses install, uninstall, and plugins", () => {
+    expect(parsePluginCommand("/install")).toEqual({ action: "install", id: "" });
+    expect(parsePluginCommand("/install suggester")).toEqual({ action: "install", id: "suggester" });
+    expect(parsePluginCommand("/install acme/weather@v1")).toEqual({ action: "install", id: "acme/weather@v1" });
+    expect(parsePluginCommand("/uninstall suggester")).toEqual({ action: "uninstall", id: "suggester" });
+    expect(parsePluginCommand("/plugins")).toEqual({ action: "list", id: "" });
+    expect(parsePluginCommand("/plugin")).toEqual({ action: "list", id: "" });
+  });
+
+  it("ignores unrelated commands", () => {
+    expect(parsePluginCommand("/suggester on")).toBeNull();
+    expect(parsePluginCommand("/btw hello")).toBeNull();
+    expect(parsePluginCommand("install suggester")).toBeNull();
+  });
+});
+
+describe("runPluginCommand", () => {
+  it("installs a bundled plugin once", () => {
+    const first = runPluginCommand({ action: "install", id: "suggester" }, []);
+    expect(first.installed).toEqual(["suggester"]);
+    expect(first.message).toContain("Installed suggester");
+
+    const again = runPluginCommand({ action: "install", id: "suggester" }, ["suggester"]);
+    expect(again.installed).toEqual(["suggester"]);
+    expect(again.message).toContain("already installed");
+  });
+
+  it("rejects unknown plugins and lists the catalog", () => {
+    const result = runPluginCommand({ action: "install", id: "nope" }, []);
+    expect(result.installed).toEqual([]);
+    expect(result.message).toContain("Unknown plugin");
+    expect(result.message).toContain("suggester");
+  });
+
+  it("uninstalls only what is installed", () => {
+    const missing = runPluginCommand({ action: "uninstall", id: "suggester" }, []);
+    expect(missing.installed).toEqual([]);
+    expect(missing.message).toContain("not installed");
+
+    const removed = runPluginCommand({ action: "uninstall", id: "suggester" }, ["suggester"]);
+    expect(removed.installed).toEqual([]);
+    expect(removed.message).toContain("Uninstalled suggester");
+  });
+
+  it("lists installable plugins", () => {
+    const text = formatPluginList([]);
+    expect(text).toContain("suggester");
+    expect(text).toContain("not installed");
+    expect(text).toContain("/install <id> or /install owner/repo");
+  });
+});

--- a/src/plugins/command.ts
+++ b/src/plugins/command.ts
@@ -1,0 +1,99 @@
+import { BUNDLED_PLUGINS, getBundledPlugin } from "./catalog.js";
+import { isPluginInstalled, withoutPluginInstalled, withPluginInstalled } from "./installed.js";
+
+export type PluginCommandAction = "install" | "uninstall" | "list";
+
+export interface ParsedPluginCommand {
+  action: PluginCommandAction;
+  id: string;
+}
+
+export interface PluginCommandResult {
+  installed: string[];
+  message: string;
+}
+
+export function parsePluginCommand(cmd: string): ParsedPluginCommand | null {
+  const trimmed = cmd.trim();
+  if (!trimmed.startsWith("/")) return null;
+  const body = trimmed.slice(1).trim();
+  const [first, ...tail] = body.split(/\s+/).filter(Boolean);
+  const verb = (first ?? "").toLowerCase();
+  const id = tail.join(" ").trim();
+
+  if (verb === "install") return { action: "install", id };
+  if (verb === "uninstall") return { action: "uninstall", id };
+  if (verb === "plugins" || verb === "plugin") return { action: "list", id };
+  return null;
+}
+
+export function pluginUsageText(): string {
+  return [
+    "Usage:",
+    "  /plugins                      List installed plugins",
+    "  /install <id>                 Enable a bundled plugin",
+    "  /install owner/repo[@ref]     Install a GitHub plugin",
+    "  /uninstall <id|spec>          Remove a plugin",
+    "",
+    "Bundled:",
+    ...BUNDLED_PLUGINS.map((plugin) => `  ${plugin.id.padEnd(14)} ${plugin.description}`),
+  ].join("\n");
+}
+
+export function formatPluginList(
+  installed: readonly string[],
+  remote: Array<{ id: string; spec: string; description?: string }> = [],
+): string {
+  const lines = ["Bundled plugins:"];
+  for (const plugin of BUNDLED_PLUGINS) {
+    const status = isPluginInstalled(installed, plugin.id) ? "installed" : "not installed";
+    lines.push(`  ${plugin.id} — ${plugin.description} (${status})`);
+  }
+  lines.push("", "Remote plugins:");
+  if (remote.length === 0) {
+    lines.push("  none");
+  } else {
+    for (const plugin of remote) {
+      lines.push(`  ${plugin.id} — ${plugin.description || plugin.spec} (${plugin.spec})`);
+    }
+  }
+  lines.push("", "Install with /install <id> or /install owner/repo.");
+  return lines.join("\n");
+}
+
+export function runPluginCommand(command: ParsedPluginCommand, installed: readonly string[]): PluginCommandResult {
+  if (command.action === "list") {
+    return { installed: [...installed], message: formatPluginList(installed) };
+  }
+
+  if (!command.id) {
+    return { installed: [...installed], message: pluginUsageText() };
+  }
+
+  const plugin = getBundledPlugin(command.id);
+  if (!plugin) {
+    return {
+      installed: [...installed],
+      message: `Unknown plugin "${command.id}".\n\n${formatPluginList(installed)}`,
+    };
+  }
+
+  if (command.action === "install") {
+    if (isPluginInstalled(installed, plugin.id)) {
+      return { installed: [...installed], message: `${plugin.name} is already installed.` };
+    }
+    return {
+      installed: withPluginInstalled(installed, plugin.id),
+      message: `Installed ${plugin.id}. /${plugin.commands[0] ?? plugin.id} is now available.`,
+    };
+  }
+
+  if (!isPluginInstalled(installed, plugin.id)) {
+    return { installed: [...installed], message: `${plugin.name} is not installed.` };
+  }
+
+  return {
+    installed: withoutPluginInstalled(installed, plugin.id),
+    message: `Uninstalled ${plugin.id}.`,
+  };
+}

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,0 +1,15 @@
+export { BUNDLED_PLUGINS, getBundledPlugin, reservedPluginCommands } from "./catalog.js";
+export { formatPluginList, parsePluginCommand, pluginUsageText, runPluginCommand } from "./command.js";
+export { installGitHubPlugin, uninstallGitHubPlugin } from "./install.js";
+export { isPluginInstalled, normalizeInstalledPlugins } from "./installed.js";
+export { loadRemotePlugin, loadRemotePlugins } from "./loader.js";
+export { findInstalledRemotePlugin, listInstalledRemotePlugins } from "./registry.js";
+export { parsePluginSpec } from "./spec.js";
+export type {
+  GrokPlugin,
+  PluginCommandContext,
+  PluginHostState,
+  PluginSessionContext,
+  PluginSlashCommand,
+  PluginTurnStatus,
+} from "./types.js";

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -1,0 +1,97 @@
+import { mkdtempSync, readFileSync, rmSync } from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, describe, expect, it } from "vitest";
+import { installGitHubPlugin, uninstallGitHubPlugin } from "./install.js";
+import { listInstalledRemotePlugins } from "./registry.js";
+import { parsePluginSpec } from "./spec.js";
+
+const dirs: string[] = [];
+
+function tempHome(): string {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "grok-plugin-"));
+  dirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function githubSpec(raw: string) {
+  const spec = parsePluginSpec(raw);
+  if (spec.kind !== "github") throw new Error(`expected github spec, got ${spec.kind}`);
+  return spec;
+}
+
+describe("installGitHubPlugin", () => {
+  it("fetches plugin.json and entry, then records the install", async () => {
+    const home = tempHome();
+    const files = new Map([
+      [
+        "plugin.json",
+        JSON.stringify({
+          id: "weather",
+          name: "Weather",
+          description: "Look up the weather",
+          version: "1.0.0",
+          entry: "index.js",
+          commands: ["weather"],
+        }),
+      ],
+      ["index.js", "export function createPlugin() { return { id: 'weather' }; }\n"],
+    ]);
+
+    const result = await installGitHubPlugin(githubSpec("acme/weather@v1"), {
+      homeDir: home,
+      fetchText: async (url) => {
+        if (url.includes("/plugin.json")) return files.get("plugin.json") ?? null;
+        if (url.endsWith("/index.js")) return files.get("index.js") ?? null;
+        return null;
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.record.id).toBe("weather");
+    expect(result.record.spec).toBe("acme/weather@v1");
+    expect(readFileSync(result.record.entryPath, "utf8")).toContain("createPlugin");
+    expect(listInstalledRemotePlugins(home).map((item) => item.id)).toEqual(["weather"]);
+  });
+
+  it("rejects a missing manifest and leaves no files", async () => {
+    const home = tempHome();
+    const result = await installGitHubPlugin(githubSpec("acme/missing"), {
+      homeDir: home,
+      fetchText: async () => null,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.message).toContain("plugin.json");
+    expect(listInstalledRemotePlugins(home)).toEqual([]);
+  });
+
+  it("uninstalls a remote plugin by id or spec", async () => {
+    const home = tempHome();
+    const installed = await installGitHubPlugin(githubSpec("acme/weather"), {
+      homeDir: home,
+      fetchText: async (url) => {
+        if (url.includes("/plugin.json")) {
+          return JSON.stringify({
+            id: "weather",
+            name: "Weather",
+            version: "1.0.0",
+            entry: "index.js",
+          });
+        }
+        return "export function createPlugin() { return { id: 'weather' }; }\n";
+      },
+    });
+    expect(installed.ok).toBe(true);
+    const removed = uninstallGitHubPlugin("weather", home);
+    expect(removed.ok).toBe(true);
+    expect(listInstalledRemotePlugins(home)).toEqual([]);
+  });
+});

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -1,0 +1,122 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { parsePluginManifest } from "./manifest.js";
+import {
+  findInstalledRemotePlugin,
+  type InstalledRemotePlugin,
+  listInstalledRemotePlugins,
+  pluginInstallDir,
+  saveInstalledRemotePlugins,
+  toInstalledRemotePlugin,
+} from "./registry.js";
+import type { GitHubPluginSpec } from "./spec.js";
+import { githubPluginId } from "./spec.js";
+
+const FETCH_TIMEOUT_MS = 10_000;
+const MAX_TEXT_BYTES = 256_000;
+
+export interface PluginFetchOptions {
+  homeDir?: string;
+  fetchText?: (url: string) => Promise<string | null>;
+}
+
+export type InstallPluginResult =
+  | { ok: true; record: InstalledRemotePlugin; message: string }
+  | { ok: false; message: string };
+
+export type UninstallPluginResult = { ok: true; message: string } | { ok: false; message: string };
+
+export function githubRawUrl(spec: GitHubPluginSpec, filePath: string): string {
+  const ref = spec.ref || "HEAD";
+  const prefix = spec.subdir ? `${spec.subdir.replace(/\/+$/, "")}/` : "";
+  return `https://raw.githubusercontent.com/${spec.owner}/${spec.repo}/${ref}/${prefix}${filePath}`;
+}
+
+export async function installGitHubPlugin(
+  spec: GitHubPluginSpec,
+  options: PluginFetchOptions = {},
+): Promise<InstallPluginResult> {
+  const homeDir = options.homeDir ?? os.homedir();
+  const fetchText = options.fetchText ?? fetchGitHubText;
+  const manifestText = await fetchText(githubRawUrl(spec, "plugin.json"));
+  if (!manifestText) {
+    return { ok: false, message: `Could not fetch plugin.json from ${githubPluginId(spec)}.` };
+  }
+
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(manifestText);
+  } catch {
+    return { ok: false, message: "plugin.json is not valid JSON." };
+  }
+
+  const manifest = parsePluginManifest(parsedJson);
+  if (!manifest) {
+    return {
+      ok: false,
+      message: "plugin.json is invalid. Need id, name, version, and a relative .js entry.",
+    };
+  }
+
+  const existing = findInstalledRemotePlugin(manifest.id, homeDir);
+  if (existing && existing.spec !== githubPluginId(spec)) {
+    return { ok: false, message: `Plugin id "${manifest.id}" is already installed from ${existing.spec}.` };
+  }
+
+  const entryText = await fetchText(githubRawUrl(spec, manifest.entry));
+  if (!entryText) {
+    return { ok: false, message: `Could not fetch entry ${manifest.entry} from ${githubPluginId(spec)}.` };
+  }
+
+  const installDir = pluginInstallDir(spec, homeDir);
+  const entryPath = path.join(installDir, manifest.entry);
+  fs.rmSync(installDir, { recursive: true, force: true });
+  fs.mkdirSync(path.dirname(entryPath), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(path.join(installDir, "plugin.json"), `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
+  fs.writeFileSync(entryPath, entryText, { mode: 0o600 });
+
+  const record = toInstalledRemotePlugin(spec, manifest, installDir);
+  const next = listInstalledRemotePlugins(homeDir).filter((plugin) => plugin.id !== record.id);
+  next.push(record);
+  saveInstalledRemotePlugins(next, homeDir);
+
+  return {
+    ok: true,
+    record,
+    message: `Installed ${record.id} from ${record.spec}. /${record.commands[0] ?? record.id} is now available.`,
+  };
+}
+
+export function uninstallGitHubPlugin(query: string, homeDir = os.homedir()): UninstallPluginResult {
+  const existing = findInstalledRemotePlugin(query, homeDir);
+  if (!existing) {
+    return { ok: false, message: `Remote plugin "${query}" is not installed.` };
+  }
+
+  fs.rmSync(existing.installDir, { recursive: true, force: true });
+  saveInstalledRemotePlugins(
+    listInstalledRemotePlugins(homeDir).filter((plugin) => plugin.id !== existing.id),
+    homeDir,
+  );
+  return { ok: true, message: `Uninstalled ${existing.id}.` };
+}
+
+async function fetchGitHubText(url: string): Promise<string | null> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: { Accept: "text/plain" },
+    });
+    if (!response.ok) return null;
+    const buffer = Buffer.from(await response.arrayBuffer());
+    if (buffer.byteLength > MAX_TEXT_BYTES) return null;
+    return buffer.toString("utf8");
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/plugins/installed.ts
+++ b/src/plugins/installed.ts
@@ -1,0 +1,23 @@
+import { BUNDLED_PLUGINS, getBundledPlugin } from "./catalog.js";
+
+export function normalizeInstalledPlugins(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  const known = new Set(BUNDLED_PLUGINS.map((plugin) => plugin.id));
+  return [...new Set(raw.filter((id): id is string => typeof id === "string" && known.has(id)))];
+}
+
+export function withPluginInstalled(installed: readonly string[], id: string): string[] {
+  const plugin = getBundledPlugin(id);
+  if (!plugin) return normalizeInstalledPlugins(installed);
+  return normalizeInstalledPlugins([...installed, plugin.id]);
+}
+
+export function withoutPluginInstalled(installed: readonly string[], id: string): string[] {
+  const plugin = getBundledPlugin(id);
+  if (!plugin) return normalizeInstalledPlugins(installed);
+  return normalizeInstalledPlugins(installed).filter((item) => item !== plugin.id);
+}
+
+export function isPluginInstalled(installed: readonly string[], id: string): boolean {
+  return normalizeInstalledPlugins(installed).includes(id.trim().toLowerCase());
+}

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1,0 +1,70 @@
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadRemotePlugin } from "./loader.js";
+import type { InstalledRemotePlugin } from "./registry.js";
+
+const dirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function record(overrides: Partial<InstalledRemotePlugin> = {}): InstalledRemotePlugin {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "grok-plugin-load-"));
+  dirs.push(dir);
+  const entryPath = path.join(dir, "index.js");
+  return {
+    id: "weather",
+    name: "Weather",
+    description: "Look up the weather",
+    version: "1.0.0",
+    commands: ["weather"],
+    spec: "acme/weather",
+    owner: "acme",
+    repo: "weather",
+    ref: "",
+    subdir: "",
+    entry: "index.js",
+    entryPath,
+    installDir: dir,
+    installedAt: "2026-08-16T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("loadRemotePlugin", () => {
+  it("loads createPlugin from a local entry file", async () => {
+    const installed = record();
+    writeFileSync(
+      installed.entryPath,
+      `export function createPlugin() {
+        return {
+          id: "weather",
+          slashCommands: [{ id: "weather", description: "Look up the weather" }],
+          handleCommand(cmd, ctx) {
+            if (!cmd.startsWith("/weather")) return false;
+            ctx.reply("sunny");
+            return true;
+          },
+        };
+      }`,
+    );
+
+    const plugin = await loadRemotePlugin(installed);
+    expect(plugin?.id).toBe("weather");
+    expect(plugin?.slashCommands?.[0]?.id).toBe("weather");
+    const replies: string[] = [];
+    expect(plugin?.handleCommand?.("/weather", { reply: (text) => replies.push(text) })).toBe(true);
+    expect(replies).toEqual(["sunny"]);
+  });
+
+  it("returns null when the entry has no factory", async () => {
+    const installed = record();
+    writeFileSync(installed.entryPath, "export const nope = true;\n");
+    expect(await loadRemotePlugin(installed)).toBeNull();
+  });
+});

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1,0 +1,41 @@
+import { pathToFileURL } from "url";
+import type { InstalledRemotePlugin } from "./registry.js";
+import type { GrokPlugin } from "./types.js";
+
+export async function loadRemotePlugin(record: InstalledRemotePlugin): Promise<GrokPlugin | null> {
+  try {
+    const href = `${pathToFileURL(record.entryPath).href}?t=${Date.now()}`;
+    const mod = (await import(href)) as { createPlugin?: unknown; default?: unknown };
+    const factory = typeof mod.createPlugin === "function" ? mod.createPlugin : mod.default;
+    if (typeof factory !== "function") return null;
+
+    const created = await factory();
+    if (!created || typeof created !== "object") return null;
+    const plugin = created as GrokPlugin;
+    const id = typeof plugin.id === "string" && plugin.id.trim() ? plugin.id.trim().toLowerCase() : record.id;
+    if (id !== record.id) return null;
+
+    return {
+      ...plugin,
+      id: record.id,
+      slashCommands:
+        plugin.slashCommands && plugin.slashCommands.length > 0
+          ? plugin.slashCommands
+          : record.commands.map((command) => ({
+              id: command,
+              description: record.description || record.name,
+            })),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function loadRemotePlugins(records: readonly InstalledRemotePlugin[]): Promise<GrokPlugin[]> {
+  const loaded: GrokPlugin[] = [];
+  for (const record of records) {
+    const plugin = await loadRemotePlugin(record);
+    if (plugin) loaded.push(plugin);
+  }
+  return loaded;
+}

--- a/src/plugins/manifest.test.ts
+++ b/src/plugins/manifest.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { parsePluginManifest } from "./manifest.js";
+
+describe("parsePluginManifest", () => {
+  it("accepts a valid remote plugin manifest", () => {
+    expect(
+      parsePluginManifest({
+        id: "weather",
+        name: "Weather",
+        description: "Look up the weather",
+        version: "1.0.0",
+        entry: "index.js",
+        commands: ["weather"],
+      }),
+    ).toEqual({
+      id: "weather",
+      name: "Weather",
+      description: "Look up the weather",
+      version: "1.0.0",
+      entry: "index.js",
+      commands: ["weather"],
+    });
+  });
+
+  it("rejects missing fields, path escape, and reserved commands", () => {
+    expect(parsePluginManifest({})).toBeNull();
+    expect(parsePluginManifest({ id: "weather", name: "W", version: "1", entry: "../evil.js" })).toBeNull();
+    expect(parsePluginManifest({ id: "weather", name: "W", version: "1", entry: "index.ts" })).toBeNull();
+    expect(
+      parsePluginManifest({
+        id: "install",
+        name: "Nope",
+        version: "1.0.0",
+        entry: "index.js",
+        commands: ["install"],
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -1,0 +1,80 @@
+import { BUNDLED_PLUGINS } from "./catalog.js";
+
+const PLUGIN_ID_RE = /^[a-z][a-z0-9-]{0,39}$/;
+const PLUGIN_ENTRY_RE = /^(?:[A-Za-z0-9._-]+\/)*[A-Za-z0-9._-]+\.js$/;
+const RESERVED_COMMANDS = new Set([
+  "install",
+  "uninstall",
+  "plugins",
+  "plugin",
+  "help",
+  "exit",
+  "quit",
+  "q",
+  "clear",
+  "model",
+  "models",
+  "sandbox",
+  "recap",
+  "recaps",
+  "remote-control",
+  "mcp",
+  "mcps",
+  "agents",
+  "agent",
+  "schedule",
+  "schedules",
+  "review",
+  "verify",
+  "commit-push",
+  "commit-pr",
+  "wallet",
+  "btw",
+  "resume",
+  "sessions",
+  "session",
+  "skills",
+  "update",
+  "new",
+  ...BUNDLED_PLUGINS.flatMap((plugin) => [plugin.id, ...plugin.commands]),
+]);
+
+export interface RemotePluginManifest {
+  id: string;
+  name: string;
+  description: string;
+  version: string;
+  entry: string;
+  commands: string[];
+}
+
+export function parsePluginManifest(raw: unknown): RemotePluginManifest | null {
+  if (!raw || typeof raw !== "object") return null;
+  const value = raw as Record<string, unknown>;
+  const id = typeof value.id === "string" ? value.id.trim().toLowerCase() : "";
+  const name = typeof value.name === "string" ? value.name.trim() : "";
+  const description = typeof value.description === "string" ? value.description.trim() : "";
+  const version = typeof value.version === "string" ? value.version.trim() : "";
+  const entry = typeof value.entry === "string" ? value.entry.trim() : "";
+  const commands = Array.isArray(value.commands)
+    ? value.commands.filter((item): item is string => typeof item === "string").map((item) => item.trim().toLowerCase())
+    : [];
+
+  if (!PLUGIN_ID_RE.test(id) || RESERVED_COMMANDS.has(id)) return null;
+  if (!name || !version) return null;
+  if (!PLUGIN_ENTRY_RE.test(entry) || entry.includes("..")) return null;
+  if (commands.some((command) => !PLUGIN_ID_RE.test(command) || RESERVED_COMMANDS.has(command))) return null;
+
+  return {
+    id,
+    name,
+    description,
+    version,
+    entry,
+    commands: [...new Set(commands.length > 0 ? commands : [id])],
+  };
+}
+
+export function isReservedPluginCommand(command: string): boolean {
+  return RESERVED_COMMANDS.has(command.trim().toLowerCase());
+}

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -1,0 +1,98 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import type { RemotePluginManifest } from "./manifest.js";
+import type { GitHubPluginSpec } from "./spec.js";
+import { githubPluginId } from "./spec.js";
+
+export interface InstalledRemotePlugin {
+  id: string;
+  name: string;
+  description: string;
+  version: string;
+  commands: string[];
+  spec: string;
+  owner: string;
+  repo: string;
+  ref: string;
+  subdir: string;
+  entry: string;
+  entryPath: string;
+  installDir: string;
+  installedAt: string;
+}
+
+export function pluginsRoot(homeDir = os.homedir()): string {
+  return path.join(homeDir, ".grok", "plugins");
+}
+
+export function pluginRegistryPath(homeDir = os.homedir()): string {
+  return path.join(pluginsRoot(homeDir), "installed.json");
+}
+
+export function listInstalledRemotePlugins(homeDir = os.homedir()): InstalledRemotePlugin[] {
+  const filePath = pluginRegistryPath(homeDir);
+  try {
+    if (!fs.existsSync(filePath)) return [];
+    const parsed = JSON.parse(fs.readFileSync(filePath, "utf8")) as { plugins?: unknown };
+    if (!Array.isArray(parsed.plugins)) return [];
+    return parsed.plugins.filter(isInstalledRemotePlugin);
+  } catch {
+    return [];
+  }
+}
+
+export function saveInstalledRemotePlugins(plugins: InstalledRemotePlugin[], homeDir = os.homedir()): void {
+  const filePath = pluginRegistryPath(homeDir);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(filePath, JSON.stringify({ plugins }, null, 2), { mode: 0o600 });
+}
+
+export function findInstalledRemotePlugin(query: string, homeDir = os.homedir()): InstalledRemotePlugin | undefined {
+  const normalized = query.trim().toLowerCase();
+  return listInstalledRemotePlugins(homeDir).find(
+    (plugin) => plugin.id === normalized || plugin.spec.toLowerCase() === normalized,
+  );
+}
+
+export function pluginInstallDir(spec: GitHubPluginSpec, homeDir = os.homedir()): string {
+  const slug = githubPluginId(spec).replace(/[/@]/g, "__");
+  return path.join(pluginsRoot(homeDir), slug);
+}
+
+export function toInstalledRemotePlugin(
+  spec: GitHubPluginSpec,
+  manifest: RemotePluginManifest,
+  installDir: string,
+): InstalledRemotePlugin {
+  return {
+    id: manifest.id,
+    name: manifest.name,
+    description: manifest.description,
+    version: manifest.version,
+    commands: manifest.commands,
+    spec: githubPluginId(spec),
+    owner: spec.owner,
+    repo: spec.repo,
+    ref: spec.ref,
+    subdir: spec.subdir,
+    entry: manifest.entry,
+    entryPath: path.join(installDir, manifest.entry),
+    installDir,
+    installedAt: new Date().toISOString(),
+  };
+}
+
+function isInstalledRemotePlugin(value: unknown): value is InstalledRemotePlugin {
+  if (!value || typeof value !== "object") return false;
+  const plugin = value as InstalledRemotePlugin;
+  return (
+    typeof plugin.id === "string" &&
+    typeof plugin.name === "string" &&
+    typeof plugin.version === "string" &&
+    typeof plugin.spec === "string" &&
+    typeof plugin.entryPath === "string" &&
+    typeof plugin.installDir === "string" &&
+    Array.isArray(plugin.commands)
+  );
+}

--- a/src/plugins/spec.test.ts
+++ b/src/plugins/spec.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { parsePluginSpec } from "./spec.js";
+
+describe("parsePluginSpec", () => {
+  it("treats known bundled ids as bundled", () => {
+    expect(parsePluginSpec("suggester")).toEqual({ kind: "bundled", id: "suggester" });
+    expect(parsePluginSpec("SUGGESTER")).toEqual({ kind: "bundled", id: "suggester" });
+  });
+
+  it("parses github owner/repo specs", () => {
+    expect(parsePluginSpec("acme/weather")).toEqual({
+      kind: "github",
+      owner: "acme",
+      repo: "weather",
+      ref: "",
+      subdir: "",
+      spec: "acme/weather",
+    });
+    expect(parsePluginSpec("github.com/acme/weather")).toEqual({
+      kind: "github",
+      owner: "acme",
+      repo: "weather",
+      ref: "",
+      subdir: "",
+      spec: "github.com/acme/weather",
+    });
+    expect(parsePluginSpec("https://github.com/acme/weather")).toEqual({
+      kind: "github",
+      owner: "acme",
+      repo: "weather",
+      ref: "",
+      subdir: "",
+      spec: "https://github.com/acme/weather",
+    });
+  });
+
+  it("parses refs and subdirs", () => {
+    expect(parsePluginSpec("acme/weather@v1.2.0")).toMatchObject({
+      kind: "github",
+      owner: "acme",
+      repo: "weather",
+      ref: "v1.2.0",
+      subdir: "",
+    });
+    expect(parsePluginSpec("acme/monorepo/plugins/weather@main")).toMatchObject({
+      kind: "github",
+      owner: "acme",
+      repo: "monorepo",
+      ref: "main",
+      subdir: "plugins/weather",
+    });
+  });
+
+  it("rejects empty, local, and non-github hosts", () => {
+    expect(parsePluginSpec("")).toEqual({ kind: "invalid", input: "", reason: "missing" });
+    expect(parsePluginSpec("nope")).toMatchObject({ kind: "invalid" });
+    expect(parsePluginSpec("../evil")).toMatchObject({ kind: "invalid" });
+    expect(parsePluginSpec("http://github.com/acme/weather")).toMatchObject({ kind: "invalid" });
+    expect(parsePluginSpec("https://gitlab.com/acme/weather")).toMatchObject({ kind: "invalid" });
+    expect(parsePluginSpec("file:///tmp/plugin")).toMatchObject({ kind: "invalid" });
+  });
+});

--- a/src/plugins/spec.ts
+++ b/src/plugins/spec.ts
@@ -1,0 +1,99 @@
+import { getBundledPlugin } from "./catalog.js";
+
+const GITHUB_OWNER_RE = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38}[A-Za-z0-9])?$/;
+const GITHUB_REPO_RE = /^[A-Za-z0-9._-]{1,100}$/;
+const GITHUB_REF_RE = /^[A-Za-z0-9._/-]{1,200}$/;
+const GITHUB_SUBDIR_RE = /^(?:[A-Za-z0-9._-]+\/)*[A-Za-z0-9._-]+$/;
+
+export interface BundledPluginSpec {
+  kind: "bundled";
+  id: string;
+}
+
+export interface GitHubPluginSpec {
+  kind: "github";
+  owner: string;
+  repo: string;
+  ref: string;
+  subdir: string;
+  spec: string;
+}
+
+export interface InvalidPluginSpec {
+  kind: "invalid";
+  input: string;
+  reason: "missing" | "unknown" | "unsafe";
+}
+
+export type PluginSpec = BundledPluginSpec | GitHubPluginSpec | InvalidPluginSpec;
+
+export function parsePluginSpec(raw: string): PluginSpec {
+  const input = raw.trim();
+  if (!input) return { kind: "invalid", input, reason: "missing" };
+
+  const bundled = getBundledPlugin(input);
+  if (bundled) return { kind: "bundled", id: bundled.id };
+
+  const github = parseGitHubSpec(input);
+  if (github) return github;
+
+  return { kind: "invalid", input, reason: looksLikeRemote(input) ? "unsafe" : "unknown" };
+}
+
+export function githubPluginId(spec: GitHubPluginSpec): string {
+  const base = `${spec.owner}/${spec.repo}${spec.subdir ? `/${spec.subdir}` : ""}`;
+  return spec.ref ? `${base}@${spec.ref}` : base;
+}
+
+function looksLikeRemote(input: string): boolean {
+  return (
+    input.includes("/") ||
+    input.includes(":") ||
+    input.startsWith(".") ||
+    input.toLowerCase().includes("github") ||
+    input.toLowerCase().includes("http")
+  );
+}
+
+function parseGitHubSpec(input: string): GitHubPluginSpec | null {
+  let rest = input;
+  if (/^https:\/\//i.test(rest)) {
+    try {
+      const url = new URL(rest);
+      if (url.protocol !== "https:") return null;
+      if (url.hostname.toLowerCase() !== "github.com") return null;
+      rest = url.pathname.replace(/^\/+|\/+$/g, "");
+    } catch {
+      return null;
+    }
+  } else if (/^github\.com\//i.test(rest)) {
+    rest = rest.slice("github.com/".length);
+  } else if (/^[a-z][a-z0-9+.-]*:/i.test(rest)) {
+    return null;
+  }
+
+  const at = rest.lastIndexOf("@");
+  let ref = "";
+  if (at > 0) {
+    ref = rest.slice(at + 1);
+    rest = rest.slice(0, at);
+  }
+  rest = rest.replace(/\.git$/i, "").replace(/^\/+|\/+$/g, "");
+  const parts = rest.split("/").filter(Boolean);
+  if (parts.length < 2) return null;
+
+  const [owner, repo, ...subdirParts] = parts;
+  if (!GITHUB_OWNER_RE.test(owner) || !GITHUB_REPO_RE.test(repo)) return null;
+  if (ref && !GITHUB_REF_RE.test(ref)) return null;
+  const subdir = subdirParts.join("/");
+  if (subdir && (!GITHUB_SUBDIR_RE.test(subdir) || subdir.includes(".."))) return null;
+
+  return {
+    kind: "github",
+    owner,
+    repo,
+    ref,
+    subdir,
+    spec: input,
+  };
+}

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1,0 +1,53 @@
+import type { KeyEvent, TextareaRenderable } from "@opentui/core";
+import type { RefObject } from "react";
+import type { ChatEntry } from "../types/index.js";
+
+export type PluginTurnStatus = "success" | "error" | "aborted";
+
+export interface PluginSlashCommand {
+  id: string;
+  description: string;
+  aliases?: string[];
+}
+
+export interface PluginCommandContext {
+  reply: (text: string) => void;
+}
+
+export interface PluginSessionContext {
+  cwd: string;
+  sessionId: string | null;
+  baseURL: string;
+  inputRef: RefObject<TextareaRenderable | null>;
+}
+
+export interface GrokPlugin {
+  id: string;
+  slashCommands?: PluginSlashCommand[];
+  handleCommand?(cmd: string, ctx: PluginCommandContext): boolean;
+  requestAfterTurn?(entries: ChatEntry[], status: PluginTurnStatus, abortNote?: string): void;
+  recordSubmit?(userPrompt: string): void;
+  ensureSeed?(): void;
+  cancel?(): void;
+  dismiss?(): void;
+  handleKey?(key: KeyEvent, blocked: boolean): boolean;
+  ghostSuggestion?: string | null;
+  ghostVisible?: boolean;
+}
+
+export interface PluginHostState {
+  installed: string[];
+  slashCommands: PluginSlashCommand[];
+  ghostSuggestion: string | null;
+  ghostVisible: boolean;
+  handleCommand: (cmd: string, reply: (text: string) => void) => boolean;
+  requestAfterTurn: (entries: ChatEntry[], status: PluginTurnStatus, abortNote?: string) => void;
+  recordSubmit: (userPrompt: string) => void;
+  ensureSeed: () => void;
+  cancel: () => void;
+  dismiss: () => void;
+  handleKey: (key: KeyEvent, blocked: boolean) => boolean;
+  install: (id: string) => string;
+  uninstall: (id: string) => string;
+  formatList: () => string;
+}

--- a/src/storage/sessions.test.ts
+++ b/src/storage/sessions.test.ts
@@ -62,3 +62,59 @@ describe("SessionStore recap persistence", () => {
     expect(store.getRequiredSession(session.id).recap).toBeNull();
   });
 });
+
+describe("SessionStore listing", () => {
+  const tempRoot = path.join(os.tmpdir(), "grok-session-list-tests");
+  let tempHome = "";
+  let tempCwd = "";
+  let otherCwd = "";
+
+  beforeEach(() => {
+    fs.mkdirSync(tempRoot, { recursive: true });
+    tempHome = fs.mkdtempSync(path.join(tempRoot, "grok-session-home-"));
+    tempCwd = fs.mkdtempSync(path.join(tempRoot, "grok-session-cwd-"));
+    otherCwd = fs.mkdtempSync(path.join(tempRoot, "grok-session-other-"));
+    process.env.HOME = tempHome;
+    vi.spyOn(os, "homedir").mockReturnValue(tempHome);
+    closeDatabase();
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    vi.restoreAllMocks();
+    process.env.HOME = originalHome;
+    fs.rmSync(tempHome, { recursive: true, force: true });
+    fs.rmSync(tempCwd, { recursive: true, force: true });
+    fs.rmSync(otherCwd, { recursive: true, force: true });
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it("returns this workspace's sessions newest first", async () => {
+    const store = new SessionStore(tempCwd);
+    const older = store.createSession("grok-4.3", "agent", tempCwd);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const newer = store.createSession("grok-4.20-non-reasoning", "plan", tempCwd);
+
+    const listed = store.listSessions();
+    expect(listed.map((session) => session.id)).toEqual([newer.id, older.id]);
+    expect(listed[0]?.model).toBe("grok-4.20-non-reasoning");
+    expect(listed[0]?.mode).toBe("plan");
+  });
+
+  it("respects a positive limit", () => {
+    const store = new SessionStore(tempCwd);
+    store.createSession("grok-4.3", "agent", tempCwd);
+    store.createSession("grok-4.3", "agent", tempCwd);
+
+    expect(store.listSessions({ limit: 1 })).toHaveLength(1);
+  });
+
+  it("does not include sessions from another workspace", () => {
+    const store = new SessionStore(tempCwd);
+    const otherStore = new SessionStore(otherCwd);
+    const local = store.createSession("grok-4.3", "agent", tempCwd);
+    otherStore.createSession("grok-4.3", "ask", otherCwd);
+
+    expect(store.listSessions().map((session) => session.id)).toEqual([local.id]);
+  });
+});

--- a/src/storage/sessions.ts
+++ b/src/storage/sessions.ts
@@ -74,18 +74,27 @@ export class SessionStore {
     return this.getRequiredSession(id);
   }
 
-  getLatestSession(): SessionInfo | null {
-    const row = getDatabase()
-      .prepare(`
+  listSessions(options: { limit?: number } = {}): SessionInfo[] {
+    const limit =
+      Number.isFinite(options.limit) && (options.limit as number) > 0 ? Math.floor(options.limit as number) : null;
+    const sql = `
       SELECT id, workspace_id, title, recap_text, recap_model, recap_updated_at, model, mode, cwd_at_start, cwd_last, status, created_at, updated_at
       FROM sessions
       WHERE workspace_id = ?
       ORDER BY updated_at DESC
-      LIMIT 1
-    `)
-      .get(this.workspace.id) as SessionRow | undefined;
+      ${limit ? "LIMIT ?" : ""}
+    `;
+    const rows = (
+      limit
+        ? getDatabase().prepare(sql).all(this.workspace.id, limit)
+        : getDatabase().prepare(sql).all(this.workspace.id)
+    ) as SessionRow[];
 
-    return row ? toSessionInfo(row) : null;
+    return rows.map(toSessionInfo);
+  }
+
+  getLatestSession(): SessionInfo | null {
+    return this.listSessions({ limit: 1 })[0] ?? null;
   }
 
   getSessionById(id: string): SessionInfo | null {

--- a/src/suggester/README.md
+++ b/src/suggester/README.md
@@ -3,9 +3,9 @@
 Grok CLI port of [pi-prompt-suggester](https://github.com/guwidoe/pi-prompt-suggester)
 by **Guido Witt-Dörring** (MIT, 2026).
 
-The original is a Pi coding-agent extension. This module is a first-class
-rewrite for Grok CLI: same product (intent seed + per-turn next-prompt guess
-+ steering), OpenTUI wiring instead of Pi's `ExtensionAPI`.
+The original is a Pi coding-agent extension. This module is the bundled
+`suggester` plugin for Grok CLI: same product (intent seed + per-turn
+next-prompt guess + steering), installed with `/install suggester`.
 
 Adapted files carry an inline copyright header. See [`NOTICE.md`](../../NOTICE.md)
 at the repo root for the full license text.

--- a/src/suggester/README.md
+++ b/src/suggester/README.md
@@ -1,0 +1,13 @@
+# Next-prompt suggester
+
+Grok CLI port of [pi-prompt-suggester](https://github.com/guwidoe/pi-prompt-suggester)
+by **Guido Witt-Dörring** (MIT, 2026).
+
+The original is a Pi coding-agent extension. This module is a first-class
+rewrite for Grok CLI: same product (intent seed + per-turn next-prompt guess
++ steering), OpenTUI wiring instead of Pi's `ExtensionAPI`.
+
+Adapted files carry an inline copyright header. See [`NOTICE.md`](../../NOTICE.md)
+at the repo root for the full license text.
+
+Upstream: https://github.com/guwidoe/pi-prompt-suggester

--- a/src/suggester/command.test.ts
+++ b/src/suggester/command.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { parseSuggesterCommand } from "./command.js";
+import { handleSuggesterCommand } from "./handle-command.js";
 
 describe("parseSuggesterCommand", () => {
   it("parses on, off, status, and help", () => {
@@ -24,5 +25,29 @@ describe("parseSuggesterCommand", () => {
   it("ignores unrelated commands", () => {
     expect(parseSuggesterCommand("/btw hello")).toBeNull();
     expect(parseSuggesterCommand("suggester on")).toBeNull();
+  });
+});
+
+describe("handleSuggesterCommand", () => {
+  it("toggles fill mode and reports status", () => {
+    const api = {
+      setEnabled: vi.fn(),
+      setAutoAccept: vi.fn(),
+      requestReseed: vi.fn(),
+      setCustomInstruction: vi.fn(),
+      setSuggesterModel: vi.fn(),
+      setSeederModel: vi.fn(),
+      formatStatus: () => "Prompt suggester: on",
+    };
+    const reply = vi.fn();
+
+    expect(handleSuggesterCommand("/suggester on", api, reply)).toBe(true);
+    expect(api.setEnabled).toHaveBeenCalledWith(true);
+    expect(reply).toHaveBeenCalledWith("Prompt suggester enabled.");
+
+    expect(handleSuggesterCommand("/suggester ghost", api, reply)).toBe(true);
+    expect(api.setAutoAccept).toHaveBeenCalledWith(false);
+
+    expect(handleSuggesterCommand("/btw hello", api, reply)).toBe(false);
   });
 });

--- a/src/suggester/command.test.ts
+++ b/src/suggester/command.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { parseSuggesterCommand } from "./command.js";
+
+describe("parseSuggesterCommand", () => {
+  it("parses on, off, status, and help", () => {
+    expect(parseSuggesterCommand("/suggester")).toEqual({ action: "status", rest: "" });
+    expect(parseSuggesterCommand("/suggester status")).toEqual({ action: "status", rest: "" });
+    expect(parseSuggesterCommand("/suggester on")).toEqual({ action: "on", rest: "" });
+    expect(parseSuggesterCommand("/SUGGESTER off")).toEqual({ action: "off", rest: "" });
+    expect(parseSuggesterCommand("/suggester auto")).toEqual({ action: "auto", rest: "" });
+    expect(parseSuggesterCommand("/suggester ghost")).toEqual({ action: "ghost", rest: "" });
+    expect(parseSuggesterCommand("/suggester reseed")).toEqual({ action: "reseed", rest: "" });
+    expect(parseSuggesterCommand("/suggester instruction set keep it short")).toEqual({
+      action: "instruction",
+      rest: "set keep it short",
+    });
+    expect(parseSuggesterCommand("/suggester model seeder grok-3-mini")).toEqual({
+      action: "model",
+      rest: "seeder grok-3-mini",
+    });
+    expect(parseSuggesterCommand("/suggester mystery")).toEqual({ action: "help", rest: "" });
+  });
+
+  it("ignores unrelated commands", () => {
+    expect(parseSuggesterCommand("/btw hello")).toBeNull();
+    expect(parseSuggesterCommand("suggester on")).toBeNull();
+  });
+});

--- a/src/suggester/command.ts
+++ b/src/suggester/command.ts
@@ -1,0 +1,51 @@
+export type SuggesterCommandAction =
+  | "status"
+  | "on"
+  | "off"
+  | "auto"
+  | "ghost"
+  | "reseed"
+  | "instruction"
+  | "model"
+  | "help";
+
+export interface ParsedSuggesterCommand {
+  action: SuggesterCommandAction;
+  rest: string;
+}
+
+const SIMPLE_ACTIONS = new Set<SuggesterCommandAction>(["status", "on", "off", "auto", "ghost", "reseed"]);
+
+export function parseSuggesterCommand(cmd: string): ParsedSuggesterCommand | null {
+  const trimmed = cmd.trim();
+  if (!trimmed.startsWith("/")) return null;
+  const body = trimmed.slice(1).trim();
+  const [first, ...tail] = body.split(/\s+/).filter(Boolean);
+  if ((first ?? "").toLowerCase() !== "suggester") return null;
+
+  const sub = (tail[0] ?? "status").toLowerCase();
+  const rest = tail.slice(1).join(" ");
+  if (SIMPLE_ACTIONS.has(sub as SuggesterCommandAction)) {
+    return { action: sub as SuggesterCommandAction, rest };
+  }
+  if (sub === "instruction" || sub === "model") {
+    return { action: sub, rest };
+  }
+  return { action: "help", rest: "" };
+}
+
+export function suggesterUsageText(): string {
+  return [
+    "Usage:",
+    "  /suggester                 Show status",
+    "  /suggester on|off          Enable or disable",
+    "  /suggester auto|ghost      Auto-insert or dim ghost",
+    "  /suggester reseed          Refresh project-intent seed",
+    "  /suggester instruction     Show custom instruction",
+    "  /suggester instruction set <text>",
+    "  /suggester instruction clear",
+    "  /suggester model           Show suggester/seeder models",
+    "  /suggester model set <id>",
+    "  /suggester model seeder <id>",
+  ].join("\n");
+}

--- a/src/suggester/config.test.ts
+++ b/src/suggester/config.test.ts
@@ -7,10 +7,10 @@ describe("resolveSuggesterSettings", () => {
     expect(resolveSuggesterSettings({})).toMatchObject({
       enabled: true,
       model: "grok-3-mini",
-      seederModel: "grok-4.20-non-reasoning",
+      seederModel: "grok-3-mini",
       ghostAcceptKeys: ["space", "right"],
       fastPathContinueOnError: true,
-      autoAccept: true,
+      autoAccept: false,
     });
   });
 

--- a/src/suggester/config.test.ts
+++ b/src/suggester/config.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_SUGGESTER_SETTINGS, resolveSuggesterSettings } from "./config.js";
+
+describe("resolveSuggesterSettings", () => {
+  it("defaults to enabled with the cheap model", () => {
+    expect(resolveSuggesterSettings()).toEqual(DEFAULT_SUGGESTER_SETTINGS);
+    expect(resolveSuggesterSettings({})).toMatchObject({
+      enabled: true,
+      model: "grok-3-mini",
+      seederModel: "grok-4.20-non-reasoning",
+      ghostAcceptKeys: ["space", "right"],
+      fastPathContinueOnError: true,
+      autoAccept: true,
+    });
+  });
+
+  it("treats enabled: false as off and clamps max chars", () => {
+    expect(resolveSuggesterSettings({ enabled: false }).enabled).toBe(false);
+    expect(resolveSuggesterSettings({ maxSuggestionChars: 5 }).maxSuggestionChars).toBe(20);
+    expect(resolveSuggesterSettings({ maxSuggestionChars: 9_000 }).maxSuggestionChars).toBe(500);
+  });
+
+  it("drops unknown accept keys and falls back when empty", () => {
+    expect(resolveSuggesterSettings({ ghostAcceptKeys: ["space"] }).ghostAcceptKeys).toEqual(["space"]);
+    expect(resolveSuggesterSettings({ ghostAcceptKeys: [] }).ghostAcceptKeys).toEqual(["space", "right"]);
+  });
+});

--- a/src/suggester/config.ts
+++ b/src/suggester/config.ts
@@ -1,0 +1,88 @@
+import { normalizeModelId } from "../grok/models.js";
+import { loadUserSettings, saveUserSettings } from "../utils/settings.js";
+import type { GhostAcceptKey, ResolvedSuggesterSettings, SuggesterSettings } from "./types.js";
+
+export const DEFAULT_SUGGESTER_MODEL = "grok-3-mini";
+export const DEFAULT_SEEDER_MODEL = "grok-4.20-non-reasoning";
+export const NO_SUGGESTION_TOKEN = "[no suggestion]";
+export const DEFAULT_RESEED_TURN_INTERVAL = 10;
+export const DEFAULT_MAX_SUGGESTION_CHARS = 200;
+export const DEFAULT_MAX_ASSISTANT_TURN_CHARS = 8_000;
+export const DEFAULT_MAX_RECENT_USER_PROMPTS = 20;
+export const DEFAULT_MAX_RECENT_USER_PROMPT_CHARS = 500;
+export const DEFAULT_MAX_TOOL_SIGNALS = 8;
+export const DEFAULT_MAX_TOOL_SIGNAL_CHARS = 240;
+export const DEFAULT_MAX_TOUCHED_FILES = 8;
+export const DEFAULT_MAX_UNRESOLVED_QUESTIONS = 6;
+
+export const DEFAULT_SUGGESTER_SETTINGS: ResolvedSuggesterSettings = {
+  enabled: true,
+  model: DEFAULT_SUGGESTER_MODEL,
+  seederModel: DEFAULT_SEEDER_MODEL,
+  maxSuggestionChars: DEFAULT_MAX_SUGGESTION_CHARS,
+  ghostAcceptKeys: ["space", "right"],
+  fastPathContinueOnError: true,
+  autoAccept: true,
+  customInstruction: "",
+  reseedEnabled: true,
+  reseedTurnInterval: DEFAULT_RESEED_TURN_INTERVAL,
+};
+
+export function normalizeGhostAcceptKeys(value: unknown): GhostAcceptKey[] {
+  if (!Array.isArray(value)) return [...DEFAULT_SUGGESTER_SETTINGS.ghostAcceptKeys];
+  const keys = value.filter((item): item is GhostAcceptKey => item === "space" || item === "right");
+  return keys.length > 0 ? [...new Set(keys)] : [...DEFAULT_SUGGESTER_SETTINGS.ghostAcceptKeys];
+}
+
+export function resolveSuggesterSettings(raw?: SuggesterSettings): ResolvedSuggesterSettings {
+  const maxChars =
+    typeof raw?.maxSuggestionChars === "number" && Number.isFinite(raw.maxSuggestionChars)
+      ? Math.max(20, Math.min(500, Math.floor(raw.maxSuggestionChars)))
+      : DEFAULT_SUGGESTER_SETTINGS.maxSuggestionChars;
+
+  return {
+    enabled: raw?.enabled !== false,
+    model: raw?.model ? normalizeModelId(raw.model) : DEFAULT_SUGGESTER_SETTINGS.model,
+    seederModel: raw?.seederModel ? normalizeModelId(raw.seederModel) : DEFAULT_SUGGESTER_SETTINGS.seederModel,
+    maxSuggestionChars: maxChars,
+    ghostAcceptKeys: normalizeGhostAcceptKeys(raw?.ghostAcceptKeys),
+    fastPathContinueOnError: raw?.fastPathContinueOnError !== false,
+    autoAccept: raw?.autoAccept !== false,
+    customInstruction: typeof raw?.customInstruction === "string" ? raw.customInstruction : "",
+    reseedEnabled: raw?.reseedEnabled !== false,
+    reseedTurnInterval:
+      typeof raw?.reseedTurnInterval === "number" && Number.isFinite(raw.reseedTurnInterval)
+        ? Math.max(1, Math.min(100, Math.floor(raw.reseedTurnInterval)))
+        : DEFAULT_SUGGESTER_SETTINGS.reseedTurnInterval,
+  };
+}
+
+export function loadSuggesterSettings(): ResolvedSuggesterSettings {
+  return resolveSuggesterSettings(loadUserSettings().suggester);
+}
+
+export function saveSuggesterSettings(partial: SuggesterSettings): ResolvedSuggesterSettings {
+  const current = loadSuggesterSettings();
+  const next = resolveSuggesterSettings({
+    ...current,
+    ...partial,
+    ...(partial.ghostAcceptKeys !== undefined
+      ? { ghostAcceptKeys: normalizeGhostAcceptKeys(partial.ghostAcceptKeys) }
+      : {}),
+  });
+  saveUserSettings({
+    suggester: {
+      enabled: next.enabled,
+      model: next.model,
+      seederModel: next.seederModel,
+      maxSuggestionChars: next.maxSuggestionChars,
+      ghostAcceptKeys: next.ghostAcceptKeys,
+      fastPathContinueOnError: next.fastPathContinueOnError,
+      autoAccept: next.autoAccept,
+      customInstruction: next.customInstruction,
+      reseedEnabled: next.reseedEnabled,
+      reseedTurnInterval: next.reseedTurnInterval,
+    },
+  });
+  return next;
+}

--- a/src/suggester/config.ts
+++ b/src/suggester/config.ts
@@ -3,17 +3,17 @@ import { loadUserSettings, saveUserSettings } from "../utils/settings.js";
 import type { GhostAcceptKey, ResolvedSuggesterSettings, SuggesterSettings } from "./types.js";
 
 export const DEFAULT_SUGGESTER_MODEL = "grok-3-mini";
-export const DEFAULT_SEEDER_MODEL = "grok-4.20-non-reasoning";
+export const DEFAULT_SEEDER_MODEL = "grok-3-mini";
 export const NO_SUGGESTION_TOKEN = "[no suggestion]";
-export const DEFAULT_RESEED_TURN_INTERVAL = 10;
-export const DEFAULT_MAX_SUGGESTION_CHARS = 200;
-export const DEFAULT_MAX_ASSISTANT_TURN_CHARS = 8_000;
-export const DEFAULT_MAX_RECENT_USER_PROMPTS = 20;
-export const DEFAULT_MAX_RECENT_USER_PROMPT_CHARS = 500;
-export const DEFAULT_MAX_TOOL_SIGNALS = 8;
-export const DEFAULT_MAX_TOOL_SIGNAL_CHARS = 240;
-export const DEFAULT_MAX_TOUCHED_FILES = 8;
-export const DEFAULT_MAX_UNRESOLVED_QUESTIONS = 6;
+export const DEFAULT_RESEED_TURN_INTERVAL = 16;
+export const DEFAULT_MAX_SUGGESTION_CHARS = 140;
+export const DEFAULT_MAX_ASSISTANT_TURN_CHARS = 1_600;
+export const DEFAULT_MAX_RECENT_USER_PROMPTS = 6;
+export const DEFAULT_MAX_RECENT_USER_PROMPT_CHARS = 220;
+export const DEFAULT_MAX_TOOL_SIGNALS = 4;
+export const DEFAULT_MAX_TOOL_SIGNAL_CHARS = 140;
+export const DEFAULT_MAX_TOUCHED_FILES = 5;
+export const DEFAULT_MAX_UNRESOLVED_QUESTIONS = 3;
 
 export const DEFAULT_SUGGESTER_SETTINGS: ResolvedSuggesterSettings = {
   enabled: true,
@@ -22,7 +22,7 @@ export const DEFAULT_SUGGESTER_SETTINGS: ResolvedSuggesterSettings = {
   maxSuggestionChars: DEFAULT_MAX_SUGGESTION_CHARS,
   ghostAcceptKeys: ["space", "right"],
   fastPathContinueOnError: true,
-  autoAccept: true,
+  autoAccept: false,
   customInstruction: "",
   reseedEnabled: true,
   reseedTurnInterval: DEFAULT_RESEED_TURN_INTERVAL,
@@ -47,7 +47,7 @@ export function resolveSuggesterSettings(raw?: SuggesterSettings): ResolvedSugge
     maxSuggestionChars: maxChars,
     ghostAcceptKeys: normalizeGhostAcceptKeys(raw?.ghostAcceptKeys),
     fastPathContinueOnError: raw?.fastPathContinueOnError !== false,
-    autoAccept: raw?.autoAccept !== false,
+    autoAccept: raw?.autoAccept === true,
     customInstruction: typeof raw?.customInstruction === "string" ? raw.customInstruction : "",
     reseedEnabled: raw?.reseedEnabled !== false,
     reseedTurnInterval:

--- a/src/suggester/context.test.ts
+++ b/src/suggester/context.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import type { ChatEntry } from "../types/index.js";
+import { buildSuggestionContext, sliceLastTurn } from "./context.js";
+
+function entry(partial: Partial<ChatEntry> & Pick<ChatEntry, "type" | "content">): ChatEntry {
+  return { timestamp: new Date("2026-08-16T12:00:00.000Z"), ...partial };
+}
+
+describe("sliceLastTurn", () => {
+  it("returns entries after the last user message", () => {
+    const entries = [
+      entry({ type: "user", content: "first" }),
+      entry({ type: "assistant", content: "ok" }),
+      entry({ type: "user", content: "second" }),
+      entry({ type: "tool_result", content: "wrote file", toolCall: tool("write_file", { path: "src/a.ts" }) }),
+      entry({ type: "assistant", content: "done" }),
+    ];
+    expect(sliceLastTurn(entries).map((item) => item.content)).toEqual(["second", "wrote file", "done"]);
+  });
+});
+
+describe("buildSuggestionContext", () => {
+  it("collects recent user prompts, tool signals, touched files, and questions", () => {
+    const entries = [
+      entry({ type: "user", content: "add tests" }),
+      entry({ type: "assistant", content: "I can add them." }),
+      entry({ type: "user", content: "do it for context.ts" }),
+      entry({
+        type: "tool_result",
+        content: "ok",
+        toolCall: tool("write_file", { path: "src/suggester/context.ts" }),
+        toolResult: {
+          success: true,
+          output: "wrote context.ts",
+          diff: { filePath: "src/suggester/context.ts", additions: 1, removals: 0, patch: "", isNew: false },
+        },
+      }),
+      entry({ type: "assistant", content: "Added tests.\nWant me to run them?" }),
+    ];
+
+    const context = buildSuggestionContext(entries, "success");
+    expect(context.turnStatus).toBe("success");
+    expect(context.recentUserPrompts).toEqual(["add tests", "do it for context.ts"]);
+    expect(context.latestAssistantTurn).toContain("Want me to run them?");
+    expect(context.toolSignals[0]).toContain("write_file: ok");
+    expect(context.touchedFiles).toContain("src/suggester/context.ts");
+    expect(context.unresolvedQuestions.some((item) => item.includes("run them"))).toBe(true);
+  });
+
+  it("passes abort notes through", () => {
+    const context = buildSuggestionContext([entry({ type: "user", content: "go" })], "aborted", {
+      abortNote: "User interrupted the previous turn.",
+    });
+    expect(context.abortContextNote).toBe("User interrupted the previous turn.");
+    expect(context.turnStatus).toBe("aborted");
+  });
+});
+
+function tool(name: string, args: Record<string, unknown>) {
+  return {
+    id: "call-1",
+    type: "function" as const,
+    function: { name, arguments: JSON.stringify(args) },
+  };
+}

--- a/src/suggester/context.ts
+++ b/src/suggester/context.ts
@@ -1,0 +1,151 @@
+import type { ChatEntry, ToolCall } from "../types/index.js";
+import {
+  DEFAULT_MAX_ASSISTANT_TURN_CHARS,
+  DEFAULT_MAX_RECENT_USER_PROMPT_CHARS,
+  DEFAULT_MAX_RECENT_USER_PROMPTS,
+  DEFAULT_MAX_SUGGESTION_CHARS,
+  DEFAULT_MAX_TOOL_SIGNAL_CHARS,
+  DEFAULT_MAX_TOOL_SIGNALS,
+  DEFAULT_MAX_TOUCHED_FILES,
+  DEFAULT_MAX_UNRESOLVED_QUESTIONS,
+  NO_SUGGESTION_TOKEN,
+} from "./config.js";
+import type { SuggestionPromptContext, TurnStatus } from "./types.js";
+
+const PATH_ARG_KEYS = ["path", "file_path", "filePath", "target_file", "targetFile"];
+
+export function buildSuggestionContext(
+  entries: ChatEntry[],
+  status: TurnStatus,
+  options?: {
+    abortNote?: string;
+    maxSuggestionChars?: number;
+    customInstruction?: string;
+    intentSeed?: string;
+    recentChanged?: Array<{ suggestedPrompt: string; actualUserPrompt: string }>;
+  },
+): SuggestionPromptContext {
+  const lastTurn = sliceLastTurn(entries);
+  const latestAssistantTurn = capText(lastAssistantText(lastTurn), DEFAULT_MAX_ASSISTANT_TURN_CHARS);
+
+  return {
+    turnStatus: status,
+    abortContextNote: options?.abortNote,
+    latestAssistantTurn,
+    recentUserPrompts: collectRecentUserPrompts(entries),
+    toolSignals: collectToolSignals(lastTurn),
+    touchedFiles: collectTouchedFiles(lastTurn),
+    unresolvedQuestions: collectUnresolvedQuestions(latestAssistantTurn),
+    recentChanged: options?.recentChanged ?? [],
+    customInstruction: options?.customInstruction ?? "",
+    intentSeed: options?.intentSeed ?? "none",
+    maxSuggestionChars: options?.maxSuggestionChars ?? DEFAULT_MAX_SUGGESTION_CHARS,
+    noSuggestionToken: NO_SUGGESTION_TOKEN,
+  };
+}
+
+export function sliceLastTurn(entries: ChatEntry[]): ChatEntry[] {
+  let lastUser = -1;
+  for (let i = entries.length - 1; i >= 0; i--) {
+    if (entries[i]?.type === "user") {
+      lastUser = i;
+      break;
+    }
+  }
+  if (lastUser < 0) return entries.slice(-20);
+  return entries.slice(lastUser);
+}
+
+function collectRecentUserPrompts(entries: ChatEntry[]): string[] {
+  const prompts: string[] = [];
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const entry = entries[i];
+    if (entry?.type !== "user") continue;
+    const text = capText(entry.content, DEFAULT_MAX_RECENT_USER_PROMPT_CHARS);
+    if (text) prompts.push(text);
+    if (prompts.length >= DEFAULT_MAX_RECENT_USER_PROMPTS) break;
+  }
+  return prompts.reverse();
+}
+
+function lastAssistantText(entries: ChatEntry[]): string {
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const entry = entries[i];
+    if (entry?.type === "assistant" && entry.content.trim()) return entry.content;
+  }
+  return "";
+}
+
+function collectToolSignals(entries: ChatEntry[]): string[] {
+  const signals: string[] = [];
+  for (const entry of entries) {
+    if (entry.type !== "tool_result") continue;
+    const name = entry.toolCall?.function.name || "tool";
+    const ok = entry.toolResult?.success !== false;
+    const detail = capText(
+      ok ? (entry.toolResult?.output ?? entry.content) : (entry.toolResult?.error ?? entry.content),
+      160,
+    );
+    const signal = capText(
+      `${name}: ${ok ? "ok" : "error"}${detail ? ` — ${detail}` : ""}`,
+      DEFAULT_MAX_TOOL_SIGNAL_CHARS,
+    );
+    if (signal) signals.push(signal);
+    if (signals.length >= DEFAULT_MAX_TOOL_SIGNALS) break;
+  }
+  return signals;
+}
+
+function collectTouchedFiles(entries: ChatEntry[]): string[] {
+  const files: string[] = [];
+  const seen = new Set<string>();
+
+  const add = (value: string | undefined) => {
+    const path = value?.trim();
+    if (!path || seen.has(path)) return;
+    seen.add(path);
+    files.push(path);
+  };
+
+  for (const entry of entries) {
+    if (entry.type !== "tool_result") continue;
+    add(entry.toolResult?.diff?.filePath);
+    addPathsFromToolCall(entry.toolCall, add);
+    if (files.length >= DEFAULT_MAX_TOUCHED_FILES) break;
+  }
+  return files.slice(0, DEFAULT_MAX_TOUCHED_FILES);
+}
+
+function addPathsFromToolCall(toolCall: ToolCall | undefined, add: (value: string | undefined) => void): void {
+  if (!toolCall) return;
+  try {
+    const args = JSON.parse(toolCall.function.arguments) as Record<string, unknown>;
+    for (const key of PATH_ARG_KEYS) {
+      const value = args[key];
+      if (typeof value === "string") add(value);
+    }
+  } catch {
+    /* ignore malformed tool args */
+  }
+}
+
+function collectUnresolvedQuestions(text: string): string[] {
+  if (!text) return [];
+  const questions: string[] = [];
+  for (const rawLine of text.split(/\n+/)) {
+    const line = rawLine
+      .trim()
+      .replace(/^[-*]\s+/, "")
+      .replace(/^\d+\.\s+/, "");
+    if (!line.includes("?") || line.length < 8 || line.startsWith("```")) continue;
+    questions.push(capText(line, 200));
+    if (questions.length >= DEFAULT_MAX_UNRESOLVED_QUESTIONS) break;
+  }
+  return questions;
+}
+
+function capText(value: string | undefined, max: number): string {
+  const text = (value ?? "").replace(/\s+/g, " ").trim();
+  if (text.length <= max) return text;
+  return text.slice(0, max).trimEnd();
+}

--- a/src/suggester/engine.test.ts
+++ b/src/suggester/engine.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { finalizeSuggestionResult, normalizeSuggestion, shouldFastPathContinue } from "./engine.js";
+
+describe("shouldFastPathContinue", () => {
+  it("fast-paths error and aborted turns when enabled", () => {
+    expect(shouldFastPathContinue("error", true)).toBe(true);
+    expect(shouldFastPathContinue("aborted", true)).toBe(true);
+    expect(shouldFastPathContinue("success", true)).toBe(false);
+    expect(shouldFastPathContinue("error", false)).toBe(false);
+  });
+});
+
+describe("normalizeSuggestion", () => {
+  it("returns null for empty or no-suggestion tokens", () => {
+    expect(normalizeSuggestion("   ", 200)).toBeNull();
+    expect(normalizeSuggestion("[no suggestion]", 200)).toBeNull();
+  });
+
+  it("trims and truncates long suggestions", () => {
+    expect(normalizeSuggestion("  Yes.  \n\n\nGo ahead.  ", 200)).toBe("Yes.\n\nGo ahead.");
+    expect(normalizeSuggestion("abcdefghij", 6)).toBe("abcdef");
+  });
+});
+
+describe("finalizeSuggestionResult", () => {
+  it("keeps usage when the model declines to suggest", () => {
+    const result = finalizeSuggestionResult(
+      { kind: "suggestion", text: "[no suggestion]", usage: { totalTokens: 12 }, modelId: "grok-3-mini" },
+      200,
+    );
+    expect(result.kind).toBe("no_suggestion");
+    expect(result.usage?.totalTokens).toBe(12);
+    expect(result.modelId).toBe("grok-3-mini");
+  });
+});

--- a/src/suggester/engine.ts
+++ b/src/suggester/engine.ts
@@ -1,0 +1,51 @@
+import { NO_SUGGESTION_TOKEN } from "./config.js";
+import type { SuggestionResult, TurnStatus } from "./types.js";
+
+export function shouldFastPathContinue(status: TurnStatus, enabled: boolean): boolean {
+  return enabled && status !== "success";
+}
+
+export function normalizeSuggestion(
+  value: string,
+  maxChars: number,
+  noSuggestionToken = NO_SUGGESTION_TOKEN,
+): string | null {
+  const normalized = value
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+
+  if (!normalized || normalized === noSuggestionToken) return null;
+  if (normalized.length <= maxChars) return normalized;
+  return normalized.slice(0, maxChars).trimEnd() || null;
+}
+
+export function finalizeSuggestionResult(
+  raw: SuggestionResult,
+  maxChars: number,
+  noSuggestionToken = NO_SUGGESTION_TOKEN,
+): SuggestionResult {
+  const text = normalizeSuggestion(raw.text, maxChars, noSuggestionToken);
+  if (!text) {
+    return {
+      kind: "no_suggestion",
+      text: noSuggestionToken,
+      usage: raw.usage,
+      modelId: raw.modelId,
+    };
+  }
+  return {
+    kind: "suggestion",
+    text,
+    usage: raw.usage,
+    modelId: raw.modelId,
+  };
+}
+
+export function fastPathContinueResult(): SuggestionResult {
+  return { kind: "suggestion", text: "continue" };
+}

--- a/src/suggester/generate.ts
+++ b/src/suggester/generate.ts
@@ -17,15 +17,14 @@ export async function generatePromptSuggestion(
   signal?: AbortSignal,
 ): Promise<SuggestionResult> {
   const runtime = resolveModelRuntime(provider, modelId);
-  const maxOutputTokens = Math.min(120, Math.max(32, Math.ceil(maxSuggestionChars / 2) + 16));
+  const maxOutputTokens = Math.min(64, Math.max(24, Math.ceil(maxSuggestionChars / 3) + 8));
 
   try {
     const { text, usage } = await generateText({
       model: runtime.model,
       abortSignal: signal,
-      temperature: 0.3,
+      temperature: 0,
       ...(runtime.modelInfo?.supportsMaxOutputTokens === false ? {} : { maxOutputTokens }),
-      ...(runtime.providerOptions ? { providerOptions: runtime.providerOptions } : {}),
       system: SYSTEM_PROMPT,
       prompt,
     });

--- a/src/suggester/generate.ts
+++ b/src/suggester/generate.ts
@@ -1,0 +1,49 @@
+import { generateText } from "ai";
+import { resolveModelRuntime, type XaiProvider } from "../grok/client.js";
+import { NO_SUGGESTION_TOKEN } from "./config.js";
+import type { SuggestionResult } from "./types.js";
+
+const SYSTEM_PROMPT = [
+  "You predict the user's next coding-agent prompt.",
+  "Output ONLY that next user message. Nothing else.",
+  `If no plausible next message is clear, output exactly ${NO_SUGGESTION_TOKEN}.`,
+].join("\n");
+
+export async function generatePromptSuggestion(
+  provider: XaiProvider,
+  prompt: string,
+  modelId: string,
+  maxSuggestionChars: number,
+  signal?: AbortSignal,
+): Promise<SuggestionResult> {
+  const runtime = resolveModelRuntime(provider, modelId);
+  const maxOutputTokens = Math.min(120, Math.max(32, Math.ceil(maxSuggestionChars / 2) + 16));
+
+  try {
+    const { text, usage } = await generateText({
+      model: runtime.model,
+      abortSignal: signal,
+      temperature: 0.3,
+      ...(runtime.modelInfo?.supportsMaxOutputTokens === false ? {} : { maxOutputTokens }),
+      ...(runtime.providerOptions ? { providerOptions: runtime.providerOptions } : {}),
+      system: SYSTEM_PROMPT,
+      prompt,
+    });
+
+    return {
+      kind: "suggestion",
+      text: text ?? "",
+      modelId: runtime.modelId,
+      usage: {
+        inputTokens: usage?.inputTokens,
+        outputTokens: usage?.outputTokens,
+        totalTokens: usage?.totalTokens,
+      },
+    };
+  } catch (error) {
+    if (signal?.aborted || (error instanceof Error && error.name === "AbortError")) {
+      return { kind: "no_suggestion", text: NO_SUGGESTION_TOKEN, modelId: runtime.modelId };
+    }
+    return { kind: "no_suggestion", text: NO_SUGGESTION_TOKEN, modelId: runtime.modelId };
+  }
+}

--- a/src/suggester/handle-command.ts
+++ b/src/suggester/handle-command.ts
@@ -1,0 +1,91 @@
+import { parseSuggesterCommand, suggesterUsageText } from "./command.js";
+
+export interface SuggesterCommandApi {
+  setEnabled: (enabled: boolean) => void;
+  setAutoAccept: (autoAccept: boolean) => void;
+  requestReseed: () => void;
+  setCustomInstruction: (instruction: string) => void;
+  setSuggesterModel: (model: string) => void;
+  setSeederModel: (model: string) => void;
+  formatStatus: () => string;
+}
+
+export function handleSuggesterCommand(cmd: string, api: SuggesterCommandApi, reply: (text: string) => void): boolean {
+  const parsed = parseSuggesterCommand(cmd);
+  if (!parsed) return false;
+
+  const rest = parsed.rest;
+  switch (parsed.action) {
+    case "help":
+      reply(suggesterUsageText());
+      return true;
+    case "on":
+      api.setEnabled(true);
+      reply("Prompt suggester enabled.");
+      return true;
+    case "off":
+      api.setEnabled(false);
+      reply("Prompt suggester disabled.");
+      return true;
+    case "auto":
+      api.setAutoAccept(true);
+      reply("Prompt suggester will insert the next prompt.");
+      return true;
+    case "ghost":
+      api.setAutoAccept(false);
+      reply("Prompt suggester will show a dim ghost. Space accepts.");
+      return true;
+    case "reseed":
+      api.requestReseed();
+      reply("Suggester reseed queued.");
+      return true;
+    case "instruction": {
+      const [verb, ...instructionParts] = rest.split(/\s+/);
+      if (!verb || verb.toLowerCase() === "show") {
+        reply(api.formatStatus());
+        return true;
+      }
+      if (verb.toLowerCase() === "clear") {
+        api.setCustomInstruction("");
+        reply("Suggester instruction cleared.");
+        return true;
+      }
+      const text = (verb.toLowerCase() === "set" ? instructionParts.join(" ") : rest).trim();
+      if (!text) {
+        reply("Usage: /suggester instruction set <text>");
+        return true;
+      }
+      api.setCustomInstruction(text);
+      reply("Suggester instruction saved.");
+      return true;
+    }
+    case "model": {
+      const [verb, ...modelParts] = rest.split(/\s+/);
+      if (!verb || verb.toLowerCase() === "show") {
+        reply(api.formatStatus());
+        return true;
+      }
+      if (verb.toLowerCase() === "seeder") {
+        const model = modelParts.join(" ").trim();
+        if (!model) {
+          reply("Usage: /suggester model seeder <id>");
+          return true;
+        }
+        api.setSeederModel(model);
+        reply(`Seeder model set to ${model}.`);
+        return true;
+      }
+      const model = (verb.toLowerCase() === "set" ? modelParts.join(" ") : rest).trim();
+      if (!model) {
+        reply("Usage: /suggester model set <id>");
+        return true;
+      }
+      api.setSuggesterModel(model);
+      reply(`Suggester model set to ${model}.`);
+      return true;
+    }
+    default:
+      reply(api.formatStatus());
+      return true;
+  }
+}

--- a/src/suggester/heuristic.test.ts
+++ b/src/suggester/heuristic.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { inferHeuristicSuggestion } from "./heuristic.js";
+import type { SuggestionPromptContext } from "./types.js";
+
+function ctx(partial: Partial<SuggestionPromptContext>): SuggestionPromptContext {
+  return {
+    turnStatus: "success",
+    latestAssistantTurn: "",
+    recentUserPrompts: [],
+    toolSignals: [],
+    touchedFiles: [],
+    unresolvedQuestions: [],
+    recentChanged: [],
+    customInstruction: "",
+    intentSeed: "none",
+    maxSuggestionChars: 200,
+    noSuggestionToken: "[no suggestion]",
+    ...partial,
+  };
+}
+
+describe("inferHeuristicSuggestion", () => {
+  it("continues after an aborted turn", () => {
+    expect(inferHeuristicSuggestion(ctx({ turnStatus: "aborted" }))).toEqual({
+      text: "continue",
+      confidence: "high",
+    });
+  });
+
+  it("answers a yes/no offer without a model call", () => {
+    expect(inferHeuristicSuggestion(ctx({ latestAssistantTurn: "Added the tests.\nWant me to run them?" }))?.text).toBe(
+      "Yes.",
+    );
+  });
+
+  it("returns null when there is no clear next move", () => {
+    expect(inferHeuristicSuggestion(ctx({ latestAssistantTurn: "Pushed the branch to origin." }))).toBeNull();
+  });
+});

--- a/src/suggester/heuristic.ts
+++ b/src/suggester/heuristic.ts
@@ -1,0 +1,58 @@
+import type { SuggestionPromptContext } from "./types.js";
+
+export interface HeuristicSuggestion {
+  text: string;
+  confidence: "high" | "low";
+}
+
+const YES_QUESTION =
+  /\b(want me to|should i|shall i|can i go ahead|ready for me to|do you want me to|ok to|okay to)\b/i;
+const PROCEED_CUE =
+  /\b(say the word|if you('d| would) like|when you('re| are) ready|i can (do|run|add|fix|continue))\b/i;
+
+export function inferHeuristicSuggestion(context: SuggestionPromptContext): HeuristicSuggestion | null {
+  if (context.turnStatus !== "success") {
+    return { text: "continue", confidence: "high" };
+  }
+
+  const assistant = context.latestAssistantTurn.trim();
+  if (!assistant) return null;
+
+  const lastQuestion = lastQuestionLine(assistant) ?? context.unresolvedQuestions.at(-1);
+  if (lastQuestion && isYesNoQuestion(lastQuestion)) {
+    return { text: "Yes.", confidence: context.customInstruction.trim() ? "low" : "high" };
+  }
+
+  if (PROCEED_CUE.test(tail(assistant, 500))) {
+    return { text: "Go ahead.", confidence: "low" };
+  }
+
+  return null;
+}
+
+function lastQuestionLine(text: string): string | undefined {
+  const lines = text
+    .split("\n")
+    .map((line) =>
+      line
+        .trim()
+        .replace(/^[-*]\s+/, "")
+        .replace(/^\d+\.\s+/, ""),
+    )
+    .filter(Boolean);
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i] ?? "";
+    if (line.endsWith("?")) return line;
+  }
+  return undefined;
+}
+
+function isYesNoQuestion(question: string): boolean {
+  if (question.length > 180) return false;
+  if (YES_QUESTION.test(question)) return true;
+  return /^(want|should|shall|can|may|do|did|does|is|are|ready)\b/i.test(question);
+}
+
+function tail(value: string, max: number): string {
+  return value.length <= max ? value : value.slice(-max);
+}

--- a/src/suggester/index.ts
+++ b/src/suggester/index.ts
@@ -1,0 +1,27 @@
+export { parseSuggesterCommand, suggesterUsageText } from "./command.js";
+export {
+  DEFAULT_SEEDER_MODEL,
+  DEFAULT_SUGGESTER_MODEL,
+  DEFAULT_SUGGESTER_SETTINGS,
+  loadSuggesterSettings,
+  NO_SUGGESTION_TOKEN,
+  resolveSuggesterSettings,
+  saveSuggesterSettings,
+} from "./config.js";
+export { buildSuggestionContext } from "./context.js";
+export { finalizeSuggestionResult, normalizeSuggestion, shouldFastPathContinue } from "./engine.js";
+export { generatePromptSuggestion } from "./generate.js";
+export { isGhostAcceptKey } from "./keys.js";
+export { renderSuggestionPrompt } from "./prompt.js";
+export { loadSeed } from "./seed.js";
+export { formatSuggesterStatus } from "./status.js";
+export { classifySteering } from "./steering.js";
+export { loadSuggesterSessionState } from "./store.js";
+export type {
+  GhostAcceptKey,
+  ResolvedSuggesterSettings,
+  SuggesterSettings,
+  SuggestionPromptContext,
+  SuggestionResult,
+  TurnStatus,
+} from "./types.js";

--- a/src/suggester/index.ts
+++ b/src/suggester/index.ts
@@ -11,6 +11,7 @@ export {
 export { buildSuggestionContext } from "./context.js";
 export { finalizeSuggestionResult, normalizeSuggestion, shouldFastPathContinue } from "./engine.js";
 export { generatePromptSuggestion } from "./generate.js";
+export { handleSuggesterCommand } from "./handle-command.js";
 export { isGhostAcceptKey } from "./keys.js";
 export { renderSuggestionPrompt } from "./prompt.js";
 export { loadSeed } from "./seed.js";

--- a/src/suggester/keys.test.ts
+++ b/src/suggester/keys.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { isGhostAcceptKey } from "./keys.js";
+
+describe("isGhostAcceptKey", () => {
+  it("matches space and right only when configured", () => {
+    expect(isGhostAcceptKey({ name: "space" }, ["space"])).toBe(true);
+    expect(isGhostAcceptKey({ sequence: " " }, ["space", "right"])).toBe(true);
+    expect(isGhostAcceptKey({ name: "right" }, ["right"])).toBe(true);
+    expect(isGhostAcceptKey({ name: "right" }, ["space"])).toBe(false);
+    expect(isGhostAcceptKey({ name: "a", sequence: "a" }, ["space", "right"])).toBe(false);
+  });
+});

--- a/src/suggester/keys.ts
+++ b/src/suggester/keys.ts
@@ -1,0 +1,22 @@
+import type { GhostAcceptKey } from "./types.js";
+
+export interface GhostKeyLike {
+  name?: string;
+  sequence?: string;
+}
+
+export function isGhostAcceptKey(key: GhostKeyLike, acceptKeys: readonly GhostAcceptKey[]): boolean {
+  for (const acceptKey of acceptKeys) {
+    if (acceptKey === "space" && isSpaceKey(key)) return true;
+    if (acceptKey === "right" && isRightKey(key)) return true;
+  }
+  return false;
+}
+
+export function isSpaceKey(key: GhostKeyLike): boolean {
+  return key.name === "space" || key.sequence === " ";
+}
+
+export function isRightKey(key: GhostKeyLike): boolean {
+  return key.name === "right" || key.name === "rightarrow";
+}

--- a/src/suggester/prompt.test.ts
+++ b/src/suggester/prompt.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { renderSuggestionPrompt } from "./prompt.js";
+import type { SuggestionPromptContext } from "./types.js";
+
+describe("renderSuggestionPrompt", () => {
+  it("includes turn signals and the no-suggestion token", () => {
+    const context: SuggestionPromptContext = {
+      turnStatus: "success",
+      latestAssistantTurn: "I added the tests.",
+      recentUserPrompts: ["add tests"],
+      toolSignals: ["write_file: ok — src/foo.test.ts"],
+      touchedFiles: ["src/foo.test.ts"],
+      unresolvedQuestions: ["Want me to run them?"],
+      recentChanged: [{ suggestedPrompt: "ship it", actualUserPrompt: "add tests first" }],
+      customInstruction: "Prefer terse commands.",
+      intentSeed: '{"projectIntentSummary":"Port the Pi suggester"}',
+      maxSuggestionChars: 200,
+      noSuggestionToken: "[no suggestion]",
+    };
+    const prompt = renderSuggestionPrompt(context);
+    expect(prompt).toContain("Grok session");
+    expect(prompt).toContain("[no suggestion]");
+    expect(prompt).toContain("add tests");
+    expect(prompt).toContain("src/foo.test.ts");
+    expect(prompt).toContain("Want me to run them?");
+    expect(prompt).toContain("ProjectIntent");
+    expect(prompt).toContain("Port the Pi suggester");
+    expect(prompt).toContain("Prefer terse commands.");
+    expect(prompt).toContain("add tests first");
+    expect(prompt).toContain("under 200 characters");
+  });
+});

--- a/src/suggester/prompt.test.ts
+++ b/src/suggester/prompt.test.ts
@@ -18,15 +18,15 @@ describe("renderSuggestionPrompt", () => {
       noSuggestionToken: "[no suggestion]",
     };
     const prompt = renderSuggestionPrompt(context);
-    expect(prompt).toContain("Grok session");
+    expect(prompt).toContain("Next user message only");
     expect(prompt).toContain("[no suggestion]");
     expect(prompt).toContain("add tests");
     expect(prompt).toContain("src/foo.test.ts");
     expect(prompt).toContain("Want me to run them?");
-    expect(prompt).toContain("ProjectIntent");
+    expect(prompt).toContain("Intent:");
     expect(prompt).toContain("Port the Pi suggester");
     expect(prompt).toContain("Prefer terse commands.");
     expect(prompt).toContain("add tests first");
-    expect(prompt).toContain("under 200 characters");
+    expect(prompt).toContain("Max 200 chars");
   });
 });

--- a/src/suggester/prompt.ts
+++ b/src/suggester/prompt.ts
@@ -1,0 +1,65 @@
+// Adapted from pi-prompt-suggester (MIT)
+// Copyright (c) 2026 Guido Witt-Dörring
+// https://github.com/guwidoe/pi-prompt-suggester
+
+import type { SuggestionPromptContext } from "./types.js";
+
+export function renderSuggestionPrompt(context: SuggestionPromptContext): string {
+  return `Write the next message the user would most likely send in this Grok session.
+
+Return only the user's message text.
+Do not explain.
+Do not describe the instructions you were given.
+If no plausible next user message is clear, return exactly ${context.noSuggestionToken}.
+
+TurnStatus:
+${context.turnStatus}
+
+AbortContext:
+${context.abortContextNote ?? "(none)"}
+
+ProjectIntent:
+${context.intentSeed}
+
+RecentUserMessages:
+${context.recentUserPrompts.length > 0 ? context.recentUserPrompts.map((prompt) => `- ${prompt}`).join("\n") : "(none)"}
+
+ToolSignals:
+${context.toolSignals.length > 0 ? context.toolSignals.map((signal) => `- ${signal}`).join("\n") : "(none)"}
+
+TouchedFiles:
+${context.touchedFiles.length > 0 ? context.touchedFiles.map((file) => `- ${file}`).join("\n") : "(none)"}
+
+UnresolvedQuestions:
+${context.unresolvedQuestions.length > 0 ? context.unresolvedQuestions.map((item) => `- ${item}`).join("\n") : "(none)"}
+
+${renderChangedExamples(context.recentChanged)}
+${context.customInstruction.trim() ? `\nAdditional user preference:\n${context.customInstruction.trim()}\n` : ""}
+LatestAssistantMessage:
+\`\`\`
+${context.latestAssistantTurn || "(empty)"}
+\`\`\`
+
+Guidance:
+- Stay close to the user's recent style and current trajectory.
+- Treat RecentUserMessages as the strongest signal.
+- Use ProjectIntent to stay aligned with the project's goals and constraints.
+- Learn from RecentUserCorrections: avoid repeating directions the user moved away from.
+- If AbortContext is present, assume the user intentionally interrupted the previous execution.
+- If the latest assistant message proposed a next step and it fits, a short reply like "Yes.", "Go ahead.", or "Proceed." is often best.
+- Only add more text when it adds new information such as a constraint, correction, or emphasis.
+- Do not restate, summarize, or paraphrase the assistant's proposal unless repeating a small part is necessary to add that new information.
+- If nothing new needs to be added, prefer affirmation only.
+- If the assistant's direction clearly conflicts with the user's recent behavior, write a natural pivot instead.
+- Keep the result under ${context.maxSuggestionChars} characters. Prefer fewer when possible.`;
+}
+
+function renderChangedExamples(examples: Array<{ suggestedPrompt: string; actualUserPrompt: string }>): string {
+  if (examples.length === 0) return "RecentUserCorrections:\n(none)";
+  return `RecentUserCorrections:\n${examples
+    .map(
+      (example) =>
+        `- instead of ${JSON.stringify(example.suggestedPrompt)}\n  the user wrote: ${JSON.stringify(example.actualUserPrompt)}`,
+    )
+    .join("\n")}`;
+}

--- a/src/suggester/prompt.ts
+++ b/src/suggester/prompt.ts
@@ -5,53 +5,18 @@
 import type { SuggestionPromptContext } from "./types.js";
 
 export function renderSuggestionPrompt(context: SuggestionPromptContext): string {
-  return `Write the next message the user would most likely send in this Grok session.
+  return `Next user message only. No explanation. If none, return ${context.noSuggestionToken}. Max ${context.maxSuggestionChars} chars. Prefer Yes./Go ahead. when the assistant offered a next step.
 
-Return only the user's message text.
-Do not explain.
-Do not describe the instructions you were given.
-If no plausible next user message is clear, return exactly ${context.noSuggestionToken}.
-
-TurnStatus:
-${context.turnStatus}
-
-AbortContext:
-${context.abortContextNote ?? "(none)"}
-
-ProjectIntent:
-${context.intentSeed}
-
-RecentUserMessages:
-${context.recentUserPrompts.length > 0 ? context.recentUserPrompts.map((prompt) => `- ${prompt}`).join("\n") : "(none)"}
-
-ToolSignals:
-${context.toolSignals.length > 0 ? context.toolSignals.map((signal) => `- ${signal}`).join("\n") : "(none)"}
-
-TouchedFiles:
-${context.touchedFiles.length > 0 ? context.touchedFiles.map((file) => `- ${file}`).join("\n") : "(none)"}
-
-UnresolvedQuestions:
-${context.unresolvedQuestions.length > 0 ? context.unresolvedQuestions.map((item) => `- ${item}`).join("\n") : "(none)"}
-
+Status: ${context.turnStatus}
+Abort: ${context.abortContextNote ?? "(none)"}
+Intent: ${context.intentSeed}
+Recent: ${context.recentUserPrompts.length > 0 ? context.recentUserPrompts.map((prompt) => `- ${prompt}`).join(" | ") : "(none)"}
+Tools: ${context.toolSignals.length > 0 ? context.toolSignals.join(" | ") : "(none)"}
+Files: ${context.touchedFiles.length > 0 ? context.touchedFiles.join(", ") : "(none)"}
+Questions: ${context.unresolvedQuestions.length > 0 ? context.unresolvedQuestions.join(" | ") : "(none)"}
 ${renderChangedExamples(context.recentChanged)}
-${context.customInstruction.trim() ? `\nAdditional user preference:\n${context.customInstruction.trim()}\n` : ""}
-LatestAssistantMessage:
-\`\`\`
-${context.latestAssistantTurn || "(empty)"}
-\`\`\`
-
-Guidance:
-- Stay close to the user's recent style and current trajectory.
-- Treat RecentUserMessages as the strongest signal.
-- Use ProjectIntent to stay aligned with the project's goals and constraints.
-- Learn from RecentUserCorrections: avoid repeating directions the user moved away from.
-- If AbortContext is present, assume the user intentionally interrupted the previous execution.
-- If the latest assistant message proposed a next step and it fits, a short reply like "Yes.", "Go ahead.", or "Proceed." is often best.
-- Only add more text when it adds new information such as a constraint, correction, or emphasis.
-- Do not restate, summarize, or paraphrase the assistant's proposal unless repeating a small part is necessary to add that new information.
-- If nothing new needs to be added, prefer affirmation only.
-- If the assistant's direction clearly conflicts with the user's recent behavior, write a natural pivot instead.
-- Keep the result under ${context.maxSuggestionChars} characters. Prefer fewer when possible.`;
+${context.customInstruction.trim() ? `Pref: ${context.customInstruction.trim()}\n` : ""}Assistant:
+${context.latestAssistantTurn || "(empty)"}`;
 }
 
 function renderChangedExamples(examples: Array<{ suggestedPrompt: string; actualUserPrompt: string }>): string {

--- a/src/suggester/seed-tools.ts
+++ b/src/suggester/seed-tools.ts
@@ -1,0 +1,128 @@
+import { existsSync, readdirSync, statSync } from "fs";
+import { isAbsolute, join, normalize, relative, resolve, sep } from "path";
+import { readFile } from "../tools/file.js";
+import { executeGrep } from "../tools/grep.js";
+
+const SKIP_DIRS = new Set([".git", "node_modules", "dist", "build", ".next", "coverage", ".grok"]);
+
+export type SeederToolName = "ls" | "find" | "grep" | "read";
+
+export interface SeederToolCall {
+  tool: SeederToolName;
+  arguments: Record<string, unknown>;
+}
+
+export function confinePath(cwd: string, inputPath?: string): string | null {
+  const root = resolve(cwd);
+  const target = resolve(root, inputPath?.trim() ? inputPath : ".");
+  if (target !== root && !target.startsWith(`${root}${sep}`)) return null;
+  return target;
+}
+
+export async function runSeederTool(cwd: string, call: SeederToolCall): Promise<string> {
+  const tool = call.tool;
+  const args = call.arguments ?? {};
+  if (tool === "ls") return runLs(cwd, asString(args.path), asNumber(args.limit, 80));
+  if (tool === "find")
+    return runFind(cwd, asString(args.pattern) || "*", asString(args.path), asNumber(args.limit, 40));
+  if (tool === "grep") {
+    const pattern = asString(args.pattern);
+    if (!pattern) return "grep error: pattern is required";
+    const result = await executeGrep(
+      {
+        pattern,
+        path: asString(args.path) || undefined,
+        include: asString(args.glob) || undefined,
+      },
+      cwd,
+    );
+    const text = result.success ? result.output || "No matches found." : result.error || "grep failed";
+    return cap(text, 4000);
+  }
+  if (tool === "read") {
+    const filePath = asString(args.path);
+    if (!filePath) return "read error: path is required";
+    const confined = confinePath(cwd, filePath);
+    if (!confined) return `read error: path escapes workspace (${filePath})`;
+    const offset = asNumber(args.offset, 1);
+    const limit = asNumber(args.limit, 200);
+    const result = readFile(filePath, cwd, offset, offset + limit - 1);
+    return cap(result.output, 6000);
+  }
+  return `unknown tool: ${String(tool)}`;
+}
+
+function runLs(cwd: string, inputPath: string, limit: number): string {
+  const confined = confinePath(cwd, inputPath);
+  if (!confined) return `ls error: path escapes workspace (${inputPath})`;
+  if (!existsSync(confined)) return `ls error: not found (${inputPath || "."})`;
+  const entries = readdirSync(confined, { withFileTypes: true })
+    .slice(0, Math.max(1, limit))
+    .map((entry) => `${entry.isDirectory() ? "dir" : "file"} ${join(inputPath || ".", entry.name)}`);
+  return entries.join("\n") || "(empty)";
+}
+
+function runFind(cwd: string, pattern: string, inputPath: string, limit: number): string {
+  const confined = confinePath(cwd, inputPath);
+  if (!confined) return `find error: path escapes workspace (${inputPath})`;
+  const needle = pattern.replace(/^\*/, "").replace(/\*$/, "").toLowerCase();
+  const matches: string[] = [];
+  walk(confined, cwd, (rel, isDir) => {
+    if (isDir) return;
+    if (needle && !rel.toLowerCase().includes(needle) && !rel.split(sep).pop()?.toLowerCase().includes(needle)) return;
+    matches.push(rel);
+    return matches.length >= limit;
+  });
+  return matches.join("\n") || "No files found.";
+}
+
+function walk(absolute: string, cwd: string, visit: (rel: string, isDir: boolean) => boolean | undefined): void {
+  let entries: Array<{ name: string; isDirectory: () => boolean }>;
+  try {
+    entries = readdirSync(absolute, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (SKIP_DIRS.has(entry.name)) continue;
+    const full = join(absolute, entry.name);
+    const rel = normalize(relative(cwd, full)) || entry.name;
+    if (entry.isDirectory()) {
+      if (visit(rel, true)) return;
+      walk(full, cwd, visit);
+    } else if (visit(rel, false)) {
+      return;
+    }
+  }
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function asNumber(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? Math.floor(value) : fallback;
+}
+
+function cap(value: string, max: number): string {
+  return value.length <= max ? value : `${value.slice(0, max)}\n…[truncated]`;
+}
+
+export function toRepoRelative(cwd: string, inputPath: string): string | null {
+  const confined = confinePath(cwd, inputPath);
+  if (!confined) return null;
+  const rel = relative(resolve(cwd), confined);
+  if (!rel || rel === ".") return null;
+  if (rel.startsWith(`..${sep}`) || isAbsolute(rel)) return null;
+  return rel;
+}
+
+export function fileExistsInRepo(cwd: string, relPath: string): boolean {
+  const confined = confinePath(cwd, relPath);
+  if (!confined) return false;
+  try {
+    return existsSync(confined) && statSync(confined).isFile();
+  } catch {
+    return false;
+  }
+}

--- a/src/suggester/seed.test.ts
+++ b/src/suggester/seed.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { parseSeedDraft, validateSeedDraft } from "./seed.js";
+import { confinePath } from "./seed-tools.js";
+import { extractJsonObject } from "./seeder-prompt.js";
+
+describe("parseSeedDraft", () => {
+  it("accepts a complete draft and rejects missing categories", () => {
+    const raw = {
+      projectIntentSummary: "Build a CLI",
+      objectivesSummary: "Ship suggester",
+      constraintsSummary: "Read-only seeder",
+      principlesGuidelinesSummary: "Keep it simple",
+      implementationStatusSummary: "In progress",
+      topObjectives: ["seed"],
+      constraints: ["no writes"],
+      keyFiles: [{ path: "README.md", whyImportant: "vision", category: "vision" }],
+      categoryFindings: {
+        vision: { found: true, rationale: "README", files: ["README.md"] },
+        architecture: { found: false, rationale: "none", files: [] },
+        principles_guidelines: { found: false, rationale: "none", files: [] },
+      },
+      openQuestions: [],
+    };
+    const draft = parseSeedDraft(raw);
+    expect(draft).not.toBeNull();
+    expect(validateSeedDraft(draft!)).toBeNull();
+
+    const incomplete = parseSeedDraft({ ...raw, categoryFindings: { vision: raw.categoryFindings.vision } });
+    expect(incomplete).toBeNull();
+  });
+});
+
+describe("extractJsonObject", () => {
+  it("pulls JSON out of a fenced reply", () => {
+    const parsed = extractJsonObject('```json\n{"type":"final","seed":{}}\n```');
+    expect(parsed).toEqual({ type: "final", seed: {} });
+  });
+});
+
+describe("confinePath", () => {
+  it("rejects paths outside the workspace", () => {
+    expect(confinePath("/tmp/repo", "../etc/passwd")).toBeNull();
+    expect(confinePath("/tmp/repo", "src/app.ts")?.endsWith("/repo/src/app.ts")).toBe(true);
+  });
+});

--- a/src/suggester/seed.ts
+++ b/src/suggester/seed.ts
@@ -1,0 +1,224 @@
+// Seed artifact shape adapted from pi-prompt-suggester (MIT)
+// Copyright (c) 2026 Guido Witt-Dörring
+// https://github.com/guwidoe/pi-prompt-suggester
+
+import { createHash } from "crypto";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { projectKeyFor } from "./store.js";
+
+export const CURRENT_SEED_VERSION = 1;
+export const CURRENT_GENERATOR_VERSION = "2026-08-16.1";
+export const SEEDER_PROMPT_VERSION = "2026-08-16.1";
+
+export type ReseedReason = "initial_missing" | "manual" | "key_file_changed";
+
+export type SeedKeyFileCategory = "vision" | "architecture" | "principles_guidelines" | "code_entrypoint" | "other";
+
+export const REQUIRED_SEED_CATEGORIES = ["vision", "architecture", "principles_guidelines"] as const;
+
+export interface SeedCategoryFinding {
+  found: boolean;
+  rationale: string;
+  files: string[];
+}
+
+export type SeedCategoryFindings = Record<(typeof REQUIRED_SEED_CATEGORIES)[number], SeedCategoryFinding>;
+
+export interface SeedKeyFile {
+  path: string;
+  hash: string;
+  whyImportant: string;
+  category: SeedKeyFileCategory;
+}
+
+export interface SeedArtifact {
+  seedVersion: number;
+  generatedAt: string;
+  sourceCommit?: string;
+  generatorVersion: string;
+  seederPromptVersion: string;
+  modelId?: string;
+  projectIntentSummary: string;
+  objectivesSummary: string;
+  constraintsSummary: string;
+  principlesGuidelinesSummary: string;
+  implementationStatusSummary: string;
+  topObjectives: string[];
+  constraints: string[];
+  keyFiles: SeedKeyFile[];
+  categoryFindings: SeedCategoryFindings;
+  openQuestions: string[];
+  reseedNotes?: string;
+  lastReseedReason?: ReseedReason;
+  lastChangedFiles?: string[];
+}
+
+export interface SeedDraft {
+  projectIntentSummary: string;
+  objectivesSummary: string;
+  constraintsSummary: string;
+  principlesGuidelinesSummary: string;
+  implementationStatusSummary: string;
+  topObjectives: string[];
+  constraints: string[];
+  keyFiles: Array<Pick<SeedKeyFile, "path" | "whyImportant" | "category">>;
+  categoryFindings: SeedCategoryFindings;
+  openQuestions: string[];
+  reseedNotes?: string;
+}
+
+export interface ReseedTrigger {
+  reason: ReseedReason;
+  changedFiles: string[];
+}
+
+export function seedPath(cwd: string, homeDir = os.homedir()): string {
+  return path.join(homeDir, ".grok", "prompt-suggester", "projects", projectKeyFor(cwd), "seed.json");
+}
+
+export function loadSeed(cwd: string, homeDir = os.homedir()): SeedArtifact | null {
+  const filePath = seedPath(cwd, homeDir);
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    return JSON.parse(fs.readFileSync(filePath, "utf-8")) as SeedArtifact;
+  } catch {
+    return null;
+  }
+}
+
+export function saveSeed(cwd: string, seed: SeedArtifact, homeDir = os.homedir()): void {
+  const filePath = seedPath(cwd, homeDir);
+  try {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+    fs.writeFileSync(filePath, JSON.stringify(seed, null, 2), { mode: 0o600 });
+  } catch {
+    /* never block the TUI */
+  }
+}
+
+export function hashFile(absolutePath: string): string {
+  return createHash("sha256").update(fs.readFileSync(absolutePath)).digest("hex");
+}
+
+export function compactSeedForPrompt(seed: SeedArtifact | null): string {
+  if (!seed) return "none";
+  return JSON.stringify(
+    {
+      projectIntentSummary: seed.projectIntentSummary,
+      objectivesSummary: seed.objectivesSummary,
+      constraintsSummary: seed.constraintsSummary,
+      principlesGuidelinesSummary: seed.principlesGuidelinesSummary,
+      implementationStatusSummary: seed.implementationStatusSummary,
+      topObjectives: seed.topObjectives,
+      constraints: seed.constraints,
+      openQuestions: seed.openQuestions,
+      keyFiles: seed.keyFiles.map((file) => ({
+        path: file.path,
+        category: file.category,
+        whyImportant: file.whyImportant,
+      })),
+      categoryFindings: seed.categoryFindings,
+    },
+    null,
+    2,
+  );
+}
+
+export function validateSeedDraft(draft: SeedDraft): string | null {
+  for (const category of REQUIRED_SEED_CATEGORIES) {
+    const finding = draft.categoryFindings[category];
+    if (!finding || typeof finding.found !== "boolean" || !finding.rationale.trim()) {
+      return `missing categoryFindings.${category}`;
+    }
+    if (finding.found) {
+      const tagged = draft.keyFiles.some((file) => file.category === category);
+      if (!tagged) return `found ${category} but no key file is tagged with that category`;
+    }
+  }
+  if (draft.keyFiles.length === 0) return "no keyFiles";
+  return null;
+}
+
+export function parseSeedDraft(value: unknown): SeedDraft | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as Record<string, unknown>;
+  const findings = parseCategoryFindings(raw.categoryFindings);
+  if (!findings) return null;
+  const keyFiles = parseKeyFileDrafts(raw.keyFiles);
+  if (!keyFiles) return null;
+  return {
+    projectIntentSummary: asString(raw.projectIntentSummary),
+    objectivesSummary: asString(raw.objectivesSummary),
+    constraintsSummary: asString(raw.constraintsSummary),
+    principlesGuidelinesSummary: asString(raw.principlesGuidelinesSummary),
+    implementationStatusSummary: asString(raw.implementationStatusSummary),
+    topObjectives: asStringArray(raw.topObjectives),
+    constraints: asStringArray(raw.constraints),
+    keyFiles,
+    categoryFindings: findings,
+    openQuestions: asStringArray(raw.openQuestions),
+    reseedNotes: asString(raw.reseedNotes) || undefined,
+  };
+}
+
+function parseCategoryFindings(value: unknown): SeedCategoryFindings | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as Record<string, unknown>;
+  const findings = {} as SeedCategoryFindings;
+  for (const category of REQUIRED_SEED_CATEGORIES) {
+    const item = raw[category];
+    if (!item || typeof item !== "object") return null;
+    const row = item as Record<string, unknown>;
+    findings[category] = {
+      found: Boolean(row.found),
+      rationale: asString(row.rationale),
+      files: asStringArray(row.files),
+    };
+  }
+  return findings;
+}
+
+function parseKeyFileDrafts(value: unknown): SeedDraft["keyFiles"] | null {
+  if (!Array.isArray(value)) return null;
+  const files: SeedDraft["keyFiles"] = [];
+  for (const item of value) {
+    if (!item || typeof item !== "object") continue;
+    const row = item as Record<string, unknown>;
+    const filePath = asString(row.path);
+    const category = asCategory(row.category);
+    if (!filePath || !category) continue;
+    files.push({
+      path: filePath,
+      whyImportant: asString(row.whyImportant) || "High-signal repository file",
+      category,
+    });
+  }
+  return files;
+}
+
+function asCategory(value: unknown): SeedKeyFileCategory | null {
+  if (
+    value === "vision" ||
+    value === "architecture" ||
+    value === "principles_guidelines" ||
+    value === "code_entrypoint" ||
+    value === "other"
+  ) {
+    return value;
+  }
+  return null;
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}

--- a/src/suggester/seed.ts
+++ b/src/suggester/seed.ts
@@ -10,6 +10,7 @@ import { projectKeyFor } from "./store.js";
 
 export const CURRENT_SEED_VERSION = 1;
 export const CURRENT_GENERATOR_VERSION = "2026-08-16.1";
+export const BOOTSTRAP_GENERATOR_VERSION = "bootstrap";
 export const SEEDER_PROMPT_VERSION = "2026-08-16.1";
 
 export type ReseedReason = "initial_missing" | "manual" | "key_file_changed";
@@ -104,26 +105,23 @@ export function hashFile(absolutePath: string): string {
 
 export function compactSeedForPrompt(seed: SeedArtifact | null): string {
   if (!seed) return "none";
-  return JSON.stringify(
-    {
-      projectIntentSummary: seed.projectIntentSummary,
-      objectivesSummary: seed.objectivesSummary,
-      constraintsSummary: seed.constraintsSummary,
-      principlesGuidelinesSummary: seed.principlesGuidelinesSummary,
-      implementationStatusSummary: seed.implementationStatusSummary,
-      topObjectives: seed.topObjectives,
-      constraints: seed.constraints,
-      openQuestions: seed.openQuestions,
-      keyFiles: seed.keyFiles.map((file) => ({
-        path: file.path,
-        category: file.category,
-        whyImportant: file.whyImportant,
-      })),
-      categoryFindings: seed.categoryFindings,
-    },
-    null,
-    2,
-  );
+  const files = seed.keyFiles
+    .slice(0, 6)
+    .map((file) => file.path)
+    .join(", ");
+  return [
+    clip(seed.projectIntentSummary, 360),
+    clip(seed.objectivesSummary, 200),
+    clip(seed.constraintsSummary, 200),
+    files ? `files: ${files}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+function clip(value: string, max: number): string {
+  const text = value.replace(/\s+/g, " ").trim();
+  return text.length <= max ? text : text.slice(0, max).trimEnd();
 }
 
 export function validateSeedDraft(draft: SeedDraft): string | null {
@@ -221,4 +219,67 @@ function asStringArray(value: unknown): string[] {
     .filter((item): item is string => typeof item === "string")
     .map((item) => item.trim())
     .filter(Boolean);
+}
+
+const BOOTSTRAP_FILES: Array<{ path: string; category: SeedKeyFileCategory }> = [
+  { path: "README.md", category: "vision" },
+  { path: "AGENTS.md", category: "principles_guidelines" },
+  { path: "package.json", category: "code_entrypoint" },
+];
+
+export function bootstrapSeedFromRepo(cwd: string): SeedArtifact | null {
+  const keyFiles: SeedKeyFile[] = [];
+  const snippets: string[] = [];
+  for (const file of BOOTSTRAP_FILES) {
+    const absolute = path.resolve(cwd, file.path);
+    try {
+      if (!fs.existsSync(absolute) || !fs.statSync(absolute).isFile()) continue;
+      const text = fs.readFileSync(absolute, "utf-8").slice(0, 1_200).replace(/\s+/g, " ").trim();
+      keyFiles.push({
+        path: file.path,
+        hash: hashFile(absolute),
+        whyImportant: "High-signal repo file used for instant seed",
+        category: file.category,
+      });
+      if (text) snippets.push(`${file.path}: ${text.slice(0, 280)}`);
+    } catch {
+      /* skip unreadable files */
+    }
+  }
+  if (keyFiles.length === 0) return null;
+
+  const summary = snippets.join(" ").slice(0, 500) || "Local repository.";
+  const emptyFinding = (found: boolean, files: string[]): SeedCategoryFinding => ({
+    found,
+    rationale: found ? "Present at repo root." : "Not found at repo root.",
+    files,
+  });
+
+  return {
+    seedVersion: CURRENT_SEED_VERSION,
+    generatedAt: new Date().toISOString(),
+    generatorVersion: BOOTSTRAP_GENERATOR_VERSION,
+    seederPromptVersion: SEEDER_PROMPT_VERSION,
+    projectIntentSummary: summary,
+    objectivesSummary: summary,
+    constraintsSummary: "",
+    principlesGuidelinesSummary: keyFiles.some((file) => file.path === "AGENTS.md") ? "See AGENTS.md" : "",
+    implementationStatusSummary: "Bootstrap seed; a background reseed will refine this.",
+    topObjectives: [],
+    constraints: [],
+    keyFiles,
+    categoryFindings: {
+      vision: emptyFinding(
+        keyFiles.some((file) => file.category === "vision"),
+        keyFiles.filter((file) => file.category === "vision").map((file) => file.path),
+      ),
+      architecture: emptyFinding(false, []),
+      principles_guidelines: emptyFinding(
+        keyFiles.some((file) => file.category === "principles_guidelines"),
+        keyFiles.filter((file) => file.category === "principles_guidelines").map((file) => file.path),
+      ),
+    },
+    openQuestions: [],
+    lastReseedReason: "initial_missing",
+  };
 }

--- a/src/suggester/seeder-prompt.ts
+++ b/src/suggester/seeder-prompt.ts
@@ -1,0 +1,94 @@
+// Adapted from pi-prompt-suggester (MIT)
+// Copyright (c) 2026 Guido Witt-Dörring
+// https://github.com/guwidoe/pi-prompt-suggester
+
+import { compactSeedForPrompt, type ReseedTrigger, type SeedArtifact } from "./seed.js";
+
+export function renderSeederSystemPrompt(): string {
+  return `You are an agentic read-only repository seeder for Grok next-prompt suggestions.
+
+You can explore using one tool call per step:
+- ls {"path"?: string, "limit"?: number}
+- find {"pattern": string, "path"?: string, "limit"?: number}
+- grep {"pattern": string, "path"?: string, "glob"?: string, "limit"?: number}
+- read {"path": string, "offset"?: number, "limit"?: number}
+
+CRITICAL RULES:
+- Read-only exploration only.
+- Explicitly investigate vision, architecture, and principles/guidelines/conventions.
+- If no file is found for a category, say so with found=false and a rationale.
+- Multiple files per category are allowed.
+
+Reply with STRICT JSON only (no markdown):
+Tool call:
+{"type":"tool","tool":"ls|find|grep|read","arguments":{},"reason":"short reason"}
+
+Final:
+{"type":"final","seed":{
+  "projectIntentSummary": string,
+  "objectivesSummary": string,
+  "constraintsSummary": string,
+  "principlesGuidelinesSummary": string,
+  "implementationStatusSummary": string,
+  "topObjectives": string[],
+  "constraints": string[],
+  "keyFiles": [{"path": string, "whyImportant": string, "category": "vision|architecture|principles_guidelines|code_entrypoint|other"}],
+  "categoryFindings": {
+    "vision": {"found": boolean, "rationale": string, "files": string[]},
+    "architecture": {"found": boolean, "rationale": string, "files": string[]},
+    "principles_guidelines": {"found": boolean, "rationale": string, "files": string[]}
+  },
+  "openQuestions": string[],
+  "reseedNotes": string
+}}
+
+Do not return type=final until you have looked for vision, architecture, and principles sources.`;
+}
+
+export function renderSeederUserPrompt(input: {
+  cwd: string;
+  trigger: ReseedTrigger;
+  previousSeed: SeedArtifact | null;
+  step: number;
+  maxSteps: number;
+  history: Array<{ modelResponse: string; toolResult?: string }>;
+  forceFinal?: boolean;
+}): string {
+  const historyText =
+    input.history.length === 0
+      ? "(none yet)"
+      : input.history
+          .map(
+            (entry, index) =>
+              `Step ${index + 1} model response:\n${entry.modelResponse}\n\nStep ${index + 1} tool result:\n${entry.toolResult ?? "(none)"}`,
+          )
+          .join("\n\n");
+
+  return `Repository root: ${input.cwd}
+Reseed reason: ${input.trigger.reason}
+Changed files: ${input.trigger.changedFiles.join(", ") || "(none)"}
+Step: ${input.step}/${input.maxSteps}
+${input.forceFinal ? "Tool use is now DISABLED. Return exactly one STRICT JSON object with type=final.\n" : ""}
+Previous seed summary:
+${compactSeedForPrompt(input.previousSeed)}
+
+Exploration history:
+${historyText}
+
+${input.forceFinal ? "Use only evidence already gathered." : "Decide the next tool call, or return type=final when you have enough evidence."}`;
+}
+
+export function extractJsonObject(text: string): unknown | null {
+  const trimmed = text
+    .trim()
+    .replace(/^```(?:json)?\s*/i, "")
+    .replace(/\s*```$/i, "");
+  const start = trimmed.indexOf("{");
+  const end = trimmed.lastIndexOf("}");
+  if (start < 0 || end <= start) return null;
+  try {
+    return JSON.parse(trimmed.slice(start, end + 1));
+  } catch {
+    return null;
+  }
+}

--- a/src/suggester/seeder.ts
+++ b/src/suggester/seeder.ts
@@ -1,0 +1,183 @@
+import { generateText } from "ai";
+import { execFileSync } from "child_process";
+import { resolve } from "path";
+import { resolveModelRuntime, type XaiProvider } from "../grok/client.js";
+import {
+  CURRENT_GENERATOR_VERSION,
+  CURRENT_SEED_VERSION,
+  hashFile,
+  parseSeedDraft,
+  type ReseedTrigger,
+  SEEDER_PROMPT_VERSION,
+  type SeedArtifact,
+  type SeedDraft,
+  saveSeed,
+  validateSeedDraft,
+} from "./seed.js";
+import { fileExistsInRepo, runSeederTool, type SeederToolName, toRepoRelative } from "./seed-tools.js";
+import { extractJsonObject, renderSeederSystemPrompt, renderSeederUserPrompt } from "./seeder-prompt.js";
+import type { SuggestionTokenUsage } from "./types.js";
+
+const MAX_SEEDER_STEPS = 8;
+
+export interface SeederRunResult {
+  seed?: SeedArtifact;
+  error?: string;
+  usage: SuggestionTokenUsage;
+  modelId: string;
+}
+
+export async function generateProjectSeed(
+  provider: XaiProvider,
+  cwd: string,
+  trigger: ReseedTrigger,
+  previousSeed: SeedArtifact | null,
+  modelId: string,
+  signal?: AbortSignal,
+): Promise<SeederRunResult> {
+  const runtime = resolveModelRuntime(provider, modelId);
+  const history: Array<{ modelResponse: string; toolResult?: string }> = [];
+  const usage: SuggestionTokenUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+
+  for (let step = 1; step <= MAX_SEEDER_STEPS + 1; step++) {
+    if (signal?.aborted) return { error: "aborted", usage, modelId: runtime.modelId };
+    const forceFinal = step > MAX_SEEDER_STEPS;
+    const { text, stepUsage } = await callSeederModel(
+      runtime,
+      renderSeederUserPrompt({
+        cwd,
+        trigger,
+        previousSeed,
+        step: Math.min(step, MAX_SEEDER_STEPS),
+        maxSteps: MAX_SEEDER_STEPS,
+        history,
+        forceFinal,
+      }),
+      signal,
+    );
+    addTokens(usage, stepUsage);
+    const parsed = extractJsonObject(text);
+    if (!parsed || typeof parsed !== "object") {
+      history.push({ modelResponse: text, toolResult: "Could not parse JSON." });
+      if (forceFinal) break;
+      continue;
+    }
+
+    const row = parsed as Record<string, unknown>;
+    if (row.type === "tool" && !forceFinal) {
+      const tool = row.tool;
+      if (tool !== "ls" && tool !== "find" && tool !== "grep" && tool !== "read") {
+        history.push({ modelResponse: text, toolResult: `Unknown tool: ${String(tool)}` });
+        continue;
+      }
+      const args = row.arguments && typeof row.arguments === "object" ? (row.arguments as Record<string, unknown>) : {};
+      const toolResult = await runSeederTool(cwd, { tool: tool as SeederToolName, arguments: args });
+      history.push({ modelResponse: text, toolResult });
+      continue;
+    }
+
+    if (row.type === "final") {
+      const draft = parseSeedDraft(row.seed);
+      if (!draft) {
+        history.push({ modelResponse: text, toolResult: "Final seed JSON was invalid." });
+        if (forceFinal) break;
+        continue;
+      }
+      const invalid = validateSeedDraft(draft);
+      if (invalid) {
+        history.push({ modelResponse: text, toolResult: `Seed validation failed: ${invalid}` });
+        if (forceFinal) break;
+        continue;
+      }
+      try {
+        const seed = finalizeSeed(cwd, draft, trigger, runtime.modelId);
+        saveSeed(cwd, seed);
+        return { seed, usage, modelId: runtime.modelId };
+      } catch (error) {
+        return { error: error instanceof Error ? error.message : String(error), usage, modelId: runtime.modelId };
+      }
+    }
+
+    history.push({ modelResponse: text, toolResult: "Expected type=tool or type=final." });
+    if (forceFinal) break;
+  }
+
+  return { error: "seeder exhausted without a valid seed", usage, modelId: runtime.modelId };
+}
+
+async function callSeederModel(
+  runtime: ReturnType<typeof resolveModelRuntime>,
+  prompt: string,
+  signal?: AbortSignal,
+): Promise<{ text: string; stepUsage: SuggestionTokenUsage }> {
+  const { text, usage } = await generateText({
+    model: runtime.model,
+    abortSignal: signal,
+    temperature: 0.2,
+    ...(runtime.modelInfo?.supportsMaxOutputTokens === false ? {} : { maxOutputTokens: 1800 }),
+    ...(runtime.providerOptions ? { providerOptions: runtime.providerOptions } : {}),
+    system: renderSeederSystemPrompt(),
+    prompt,
+  });
+  return {
+    text: text ?? "",
+    stepUsage: {
+      inputTokens: usage?.inputTokens,
+      outputTokens: usage?.outputTokens,
+      totalTokens: usage?.totalTokens,
+    },
+  };
+}
+
+function finalizeSeed(cwd: string, draft: SeedDraft, trigger: ReseedTrigger, modelId: string): SeedArtifact {
+  const keyFiles = [];
+  for (const file of draft.keyFiles.slice(0, 32)) {
+    const rel = toRepoRelative(cwd, file.path);
+    if (!rel || !fileExistsInRepo(cwd, rel)) continue;
+    keyFiles.push({
+      path: rel,
+      hash: hashFile(resolve(cwd, rel)),
+      whyImportant: file.whyImportant,
+      category: file.category,
+    });
+  }
+  if (keyFiles.length === 0) {
+    throw new Error("Seeder returned keyFiles, but none could be resolved on disk.");
+  }
+
+  return {
+    seedVersion: CURRENT_SEED_VERSION,
+    generatedAt: new Date().toISOString(),
+    sourceCommit: gitHead(cwd),
+    generatorVersion: CURRENT_GENERATOR_VERSION,
+    seederPromptVersion: SEEDER_PROMPT_VERSION,
+    modelId,
+    projectIntentSummary: draft.projectIntentSummary,
+    objectivesSummary: draft.objectivesSummary,
+    constraintsSummary: draft.constraintsSummary,
+    principlesGuidelinesSummary: draft.principlesGuidelinesSummary,
+    implementationStatusSummary: draft.implementationStatusSummary,
+    topObjectives: draft.topObjectives,
+    constraints: draft.constraints,
+    keyFiles,
+    categoryFindings: draft.categoryFindings,
+    openQuestions: draft.openQuestions,
+    reseedNotes: draft.reseedNotes,
+    lastReseedReason: trigger.reason,
+    lastChangedFiles: trigger.changedFiles,
+  };
+}
+
+function gitHead(cwd: string): string | undefined {
+  try {
+    return execFileSync("git", ["rev-parse", "HEAD"], { cwd, encoding: "utf-8", timeout: 2000 }).trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function addTokens(total: SuggestionTokenUsage, delta: SuggestionTokenUsage): void {
+  total.inputTokens = (total.inputTokens ?? 0) + (delta.inputTokens ?? 0);
+  total.outputTokens = (total.outputTokens ?? 0) + (delta.outputTokens ?? 0);
+  total.totalTokens = (total.totalTokens ?? 0) + (delta.totalTokens ?? 0);
+}

--- a/src/suggester/seeder.ts
+++ b/src/suggester/seeder.ts
@@ -18,7 +18,7 @@ import { fileExistsInRepo, runSeederTool, type SeederToolName, toRepoRelative } 
 import { extractJsonObject, renderSeederSystemPrompt, renderSeederUserPrompt } from "./seeder-prompt.js";
 import type { SuggestionTokenUsage } from "./types.js";
 
-const MAX_SEEDER_STEPS = 8;
+const MAX_SEEDER_STEPS = 4;
 
 export interface SeederRunResult {
   seed?: SeedArtifact;
@@ -50,7 +50,7 @@ export async function generateProjectSeed(
         previousSeed,
         step: Math.min(step, MAX_SEEDER_STEPS),
         maxSteps: MAX_SEEDER_STEPS,
-        history,
+        history: history.slice(-2),
         forceFinal,
       }),
       signal,

--- a/src/suggester/staleness.ts
+++ b/src/suggester/staleness.ts
@@ -1,0 +1,29 @@
+import { resolve } from "path";
+import { hashFile, loadSeed, type ReseedTrigger, type SeedArtifact } from "./seed.js";
+
+export interface StalenessResult {
+  stale: boolean;
+  trigger?: ReseedTrigger;
+}
+
+export function checkSeedStaleness(cwd: string, seed: SeedArtifact | null = loadSeed(cwd)): StalenessResult {
+  if (!seed) {
+    return { stale: true, trigger: { reason: "initial_missing", changedFiles: [] } };
+  }
+
+  const changed: string[] = [];
+  for (const file of seed.keyFiles) {
+    try {
+      const current = hashFile(resolve(cwd, file.path));
+      if (current !== file.hash) changed.push(file.path);
+    } catch {
+      changed.push(file.path);
+    }
+  }
+
+  if (changed.length > 0) {
+    return { stale: true, trigger: { reason: "key_file_changed", changedFiles: changed } };
+  }
+
+  return { stale: false };
+}

--- a/src/suggester/staleness.ts
+++ b/src/suggester/staleness.ts
@@ -1,5 +1,5 @@
 import { resolve } from "path";
-import { hashFile, loadSeed, type ReseedTrigger, type SeedArtifact } from "./seed.js";
+import { BOOTSTRAP_GENERATOR_VERSION, hashFile, loadSeed, type ReseedTrigger, type SeedArtifact } from "./seed.js";
 
 export interface StalenessResult {
   stale: boolean;
@@ -9,6 +9,13 @@ export interface StalenessResult {
 export function checkSeedStaleness(cwd: string, seed: SeedArtifact | null = loadSeed(cwd)): StalenessResult {
   if (!seed) {
     return { stale: true, trigger: { reason: "initial_missing", changedFiles: [] } };
+  }
+
+  if (seed.generatorVersion === BOOTSTRAP_GENERATOR_VERSION) {
+    return {
+      stale: true,
+      trigger: { reason: "initial_missing", changedFiles: seed.keyFiles.map((file) => file.path) },
+    };
   }
 
   const changed: string[] = [];

--- a/src/suggester/status.test.ts
+++ b/src/suggester/status.test.ts
@@ -7,7 +7,7 @@ describe("formatSuggesterStatus", () => {
   it("reports off and empty history", () => {
     const text = formatSuggesterStatus({ ...DEFAULT_SUGGESTER_SETTINGS, enabled: false }, emptySessionState());
     expect(text).toContain("Prompt suggester: off");
-    expect(text).toContain("Fill: auto");
+    expect(text).toContain("Fill: ghost");
     expect(text).toContain("Last suggestion: none yet this session");
   });
 

--- a/src/suggester/status.test.ts
+++ b/src/suggester/status.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_SUGGESTER_SETTINGS } from "./config.js";
+import { formatSuggesterStatus } from "./status.js";
+import { emptySessionState } from "./store.js";
+
+describe("formatSuggesterStatus", () => {
+  it("reports off and empty history", () => {
+    const text = formatSuggesterStatus({ ...DEFAULT_SUGGESTER_SETTINGS, enabled: false }, emptySessionState());
+    expect(text).toContain("Prompt suggester: off");
+    expect(text).toContain("Fill: auto");
+    expect(text).toContain("Last suggestion: none yet this session");
+  });
+
+  it("includes last suggestion and usage", () => {
+    const text = formatSuggesterStatus(DEFAULT_SUGGESTER_SETTINGS, {
+      lastSuggestion: { text: "run the tests", shownAt: "2026-08-16T12:00:00.000Z", turnStatus: "success" },
+      lastUsage: { inputTokens: 80, outputTokens: 6, totalTokens: 86, modelId: "grok-3-mini" },
+      suggestionUsage: { inputTokens: 80, outputTokens: 6, totalTokens: 86, calls: 1, modelId: "grok-3-mini" },
+      seederUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0, calls: 0 },
+      steeringHistory: [],
+      turnsSinceLastStalenessCheck: 0,
+    });
+    expect(text).toContain("Prompt suggester: on");
+    expect(text).toContain("run the tests");
+    expect(text).toContain("80 in / 6 out");
+    expect(text).toContain("1 call");
+    expect(text).toContain("Seed: none yet");
+  });
+});

--- a/src/suggester/status.ts
+++ b/src/suggester/status.ts
@@ -1,0 +1,65 @@
+import type { SeedArtifact } from "./seed.js";
+import type { ResolvedSuggesterSettings, SuggesterSessionState } from "./types.js";
+
+export function formatSuggesterStatus(
+  settings: ResolvedSuggesterSettings,
+  state: SuggesterSessionState,
+  seed: SeedArtifact | null = null,
+): string {
+  const lines = [
+    `Prompt suggester: ${settings.enabled ? "on" : "off"}`,
+    `Fill: ${settings.autoAccept ? "auto" : "ghost"}`,
+    `Suggester model: ${settings.model}`,
+    `Seeder model: ${settings.seederModel}`,
+    `Accept: ${settings.ghostAcceptKeys.join(", ") || "none"}`,
+  ];
+
+  if (state.lastSuggestion?.text) {
+    const preview = state.lastSuggestion.text.replace(/\s+/g, " ").trim();
+    lines.push(`Last suggestion: ${preview.length > 80 ? `${preview.slice(0, 77)}...` : preview}`);
+  } else {
+    lines.push("Last suggestion: none yet this session");
+  }
+
+  const usage = state.lastUsage;
+  if (usage && (usage.totalTokens || usage.inputTokens || usage.outputTokens)) {
+    lines.push(`Last call: ${usage.inputTokens ?? 0} in / ${usage.outputTokens ?? 0} out (${usage.modelId})`);
+  }
+
+  if (state.suggestionUsage.calls > 0) {
+    lines.push(
+      `Suggester usage: ${state.suggestionUsage.calls} call${state.suggestionUsage.calls === 1 ? "" : "s"}, ${state.suggestionUsage.totalTokens} tokens`,
+    );
+  }
+  if (state.seederUsage.calls > 0) {
+    lines.push(
+      `Seeder usage: ${state.seederUsage.calls} call${state.seederUsage.calls === 1 ? "" : "s"}, ${state.seederUsage.totalTokens} tokens`,
+    );
+  }
+
+  if (seed) {
+    const found = Object.entries(seed.categoryFindings)
+      .filter(([, finding]) => finding.found)
+      .map(([name]) => name)
+      .join(", ");
+    lines.push(`Seed: ${seed.keyFiles.length} key files${found ? ` (${found})` : ""}`);
+    lines.push(`Seeded: ${seed.generatedAt}${seed.lastReseedReason ? ` via ${seed.lastReseedReason}` : ""}`);
+  } else {
+    lines.push("Seed: none yet");
+  }
+
+  if (settings.customInstruction.trim()) {
+    const preview = settings.customInstruction.replace(/\s+/g, " ").trim();
+    lines.push(`Instruction: ${preview.length > 80 ? `${preview.slice(0, 77)}...` : preview}`);
+  } else {
+    lines.push("Instruction: none");
+  }
+
+  const changed = state.steeringHistory.filter((event) => event.classification === "changed_course").length;
+  const accepted = state.steeringHistory.length - changed;
+  if (state.steeringHistory.length > 0) {
+    lines.push(`Steering: ${accepted} accepted / ${changed} changed course`);
+  }
+
+  return lines.join("\n");
+}

--- a/src/suggester/steering.test.ts
+++ b/src/suggester/steering.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { classifySteering, isRepeatedRejected } from "./steering.js";
+
+describe("classifySteering", () => {
+  it("marks exact matches", () => {
+    expect(classifySteering("run the tests", "run the tests").classification).toBe("accepted_exact");
+  });
+
+  it("marks light edits as accepted_edited", () => {
+    expect(classifySteering("please run the tests now", "please run the tests", 0.5).classification).toBe(
+      "accepted_edited",
+    );
+  });
+
+  it("marks a different course", () => {
+    expect(classifySteering("run the tests", "rewrite the README instead").classification).toBe("changed_course");
+  });
+});
+
+describe("isRepeatedRejected", () => {
+  it("suppresses a previously rejected suggestion", () => {
+    expect(
+      isRepeatedRejected("run the tests", [
+        {
+          classification: "changed_course",
+          suggestedPrompt: "run the tests",
+          actualUserPrompt: "do something else",
+          similarity: 0.1,
+          at: "2026-08-16T12:00:00.000Z",
+        },
+      ]),
+    ).toBe(true);
+    expect(isRepeatedRejected("ship it", [])).toBe(false);
+  });
+});

--- a/src/suggester/steering.ts
+++ b/src/suggester/steering.ts
@@ -1,0 +1,88 @@
+// Adapted from pi-prompt-suggester (MIT)
+// Copyright (c) 2026 Guido Witt-Dörring
+// https://github.com/guwidoe/pi-prompt-suggester
+
+import type { SteeringClassification, SteeringEvent } from "./types.js";
+
+export const DEFAULT_ACCEPTED_THRESHOLD = 0.82;
+export const DEFAULT_STEERING_WINDOW = 20;
+export const DEFAULT_MAX_CHANGED_EXAMPLES = 3;
+
+export function classifySteering(
+  suggestedPrompt: string,
+  actualUserPrompt: string,
+  acceptedThreshold = DEFAULT_ACCEPTED_THRESHOLD,
+): { classification: SteeringClassification; similarity: number } {
+  const suggested = normalizeText(suggestedPrompt);
+  const actual = normalizeText(actualUserPrompt);
+  if (suggested === actual) {
+    return { classification: "accepted_exact", similarity: 1 };
+  }
+
+  const similarity = (jaccard(tokenSet(suggested), tokenSet(actual)) + sequenceSimilarity(suggested, actual)) / 2;
+  return {
+    classification: similarity >= acceptedThreshold ? "accepted_edited" : "changed_course",
+    similarity,
+  };
+}
+
+export function appendSteeringEvent(
+  history: SteeringEvent[],
+  event: SteeringEvent,
+  window = DEFAULT_STEERING_WINDOW,
+): SteeringEvent[] {
+  return [...history, event].slice(-window);
+}
+
+export function recentChangedExamples(
+  history: SteeringEvent[],
+  max = DEFAULT_MAX_CHANGED_EXAMPLES,
+): Array<{ suggestedPrompt: string; actualUserPrompt: string }> {
+  return history
+    .filter((event) => event.classification === "changed_course")
+    .slice(-max)
+    .reverse()
+    .map((event) => ({ suggestedPrompt: event.suggestedPrompt, actualUserPrompt: event.actualUserPrompt }));
+}
+
+export function isRepeatedRejected(suggestion: string, history: SteeringEvent[]): boolean {
+  const normalized = normalizeText(suggestion);
+  return history.some(
+    (event) => event.classification === "changed_course" && normalizeText(event.suggestedPrompt) === normalized,
+  );
+}
+
+function normalizeText(value: string): string {
+  return value.toLowerCase().replace(/\s+/g, " ").replace(/[“”]/g, '"').replace(/[‘’]/g, "'").trim();
+}
+
+function tokenSet(value: string): Set<string> {
+  return new Set(value.split(/[^a-z0-9]+/).filter(Boolean));
+}
+
+function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 1;
+  let intersection = 0;
+  for (const value of a) if (b.has(value)) intersection += 1;
+  const union = new Set([...a, ...b]).size;
+  return union === 0 ? 0 : intersection / union;
+}
+
+function lcsLength(a: string, b: string): number {
+  const rows = a.length + 1;
+  const cols = b.length + 1;
+  const dp = Array.from({ length: rows }, () => new Array<number>(cols).fill(0));
+  for (let i = 1; i < rows; i += 1) {
+    for (let j = 1; j < cols; j += 1) {
+      dp[i]![j] =
+        a[i - 1] === b[j - 1] ? (dp[i - 1]![j - 1] ?? 0) + 1 : Math.max(dp[i - 1]![j] ?? 0, dp[i]![j - 1] ?? 0);
+    }
+  }
+  return dp[a.length]![b.length] ?? 0;
+}
+
+function sequenceSimilarity(a: string, b: string): number {
+  if (!a && !b) return 1;
+  const lcs = lcsLength(a, b);
+  return (2 * lcs) / Math.max(1, a.length + b.length);
+}

--- a/src/suggester/store.test.ts
+++ b/src/suggester/store.test.ts
@@ -1,0 +1,44 @@
+import { mkdtempSync, rmSync } from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, describe, expect, it } from "vitest";
+import { addUsage, emptySessionState, loadSuggesterSessionState, saveSuggesterSessionState } from "./store.js";
+
+const dirs: string[] = [];
+
+function tempHome(): string {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "grok-suggester-"));
+  dirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("suggester session store", () => {
+  it("round-trips last suggestion and usage", () => {
+    const home = tempHome();
+    const cwd = path.join(home, "repo");
+    const state = emptySessionState();
+    state.lastSuggestion = { text: "run the tests", shownAt: "2026-08-16T12:00:00.000Z", turnStatus: "success" };
+    state.suggestionUsage = addUsage(
+      state.suggestionUsage,
+      { inputTokens: 10, outputTokens: 4, totalTokens: 14 },
+      "grok-3-mini",
+    );
+    saveSuggesterSessionState(cwd, "sess-1", state, home);
+
+    const loaded = loadSuggesterSessionState(cwd, "sess-1", home);
+    expect(loaded.lastSuggestion?.text).toBe("run the tests");
+    expect(loaded.suggestionUsage.calls).toBe(1);
+    expect(loaded.suggestionUsage.totalTokens).toBe(14);
+    expect(loaded.suggestionUsage.modelId).toBe("grok-3-mini");
+  });
+
+  it("returns empty state when missing", () => {
+    expect(loadSuggesterSessionState("/tmp/missing-repo", "nope", tempHome()).suggestionUsage.calls).toBe(0);
+  });
+});

--- a/src/suggester/store.ts
+++ b/src/suggester/store.ts
@@ -1,0 +1,93 @@
+import { createHash } from "crypto";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { findGitRoot } from "../utils/git-root.js";
+import type { SuggesterSessionState, SuggestionUsage } from "./types.js";
+
+const EMPTY_USAGE: SuggestionUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0, calls: 0 };
+
+export function projectKeyFor(cwd: string): string {
+  const root = findGitRoot(cwd) ?? cwd;
+  return createHash("sha256").update(path.resolve(root)).digest("hex").slice(0, 16);
+}
+
+export function suggesterStatePath(cwd: string, sessionId: string, homeDir = os.homedir()): string {
+  return path.join(
+    homeDir,
+    ".grok",
+    "prompt-suggester",
+    "projects",
+    projectKeyFor(cwd),
+    "sessions",
+    sessionId,
+    "state.json",
+  );
+}
+
+export function loadSuggesterSessionState(
+  cwd: string,
+  sessionId: string,
+  homeDir = os.homedir(),
+): SuggesterSessionState {
+  const filePath = suggesterStatePath(cwd, sessionId, homeDir);
+  try {
+    if (!fs.existsSync(filePath)) return emptySessionState();
+    const parsed = JSON.parse(fs.readFileSync(filePath, "utf-8")) as Partial<SuggesterSessionState>;
+    return {
+      lastSuggestion: parsed.lastSuggestion,
+      lastUsage: parsed.lastUsage,
+      suggestionUsage: {
+        ...EMPTY_USAGE,
+        ...parsed.suggestionUsage,
+      },
+      seederUsage: {
+        ...EMPTY_USAGE,
+        ...parsed.seederUsage,
+      },
+      steeringHistory: Array.isArray(parsed.steeringHistory) ? parsed.steeringHistory : [],
+      turnsSinceLastStalenessCheck:
+        typeof parsed.turnsSinceLastStalenessCheck === "number" ? parsed.turnsSinceLastStalenessCheck : 0,
+    };
+  } catch {
+    return emptySessionState();
+  }
+}
+
+export function saveSuggesterSessionState(
+  cwd: string,
+  sessionId: string,
+  state: SuggesterSessionState,
+  homeDir = os.homedir(),
+): void {
+  const filePath = suggesterStatePath(cwd, sessionId, homeDir);
+  try {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+    fs.writeFileSync(filePath, JSON.stringify(state, null, 2), { mode: 0o600 });
+  } catch {
+    /* never block the TUI on suggester persistence */
+  }
+}
+
+export function emptySessionState(): SuggesterSessionState {
+  return {
+    suggestionUsage: { ...EMPTY_USAGE },
+    seederUsage: { ...EMPTY_USAGE },
+    steeringHistory: [],
+    turnsSinceLastStalenessCheck: 0,
+  };
+}
+
+export function addUsage(
+  current: SuggestionUsage,
+  delta?: { inputTokens?: number; outputTokens?: number; totalTokens?: number },
+  modelId?: string,
+): SuggestionUsage {
+  return {
+    inputTokens: current.inputTokens + (delta?.inputTokens ?? 0),
+    outputTokens: current.outputTokens + (delta?.outputTokens ?? 0),
+    totalTokens: current.totalTokens + (delta?.totalTokens ?? 0),
+    calls: current.calls + 1,
+    modelId: modelId ?? current.modelId,
+  };
+}

--- a/src/suggester/types.ts
+++ b/src/suggester/types.ts
@@ -1,0 +1,95 @@
+export type TurnStatus = "success" | "error" | "aborted";
+
+export type GhostAcceptKey = "space" | "right";
+
+export interface SuggesterSettings {
+  enabled?: boolean;
+  model?: string;
+  seederModel?: string;
+  maxSuggestionChars?: number;
+  ghostAcceptKeys?: GhostAcceptKey[];
+  fastPathContinueOnError?: boolean;
+  autoAccept?: boolean;
+  customInstruction?: string;
+  reseedEnabled?: boolean;
+  reseedTurnInterval?: number;
+}
+
+export interface ResolvedSuggesterSettings {
+  enabled: boolean;
+  model: string;
+  seederModel: string;
+  maxSuggestionChars: number;
+  ghostAcceptKeys: GhostAcceptKey[];
+  fastPathContinueOnError: boolean;
+  autoAccept: boolean;
+  customInstruction: string;
+  reseedEnabled: boolean;
+  reseedTurnInterval: number;
+}
+
+export interface SuggestionUsage {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  calls: number;
+  modelId?: string;
+}
+
+export interface LastSuggestion {
+  text: string;
+  shownAt: string;
+  turnStatus: TurnStatus;
+}
+
+export type SteeringClassification = "accepted_exact" | "accepted_edited" | "changed_course";
+
+export interface SteeringEvent {
+  classification: SteeringClassification;
+  suggestedPrompt: string;
+  actualUserPrompt: string;
+  similarity: number;
+  at: string;
+}
+
+export interface SuggesterSessionState {
+  lastSuggestion?: LastSuggestion;
+  lastUsage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+    modelId: string;
+  };
+  suggestionUsage: SuggestionUsage;
+  seederUsage: SuggestionUsage;
+  steeringHistory: SteeringEvent[];
+  turnsSinceLastStalenessCheck: number;
+}
+
+export interface SuggestionPromptContext {
+  turnStatus: TurnStatus;
+  abortContextNote?: string;
+  latestAssistantTurn: string;
+  recentUserPrompts: string[];
+  toolSignals: string[];
+  touchedFiles: string[];
+  unresolvedQuestions: string[];
+  recentChanged: Array<{ suggestedPrompt: string; actualUserPrompt: string }>;
+  customInstruction: string;
+  intentSeed: string;
+  maxSuggestionChars: number;
+  noSuggestionToken: string;
+}
+
+export interface SuggestionTokenUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+}
+
+export interface SuggestionResult {
+  kind: "suggestion" | "no_suggestion";
+  text: string;
+  usage?: SuggestionTokenUsage;
+  modelId?: string;
+}

--- a/src/ui/app.tsx
+++ b/src/ui/app.tsx
@@ -16,6 +16,7 @@ import {
 import { POPULAR_MCP_CATALOG } from "../mcp/catalog";
 import { parseEnvLines, parseHeaderLines } from "../mcp/parse-headers";
 import { toMcpServerId, validateMcpServerConfig } from "../mcp/validate";
+import { parseSuggesterCommand, suggesterUsageText } from "../suggester/command.js";
 import { createTelegramBridge, type TelegramBridgeHandle } from "../telegram/bridge";
 import { approvePairingCode } from "../telegram/pairing";
 import { createTurnCoordinator } from "../telegram/turn-coordinator";
@@ -70,7 +71,9 @@ import {
   SubagentsBrowserModal,
 } from "./agents-modal";
 import { BtwOverlay, type BtwState } from "./components/btw-overlay.js";
+import { GhostPromptHint } from "./components/GhostPromptHint.js";
 import { SuggestionOverlay } from "./components/SuggestionOverlay.js";
+import { usePromptSuggester } from "./hooks/usePromptSuggester.js";
 import { type TypeaheadState, useTypeahead } from "./hooks/useTypeahead.js";
 import { Markdown } from "./markdown";
 import { buildMcpBrowseRows, McpBrowserModal, McpEditorModal } from "./mcp-modal";
@@ -351,6 +354,7 @@ const BUILTIN_TYPED_SLASH_COMMANDS = new Set([
   "/commit-pr",
   "/wallet",
   "/btw",
+  "/suggester",
 ]);
 
 interface SandboxRow {
@@ -777,6 +781,13 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
   const typeahead = useTypeahead(inputRef, fileIndexRef.current, handleFileAccept);
   const typeaheadRef = useRef(typeahead);
   typeaheadRef.current = typeahead;
+  const promptSuggester = usePromptSuggester(inputRef, agent.getCwd(), sessionId, startupConfig.baseURL);
+  const promptSuggesterRef = useRef(promptSuggester);
+  promptSuggesterRef.current = promptSuggester;
+  useEffect(() => {
+    if (!sessionId) return;
+    promptSuggesterRef.current.ensureSeed();
+  }, [sessionId]);
 
   const setMode = useCallback(
     (m: AgentMode) => {
@@ -1563,6 +1574,15 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
         }
       }
 
+      if (activeTurn.kind === "local" && queuedMessagesRef.current.length === 0) {
+        const status = wasInterrupted ? "aborted" : hadError ? "error" : "success";
+        promptSuggesterRef.current.requestAfterTurn(
+          activeTurn.agent.getChatEntries(),
+          status,
+          wasInterrupted ? "User interrupted the previous turn." : undefined,
+        );
+      }
+
       activeTurnRef.current = null;
       clearLiveTurnUi();
       finishTurnProcessing();
@@ -2041,6 +2061,8 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
     replacePasteBlocks([]);
     queuedMessagesRef.current = [];
     setQueuedMessages([]);
+    promptSuggesterRef.current.cancel();
+    promptSuggesterRef.current.dismiss();
   }, [agent, clearLiveTurnUi, replacePasteBlocks]);
 
   const processMessage = useCallback(
@@ -2050,6 +2072,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
       const isStale = () => activeRunIdRef.current !== runId;
       isProcessingRef.current = true;
       setIsProcessing(true);
+      promptSuggesterRef.current.cancel();
       if (!sessionTitle)
         agent
           .generateTitle((displayText ?? text).trim())
@@ -2274,6 +2297,91 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
         processMessage(COMMIT_PR_PROMPT);
         return true;
       }
+      const suggesterCommand = parseSuggesterCommand(cmd);
+      if (suggesterCommand) {
+        const action = suggesterCommand.action;
+        const rest = suggesterCommand.rest;
+        if (action === "help") {
+          setMessages((prev) => [...prev, buildAssistantEntry(suggesterUsageText())]);
+          return true;
+        }
+        if (action === "on") {
+          promptSuggesterRef.current.setEnabled(true);
+          setMessages((prev) => [...prev, buildAssistantEntry("Prompt suggester enabled.")]);
+          return true;
+        }
+        if (action === "off") {
+          promptSuggesterRef.current.setEnabled(false);
+          setMessages((prev) => [...prev, buildAssistantEntry("Prompt suggester disabled.")]);
+          return true;
+        }
+        if (action === "auto") {
+          promptSuggesterRef.current.setAutoAccept(true);
+          setMessages((prev) => [...prev, buildAssistantEntry("Prompt suggester will insert the next prompt.")]);
+          return true;
+        }
+        if (action === "ghost") {
+          promptSuggesterRef.current.setAutoAccept(false);
+          setMessages((prev) => [
+            ...prev,
+            buildAssistantEntry("Prompt suggester will show a dim ghost. Space accepts."),
+          ]);
+          return true;
+        }
+        if (action === "reseed") {
+          promptSuggesterRef.current.requestReseed();
+          setMessages((prev) => [...prev, buildAssistantEntry("Suggester reseed queued.")]);
+          return true;
+        }
+        if (action === "instruction") {
+          const [verb, ...instructionParts] = rest.split(/\s+/);
+          if (!verb || verb.toLowerCase() === "show") {
+            const status = promptSuggesterRef.current.formatStatus();
+            setMessages((prev) => [...prev, buildAssistantEntry(status)]);
+            return true;
+          }
+          if (verb.toLowerCase() === "clear") {
+            promptSuggesterRef.current.setCustomInstruction("");
+            setMessages((prev) => [...prev, buildAssistantEntry("Suggester instruction cleared.")]);
+            return true;
+          }
+          const text = (verb.toLowerCase() === "set" ? instructionParts.join(" ") : rest).trim();
+          if (!text) {
+            setMessages((prev) => [...prev, buildAssistantEntry("Usage: /suggester instruction set <text>")]);
+            return true;
+          }
+          promptSuggesterRef.current.setCustomInstruction(text);
+          setMessages((prev) => [...prev, buildAssistantEntry("Suggester instruction saved.")]);
+          return true;
+        }
+        if (action === "model") {
+          const [verb, ...modelParts] = rest.split(/\s+/);
+          if (!verb || verb.toLowerCase() === "show") {
+            setMessages((prev) => [...prev, buildAssistantEntry(promptSuggesterRef.current.formatStatus())]);
+            return true;
+          }
+          if (verb.toLowerCase() === "seeder") {
+            const model = modelParts.join(" ").trim();
+            if (!model) {
+              setMessages((prev) => [...prev, buildAssistantEntry("Usage: /suggester model seeder <id>")]);
+              return true;
+            }
+            promptSuggesterRef.current.setSeederModel(model);
+            setMessages((prev) => [...prev, buildAssistantEntry(`Seeder model set to ${model}.`)]);
+            return true;
+          }
+          const model = (verb.toLowerCase() === "set" ? modelParts.join(" ") : rest).trim();
+          if (!model) {
+            setMessages((prev) => [...prev, buildAssistantEntry("Usage: /suggester model set <id>")]);
+            return true;
+          }
+          promptSuggesterRef.current.setSuggesterModel(model);
+          setMessages((prev) => [...prev, buildAssistantEntry(`Suggester model set to ${model}.`)]);
+          return true;
+        }
+        setMessages((prev) => [...prev, buildAssistantEntry(promptSuggesterRef.current.formatStatus())]);
+        return true;
+      }
       if (c.startsWith("/btw ") || c === "/btw") {
         const question = cmd.trim().slice(4).trim();
         if (!question) {
@@ -2409,6 +2517,9 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
           break;
         case "commit-pr":
           processMessage(COMMIT_PR_PROMPT);
+          break;
+        case "suggester":
+          setMessages((prev) => [...prev, buildAssistantEntry(promptSuggesterRef.current.formatStatus())]);
           break;
         case "btw":
           inputRef.current?.clear();
@@ -3256,6 +3367,18 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
           return;
         }
       }
+      const ghostBlocked =
+        isProcessing ||
+        showSlashMenu ||
+        showModelPicker ||
+        showSandboxPicker ||
+        showWalletPicker ||
+        showPlanPanel ||
+        showApiKeyModal ||
+        blockPrompt;
+      if (promptSuggesterRef.current.handleKey(key, ghostBlocked)) {
+        return;
+      }
       if (key.name === "tab" && !isProcessing) {
         cycleMode();
         return;
@@ -3325,6 +3448,8 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
       pendingPaymentApproval,
       processMessage,
       showWalletPicker,
+      showApiKeyModal,
+      blockPrompt,
       walletSettings,
       walletFocusIndex,
       walletDisplayInfo,
@@ -3402,6 +3527,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
       return;
     }
     if (handleCommand(message)) return;
+    promptSuggesterRef.current.recordSubmit(displayText);
     const { enhancedMessage } = processAtMentions(message.trim(), agent.getCwd());
     if (isProcessingRef.current) {
       queuedMessagesRef.current.push({ text: enhancedMessage, displayText });
@@ -3510,6 +3636,8 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
                 queuedCount={queuedMessages.length}
                 queuedMessages={queuedMessages}
                 typeahead={typeahead}
+                ghostSuggestion={promptSuggester.suggestion}
+                ghostVisible={promptSuggester.visible}
               />
             </box>
           </box>
@@ -3549,6 +3677,8 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
                 contextStats={contextStats}
                 placeholder={"What are we building?"}
                 typeahead={typeahead}
+                ghostSuggestion={promptSuggester.suggestion}
+                ghostVisible={promptSuggester.visible}
               />
             </box>
             <box height={2} minHeight={0} flexShrink={1} />
@@ -3841,6 +3971,8 @@ function PromptBox({
   queuedCount,
   queuedMessages,
   typeahead,
+  ghostSuggestion,
+  ghostVisible,
 }: {
   t: Theme;
   inputRef: React.RefObject<TextareaRenderable | null>;
@@ -3863,9 +3995,14 @@ function PromptBox({
   queuedCount?: number;
   queuedMessages?: string[];
   typeahead?: TypeaheadState;
+  ghostSuggestion?: string | null;
+  ghostVisible?: boolean;
 }) {
   const hasQueue = (queuedMessages?.length ?? 0) > 0;
   const showSuggestions = typeahead?.visible ?? false;
+  const showGhost = Boolean(
+    ghostVisible && ghostSuggestion && !hasQueue && !isProcessing && !showSlashMenu && !showSuggestions,
+  );
 
   return (
     <box backgroundColor={t.backgroundPanel}>
@@ -3926,7 +4063,13 @@ function PromptBox({
                 !showApiKeyModal &&
                 !blockPrompt
               }
-              placeholder={isProcessing ? "Queue a follow-up... (esc to interrupt)" : placeholder || "Message Grok..."}
+              placeholder={
+                isProcessing
+                  ? "Queue a follow-up... (esc to interrupt)"
+                  : showGhost && ghostSuggestion
+                    ? ghostSuggestion
+                    : placeholder || "Message Grok..."
+              }
               textColor={t.text}
               backgroundColor={t.backgroundElement}
               placeholderColor={t.textMuted}
@@ -3980,6 +4123,8 @@ function PromptBox({
                 <span style={{ fg: t.textMuted }}>{"dismiss"}</span>
               </text>
             </box>
+          ) : showGhost ? (
+            <GhostPromptHint t={t} visible />
           ) : (
             <>
               <text fg={t.text}>

--- a/src/ui/app.tsx
+++ b/src/ui/app.tsx
@@ -16,7 +16,6 @@ import {
 import { POPULAR_MCP_CATALOG } from "../mcp/catalog";
 import { parseEnvLines, parseHeaderLines } from "../mcp/parse-headers";
 import { toMcpServerId, validateMcpServerConfig } from "../mcp/validate";
-import { parseSuggesterCommand, suggesterUsageText } from "../suggester/command.js";
 import { createTelegramBridge, type TelegramBridgeHandle } from "../telegram/bridge";
 import { approvePairingCode } from "../telegram/pairing";
 import { createTurnCoordinator } from "../telegram/turn-coordinator";
@@ -29,6 +28,8 @@ import type {
   Plan,
   PlanQuestion,
   ReasoningEffort,
+  SessionInfo,
+  SessionSnapshot,
   SubagentStatus,
   ToolCall,
   ToolResult,
@@ -73,7 +74,7 @@ import {
 import { BtwOverlay, type BtwState } from "./components/btw-overlay.js";
 import { GhostPromptHint } from "./components/GhostPromptHint.js";
 import { SuggestionOverlay } from "./components/SuggestionOverlay.js";
-import { usePromptSuggester } from "./hooks/usePromptSuggester.js";
+import { pluginReservedCommands, usePluginHost } from "./hooks/usePluginHost.js";
 import { type TypeaheadState, useTypeahead } from "./hooks/useTypeahead.js";
 import { Markdown } from "./markdown";
 import { buildMcpBrowseRows, McpBrowserModal, McpEditorModal } from "./mcp-modal";
@@ -86,6 +87,7 @@ import {
   PlanView,
 } from "./plan";
 import { buildScheduleBrowseRows, ScheduleBrowserModal } from "./schedule-modal";
+import { buildSessionBrowseRows, SessionBrowserModal } from "./session-modal";
 import { filterSlashMenuItems, SLASH_MENU_ITEMS, type SlashMenuItem } from "./slash-menu";
 import {
   buildAssistantEntry,
@@ -98,6 +100,7 @@ import {
 } from "./telegram-turn-ui";
 import { getCompactTuiSelectionText } from "./terminal-selection-text";
 import { dark, type Theme } from "./theme";
+import { isCtrlU } from "./update-hotkey";
 
 const STAR_PALETTE = ["#777777", "#666666", "#4a4a4a", "#333333", "#222222"];
 const LOADING_SPINNER_FRAMES = ["⬒", "⬔", "⬓", "⬕"];
@@ -354,7 +357,10 @@ const BUILTIN_TYPED_SLASH_COMMANDS = new Set([
   "/commit-pr",
   "/wallet",
   "/btw",
-  "/suggester",
+  "/resume",
+  "/sessions",
+  "/session",
+  "/update",
 ]);
 
 interface SandboxRow {
@@ -525,6 +531,7 @@ const WALLET_ROWS: WalletRow[] = [
 function parseCustomSubagentSlashCommand(
   cmd: string,
   subagents: CustomSubagentConfig[],
+  reservedCommands: Iterable<string> = [],
 ): { agentName: string; prompt: string } | null {
   const trimmed = cmd.trim();
   if (!trimmed.startsWith("/")) return null;
@@ -533,7 +540,8 @@ function parseCustomSubagentSlashCommand(
   if (!body) return null;
 
   const commandToken = body.split(/\s+/, 1)[0]?.toLowerCase();
-  if (commandToken && BUILTIN_TYPED_SLASH_COMMANDS.has(`/${commandToken}`)) {
+  const reserved = new Set([...BUILTIN_TYPED_SLASH_COMMANDS, ...reservedCommands]);
+  if (commandToken && reserved.has(`/${commandToken}`)) {
     return null;
   }
 
@@ -747,6 +755,11 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
   const [scheduleSearchQuery, setScheduleSearchQuery] = useState("");
   const [scheduleModalIndex, setScheduleModalIndex] = useState(0);
   const showScheduleModalRef = useRef(false);
+  const [showSessionModal, setShowSessionModal] = useState(false);
+  const [sessions, setSessions] = useState<SessionInfo[]>([]);
+  const [sessionSearchQuery, setSessionSearchQuery] = useState("");
+  const [sessionModalIndex, setSessionModalIndex] = useState(0);
+  const showSessionModalRef = useRef(false);
 
   const [updateInfo, setUpdateInfo] = useState<UpdateCheckResult | null>(null);
   const [showUpdateModal, setShowUpdateModal] = useState(false);
@@ -781,13 +794,9 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
   const typeahead = useTypeahead(inputRef, fileIndexRef.current, handleFileAccept);
   const typeaheadRef = useRef(typeahead);
   typeaheadRef.current = typeahead;
-  const promptSuggester = usePromptSuggester(inputRef, agent.getCwd(), sessionId, startupConfig.baseURL);
-  const promptSuggesterRef = useRef(promptSuggester);
-  promptSuggesterRef.current = promptSuggester;
-  useEffect(() => {
-    if (!sessionId) return;
-    promptSuggesterRef.current.ensureSeed();
-  }, [sessionId]);
+  const pluginHost = usePluginHost(inputRef, agent.getCwd(), sessionId, startupConfig.baseURL);
+  const pluginHostRef = useRef(pluginHost);
+  pluginHostRef.current = pluginHost;
 
   const setMode = useCallback(
     (m: AgentMode) => {
@@ -827,7 +836,21 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
       )
     : MODELS;
   const filteredModelIds = filteredModels.map((m) => m.id);
-  const filteredSlashItems = filterSlashMenuItems(SLASH_MENU_ITEMS, slashSearchQuery);
+  const slashMenuItems = useMemo(
+    () => [
+      ...SLASH_MENU_ITEMS,
+      ...pluginHost.slashCommands
+        .filter((command) => !SLASH_MENU_ITEMS.some((item) => item.id === command.id))
+        .map((command) => ({
+          id: command.id,
+          label: command.id,
+          description: command.description,
+          aliases: command.aliases,
+        })),
+    ],
+    [pluginHost.slashCommands],
+  );
+  const filteredSlashItems = filterSlashMenuItems(slashMenuItems, slashSearchQuery);
   const mcpRows = buildMcpBrowseRows(mcpServers, POPULAR_MCP_CATALOG, mcpSearchQuery);
   const mcpEditorFields = mcpEditorDraft.transport === "stdio" ? MCP_STDIO_FIELDS : MCP_REMOTE_FIELDS;
   const agentRows = useMemo(
@@ -837,6 +860,10 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
   const scheduleRows = useMemo(
     () => buildScheduleBrowseRows(schedules, scheduleSearchQuery),
     [schedules, scheduleSearchQuery],
+  );
+  const sessionRows = useMemo(
+    () => buildSessionBrowseRows(sessions, sessionSearchQuery),
+    [sessions, sessionSearchQuery],
   );
 
   const syncStoredMcpServers = useCallback((servers: McpServerConfig[]) => {
@@ -1576,7 +1603,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
 
       if (activeTurn.kind === "local" && queuedMessagesRef.current.length === 0) {
         const status = wasInterrupted ? "aborted" : hadError ? "error" : "success";
-        promptSuggesterRef.current.requestAfterTurn(
+        pluginHostRef.current.requestAfterTurn(
           activeTurn.agent.getChatEntries(),
           status,
           wasInterrupted ? "User interrupted the previous turn." : undefined,
@@ -1860,15 +1887,17 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
     showScheduleModalRef.current = showScheduleModal;
   }, [showScheduleModal]);
   useEffect(() => {
+    showSessionModalRef.current = showSessionModal;
+  }, [showSessionModal]);
+  useEffect(() => {
     showUpdateModalRef.current = showUpdateModal;
   }, [showUpdateModal]);
 
   useEffect(() => {
     let cancelled = false;
     checkForUpdate(startupConfig.version).then((result) => {
-      if (cancelled || !result?.hasUpdate) return;
+      if (cancelled || !result) return;
       setUpdateInfo(result);
-      setShowUpdateModal(true);
     });
     return () => {
       cancelled = true;
@@ -2047,23 +2076,103 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
     };
   }, [interruptActiveRun, renderer]);
 
+  const applySessionSnapshot = useCallback(
+    (snapshot: SessionSnapshot | null) => {
+      setMessages(snapshot?.entries ?? []);
+      setExpandedMessages(new Set());
+      activeTurnRef.current = null;
+      clearLiveTurnUi();
+      setSessionTitle(snapshot?.session.title ?? null);
+      setSessionId(snapshot?.session.id ?? agent.getSessionId());
+      setSessionRecap(agent.getSessionRecap());
+      setModeState(agent.getMode());
+      setModel(agent.getModel());
+      setActivePlan(null);
+      setPqs(initialPlanQuestionsState());
+      replacePasteBlocks([]);
+      queuedMessagesRef.current = [];
+      setQueuedMessages([]);
+      pluginHostRef.current.cancel();
+      pluginHostRef.current.dismiss();
+      btwAbortRef.current?.abort();
+      btwAbortRef.current = null;
+      btwStateRef.current = null;
+      setBtwState(null);
+    },
+    [agent, clearLiveTurnUi, replacePasteBlocks],
+  );
+
   const resetToNewSession = useCallback(() => {
-    const snapshot = agent.startNewSession();
-    setMessages(snapshot?.entries ?? []);
-    setExpandedMessages(new Set());
-    activeTurnRef.current = null;
-    clearLiveTurnUi();
-    setSessionTitle(snapshot?.session.title ?? null);
-    setSessionId(snapshot?.session.id ?? agent.getSessionId());
-    setSessionRecap(agent.getSessionRecap());
-    setActivePlan(null);
-    setPqs(initialPlanQuestionsState());
-    replacePasteBlocks([]);
-    queuedMessagesRef.current = [];
-    setQueuedMessages([]);
-    promptSuggesterRef.current.cancel();
-    promptSuggesterRef.current.dismiss();
-  }, [agent, clearLiveTurnUi, replacePasteBlocks]);
+    applySessionSnapshot(agent.startNewSession());
+  }, [agent, applySessionSnapshot]);
+
+  const beginUpdate = useCallback(() => {
+    if (isUpdating) return;
+    setShowUpdateModal(false);
+    setIsUpdating(true);
+    setUpdateOutput(null);
+    runUpdate(startupConfig.version).then((result) => {
+      setIsUpdating(false);
+      setUpdateOutput(result.success ? result.output : `Update failed: ${result.output}`);
+    });
+  }, [isUpdating, startupConfig.version]);
+
+  const formatResumedSessionLabel = useCallback((session: SessionInfo): string => {
+    const title = session.title?.trim();
+    return title ? `${title} (${session.id})` : session.id;
+  }, []);
+
+  const switchToSession = useCallback(
+    (selector: string): boolean => {
+      if (isProcessingRef.current) {
+        setMessages((prev) => [
+          ...prev,
+          buildAssistantEntry("Finish or Esc the current turn before resuming another session."),
+        ]);
+        return false;
+      }
+
+      try {
+        const currentId = agent.getSessionId();
+        const snapshot = agent.resumeSession(selector);
+        if (!snapshot) {
+          setMessages((prev) => [...prev, buildAssistantEntry("Session persistence is disabled.")]);
+          return false;
+        }
+        applySessionSnapshot(snapshot);
+        setShowSessionModal(false);
+        setSessionSearchQuery("");
+        if (snapshot.session.id !== currentId) {
+          setMessages((prev) => [
+            ...prev,
+            buildAssistantEntry(`Resumed ${formatResumedSessionLabel(snapshot.session)}.`),
+          ]);
+        }
+        return true;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        setMessages((prev) => [...prev, buildAssistantEntry(message)]);
+        return false;
+      }
+    },
+    [agent, applySessionSnapshot, formatResumedSessionLabel],
+  );
+
+  const openSessionPicker = useCallback(() => {
+    if (isProcessingRef.current) {
+      setMessages((prev) => [
+        ...prev,
+        buildAssistantEntry("Finish or Esc the current turn before resuming another session."),
+      ]);
+      return;
+    }
+    const latest = agent.listSessions();
+    setSessions(latest);
+    setSessionSearchQuery("");
+    const currentIndex = latest.findIndex((session) => session.id === agent.getSessionId());
+    setSessionModalIndex(currentIndex >= 0 ? currentIndex : 0);
+    setShowSessionModal(true);
+  }, [agent]);
 
   const processMessage = useCallback(
     async (text: string, displayText?: string) => {
@@ -2072,7 +2181,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
       const isStale = () => activeRunIdRef.current !== runId;
       isProcessingRef.current = true;
       setIsProcessing(true);
-      promptSuggesterRef.current.cancel();
+      pluginHostRef.current.cancel();
       if (!sessionTitle)
         agent
           .generateTitle((displayText ?? text).trim())
@@ -2277,6 +2386,23 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
         openScheduleModal();
         return true;
       }
+      if (c === "/resume" || c === "/sessions" || c === "/session") {
+        openSessionPicker();
+        return true;
+      }
+      if (c === "/update") {
+        beginUpdate();
+        return true;
+      }
+      if (c.startsWith("/resume ") || c.startsWith("/sessions ") || c.startsWith("/session ")) {
+        const selector = cmd.trim().split(/\s+/, 2)[1]?.trim();
+        if (!selector) {
+          openSessionPicker();
+          return true;
+        }
+        switchToSession(selector);
+        return true;
+      }
       if (c === "/quit" || c === "/exit" || c === "/q") {
         handleExit();
         return true;
@@ -2297,89 +2423,11 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
         processMessage(COMMIT_PR_PROMPT);
         return true;
       }
-      const suggesterCommand = parseSuggesterCommand(cmd);
-      if (suggesterCommand) {
-        const action = suggesterCommand.action;
-        const rest = suggesterCommand.rest;
-        if (action === "help") {
-          setMessages((prev) => [...prev, buildAssistantEntry(suggesterUsageText())]);
-          return true;
-        }
-        if (action === "on") {
-          promptSuggesterRef.current.setEnabled(true);
-          setMessages((prev) => [...prev, buildAssistantEntry("Prompt suggester enabled.")]);
-          return true;
-        }
-        if (action === "off") {
-          promptSuggesterRef.current.setEnabled(false);
-          setMessages((prev) => [...prev, buildAssistantEntry("Prompt suggester disabled.")]);
-          return true;
-        }
-        if (action === "auto") {
-          promptSuggesterRef.current.setAutoAccept(true);
-          setMessages((prev) => [...prev, buildAssistantEntry("Prompt suggester will insert the next prompt.")]);
-          return true;
-        }
-        if (action === "ghost") {
-          promptSuggesterRef.current.setAutoAccept(false);
-          setMessages((prev) => [
-            ...prev,
-            buildAssistantEntry("Prompt suggester will show a dim ghost. Space accepts."),
-          ]);
-          return true;
-        }
-        if (action === "reseed") {
-          promptSuggesterRef.current.requestReseed();
-          setMessages((prev) => [...prev, buildAssistantEntry("Suggester reseed queued.")]);
-          return true;
-        }
-        if (action === "instruction") {
-          const [verb, ...instructionParts] = rest.split(/\s+/);
-          if (!verb || verb.toLowerCase() === "show") {
-            const status = promptSuggesterRef.current.formatStatus();
-            setMessages((prev) => [...prev, buildAssistantEntry(status)]);
-            return true;
-          }
-          if (verb.toLowerCase() === "clear") {
-            promptSuggesterRef.current.setCustomInstruction("");
-            setMessages((prev) => [...prev, buildAssistantEntry("Suggester instruction cleared.")]);
-            return true;
-          }
-          const text = (verb.toLowerCase() === "set" ? instructionParts.join(" ") : rest).trim();
-          if (!text) {
-            setMessages((prev) => [...prev, buildAssistantEntry("Usage: /suggester instruction set <text>")]);
-            return true;
-          }
-          promptSuggesterRef.current.setCustomInstruction(text);
-          setMessages((prev) => [...prev, buildAssistantEntry("Suggester instruction saved.")]);
-          return true;
-        }
-        if (action === "model") {
-          const [verb, ...modelParts] = rest.split(/\s+/);
-          if (!verb || verb.toLowerCase() === "show") {
-            setMessages((prev) => [...prev, buildAssistantEntry(promptSuggesterRef.current.formatStatus())]);
-            return true;
-          }
-          if (verb.toLowerCase() === "seeder") {
-            const model = modelParts.join(" ").trim();
-            if (!model) {
-              setMessages((prev) => [...prev, buildAssistantEntry("Usage: /suggester model seeder <id>")]);
-              return true;
-            }
-            promptSuggesterRef.current.setSeederModel(model);
-            setMessages((prev) => [...prev, buildAssistantEntry(`Seeder model set to ${model}.`)]);
-            return true;
-          }
-          const model = (verb.toLowerCase() === "set" ? modelParts.join(" ") : rest).trim();
-          if (!model) {
-            setMessages((prev) => [...prev, buildAssistantEntry("Usage: /suggester model set <id>")]);
-            return true;
-          }
-          promptSuggesterRef.current.setSuggesterModel(model);
-          setMessages((prev) => [...prev, buildAssistantEntry(`Suggester model set to ${model}.`)]);
-          return true;
-        }
-        setMessages((prev) => [...prev, buildAssistantEntry(promptSuggesterRef.current.formatStatus())]);
+      if (
+        pluginHostRef.current.handleCommand(cmd, (text) => {
+          setMessages((prev) => [...prev, buildAssistantEntry(text)]);
+        })
+      ) {
         return true;
       }
       if (c.startsWith("/btw ") || c === "/btw") {
@@ -2416,7 +2464,11 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
           });
         return true;
       }
-      const customSubagentCommand = parseCustomSubagentSlashCommand(cmd, subAgents);
+      const customSubagentCommand = parseCustomSubagentSlashCommand(
+        cmd,
+        subAgents,
+        pluginReservedCommands(pluginHostRef.current.slashCommands.map((command) => command.id)),
+      );
       if (customSubagentCommand) {
         if (!customSubagentCommand.prompt) {
           setMessages((prev) => [
@@ -2442,9 +2494,12 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
       openSandboxPicker,
       openWalletPicker,
       openScheduleModal,
+      beginUpdate,
+      openSessionPicker,
       processMessage,
       resetToNewSession,
       subAgents,
+      switchToSession,
     ],
   );
 
@@ -2455,6 +2510,9 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
       switch (item.id) {
         case "new":
           resetToNewSession();
+          break;
+        case "resume":
+          openSessionPicker();
           break;
         case "models":
           setShowModelPicker(true);
@@ -2482,7 +2540,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
             ...p,
             {
               type: "assistant",
-              content: SLASH_MENU_ITEMS.map((i) => `/${i.label} — ${i.description}`).join("\n"),
+              content: slashMenuItems.map((i) => `/${i.label} — ${i.description}`).join("\n"),
               timestamp: new Date(),
             },
           ]);
@@ -2518,20 +2576,20 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
         case "commit-pr":
           processMessage(COMMIT_PR_PROMPT);
           break;
+        case "plugins":
+        case "install":
+        case "uninstall":
         case "suggester":
-          setMessages((prev) => [...prev, buildAssistantEntry(promptSuggesterRef.current.formatStatus())]);
+          pluginHostRef.current.handleCommand(`/${item.id}`, (text) => {
+            setMessages((prev) => [...prev, buildAssistantEntry(text)]);
+          });
           break;
         case "btw":
           inputRef.current?.clear();
           inputRef.current?.insertText("/btw ");
           break;
         case "update":
-          setIsUpdating(true);
-          setUpdateOutput(null);
-          runUpdate(startupConfig.version).then((result) => {
-            setIsUpdating(false);
-            setUpdateOutput(result.success ? result.output : `Update failed: ${result.output}`);
-          });
+          beginUpdate();
           break;
       }
     },
@@ -2544,9 +2602,11 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
       openSandboxPicker,
       openWalletPicker,
       openScheduleModal,
+      beginUpdate,
+      openSessionPicker,
       processMessage,
       resetToNewSession,
-      startupConfig.version,
+      slashMenuItems,
     ],
   );
 
@@ -2560,6 +2620,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
     showWalletPicker ||
     !!pendingPaymentApproval ||
     showScheduleModal ||
+    showSessionModal ||
     showAgentsModal ||
     showAgentsEditor ||
     showUpdateModal;
@@ -2634,6 +2695,12 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
 
   const handleKey = useCallback(
     (key: KeyEvent) => {
+      if (isCtrlU(key)) {
+        key.preventDefault();
+        key.stopPropagation();
+        beginUpdate();
+        return;
+      }
       if (btwState) {
         if (isEscapeKey(key) || key.name === "return") {
           dismissBtw();
@@ -2771,12 +2838,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
           return;
         }
         if (key.name === "return") {
-          setIsUpdating(true);
-          setShowUpdateModal(false);
-          runUpdate(startupConfig.version).then((result) => {
-            setIsUpdating(false);
-            setUpdateOutput(result.output);
-          });
+          beginUpdate();
           return;
         }
         return;
@@ -2894,6 +2956,39 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
         if (key.sequence && key.sequence.length === 1 && !key.ctrl && !key.meta) {
           setMcpSearchQuery((q) => q + key.sequence);
           setMcpModalIndex(0);
+          return;
+        }
+        return;
+      }
+      if (showSessionModalRef.current) {
+        const row = sessionRows[sessionModalIndex];
+        if (isEscapeKey(key)) {
+          setShowSessionModal(false);
+          setSessionSearchQuery("");
+          return;
+        }
+        if (key.name === "up") {
+          setSessionModalIndex((index) => Math.max(0, index - 1));
+          return;
+        }
+        if (key.name === "down") {
+          setSessionModalIndex((index) => Math.min(Math.max(0, sessionRows.length - 1), index + 1));
+          return;
+        }
+        if (key.name === "return") {
+          if (row?.kind === "session") {
+            switchToSession(row.session.id);
+          }
+          return;
+        }
+        if (key.name === "backspace") {
+          setSessionSearchQuery((query) => query.slice(0, -1));
+          setSessionModalIndex(0);
+          return;
+        }
+        if (key.sequence && key.sequence.length === 1 && !key.ctrl && !key.meta) {
+          setSessionSearchQuery((query) => query + key.sequence);
+          setSessionModalIndex(0);
           return;
         }
         return;
@@ -3376,7 +3471,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
         showPlanPanel ||
         showApiKeyModal ||
         blockPrompt;
-      if (promptSuggesterRef.current.handleKey(key, ghostBlocked)) {
+      if (pluginHostRef.current.handleKey(key, ghostBlocked)) {
         return;
       }
       if (key.name === "tab" && !isProcessing) {
@@ -3386,6 +3481,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
     },
     [
       agent,
+      beginUpdate,
       agentRows,
       agentsEditorField,
       agentsModalIndex,
@@ -3423,7 +3519,10 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
       removeSchedule,
       scheduleModalIndex,
       scheduleRows,
+      sessionModalIndex,
+      sessionRows,
       showScheduleDetails,
+      switchToSession,
       submitTelegramPair,
       submitTelegramToken,
       submitMcpEditor,
@@ -3461,7 +3560,6 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
       copyTuiSelectionToHost,
       toggleSavedMcp,
       messages,
-      startupConfig.version,
     ],
   );
   useKeyboard(handleKey);
@@ -3527,7 +3625,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
       return;
     }
     if (handleCommand(message)) return;
-    promptSuggesterRef.current.recordSubmit(displayText);
+    pluginHostRef.current.recordSubmit(displayText);
     const { enhancedMessage } = processAtMentions(message.trim(), agent.getCwd());
     if (isProcessingRef.current) {
       queuedMessagesRef.current.push({ text: enhancedMessage, displayText });
@@ -3636,8 +3734,8 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
                 queuedCount={queuedMessages.length}
                 queuedMessages={queuedMessages}
                 typeahead={typeahead}
-                ghostSuggestion={promptSuggester.suggestion}
-                ghostVisible={promptSuggester.visible}
+                ghostSuggestion={pluginHost.ghostSuggestion}
+                ghostVisible={pluginHost.ghostVisible}
               />
             </box>
           </box>
@@ -3677,8 +3775,8 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
                 contextStats={contextStats}
                 placeholder={"What are we building?"}
                 typeahead={typeahead}
-                ghostSuggestion={promptSuggester.suggestion}
-                ghostVisible={promptSuggester.visible}
+                ghostSuggestion={pluginHost.ghostSuggestion}
+                ghostVisible={pluginHost.ghostVisible}
               />
             </box>
             <box height={2} minHeight={0} flexShrink={1} />
@@ -3691,7 +3789,7 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
                 {startupConfig.version}
                 {" → v"}
                 {updateInfo.latestVersion}
-                {" — run /update to install"}
+                {" — ctrl+u or /update"}
               </text>
             </box>
           )}
@@ -3783,6 +3881,17 @@ export function App({ agent, startupConfig, initialMessage, onExit }: AppProps) 
           selectedIndex={scheduleModalIndex}
           searchQuery={scheduleSearchQuery}
           rows={scheduleRows}
+        />
+      )}
+      {showSessionModal && (
+        <SessionBrowserModal
+          t={t}
+          width={width}
+          height={height}
+          selectedIndex={sessionModalIndex}
+          searchQuery={sessionSearchQuery}
+          rows={sessionRows}
+          currentSessionId={sessionId}
         />
       )}
       {showAgentsModal && !showAgentsEditor && (
@@ -5118,7 +5227,7 @@ function UpdateModal({
         </box>
         <box flexShrink={0} paddingLeft={2} paddingRight={2} paddingTop={1}>
           <text fg={t.text}>
-            {"A new version of grok is available: "}
+            {"A new upstream grok release is available: "}
             <span style={{ fg: t.textMuted }}>
               {"v"}
               {currentVersion}
@@ -5131,7 +5240,7 @@ function UpdateModal({
           </text>
         </box>
         <box flexShrink={0} paddingLeft={2} paddingRight={2} paddingTop={1}>
-          <text fg={t.textMuted}>{"Press enter to update now, or esc to dismiss"}</text>
+          <text fg={t.textMuted}>{"ctrl+u or enter to update now, esc to dismiss"}</text>
         </box>
       </box>
     </box>

--- a/src/ui/components/GhostPromptHint.tsx
+++ b/src/ui/components/GhostPromptHint.tsx
@@ -1,0 +1,18 @@
+import type { Theme } from "../theme.js";
+
+export function GhostPromptHint({ t, visible }: { t: Theme; visible: boolean }) {
+  if (!visible) return null;
+
+  return (
+    <box flexDirection="row" gap={1}>
+      <text fg={t.text}>
+        {"space "}
+        <span style={{ fg: t.textMuted }}>{"accept"}</span>
+      </text>
+      <text fg={t.text}>
+        {"esc "}
+        <span style={{ fg: t.textMuted }}>{"dismiss"}</span>
+      </text>
+    </box>
+  );
+}

--- a/src/ui/hooks/usePluginHost.ts
+++ b/src/ui/hooks/usePluginHost.ts
@@ -1,0 +1,235 @@
+import type { KeyEvent, TextareaRenderable } from "@opentui/core";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  findInstalledRemotePlugin,
+  formatPluginList,
+  type GrokPlugin,
+  installGitHubPlugin,
+  isPluginInstalled,
+  listInstalledRemotePlugins,
+  loadRemotePlugins,
+  type PluginHostState,
+  type PluginSlashCommand,
+  type PluginTurnStatus,
+  parsePluginCommand,
+  parsePluginSpec,
+  pluginUsageText,
+  reservedPluginCommands,
+  runPluginCommand,
+  uninstallGitHubPlugin,
+} from "../../plugins/index.js";
+import { handleSuggesterCommand } from "../../suggester/handle-command.js";
+import type { ChatEntry } from "../../types/index.js";
+import { loadInstalledPlugins, saveInstalledPlugins } from "../../utils/settings.js";
+import { usePromptSuggester } from "./usePromptSuggester.js";
+
+export const PLUGIN_TYPED_SLASH_COMMANDS = ["/install", "/uninstall", "/plugins", "/plugin"] as const;
+
+export function pluginReservedCommands(extra: string[] = []): string[] {
+  return [
+    ...PLUGIN_TYPED_SLASH_COMMANDS,
+    ...reservedPluginCommands().map((command) => `/${command}`),
+    ...extra.map((command) => (command.startsWith("/") ? command : `/${command}`)),
+  ];
+}
+
+export function usePluginHost(
+  inputRef: React.RefObject<TextareaRenderable | null>,
+  cwd: string,
+  sessionId: string | null,
+  baseURL: string,
+): PluginHostState {
+  const [installed, setInstalled] = useState<string[]>(() => loadInstalledPlugins());
+  const [remoteRecords, setRemoteRecords] = useState(() => listInstalledRemotePlugins());
+  const [remotePlugins, setRemotePlugins] = useState<GrokPlugin[]>([]);
+  const suggesterActive = isPluginInstalled(installed, "suggester");
+  const suggester = usePromptSuggester(inputRef, cwd, sessionId, baseURL, suggesterActive);
+
+  const reloadRemote = useCallback(async () => {
+    const records = listInstalledRemotePlugins();
+    setRemoteRecords(records);
+    setRemotePlugins(await loadRemotePlugins(records));
+  }, []);
+
+  useEffect(() => {
+    void reloadRemote();
+  }, [reloadRemote]);
+
+  useEffect(() => {
+    if (!sessionId || !suggesterActive) return;
+    suggester.ensureSeed();
+  }, [sessionId, suggester.ensureSeed, suggesterActive]);
+
+  const persist = useCallback((next: string[]) => {
+    const saved = saveInstalledPlugins(next);
+    setInstalled(saved);
+    return saved;
+  }, []);
+
+  const installBundled = useCallback(
+    (id: string) => {
+      const result = runPluginCommand({ action: "install", id }, installed);
+      persist(result.installed);
+      return result.message;
+    },
+    [installed, persist],
+  );
+
+  const uninstall = useCallback(
+    (id: string) => {
+      const remote = findInstalledRemotePlugin(id);
+      if (remote) {
+        const result = uninstallGitHubPlugin(id);
+        void reloadRemote();
+        return result.message;
+      }
+      const result = runPluginCommand({ action: "uninstall", id }, installed);
+      persist(result.installed);
+      if (!isPluginInstalled(result.installed, "suggester")) {
+        suggester.cancel();
+        suggester.dismiss();
+      }
+      return result.message;
+    },
+    [installed, persist, reloadRemote, suggester],
+  );
+
+  const formatList = useCallback(() => formatPluginList(installed, remoteRecords), [installed, remoteRecords]);
+
+  const slashCommands = useMemo<PluginSlashCommand[]>(() => {
+    const items: PluginSlashCommand[] = [
+      { id: "plugins", description: "List installed plugins", aliases: ["plugin"] },
+      { id: "install", description: "Install a bundled or GitHub plugin" },
+      { id: "uninstall", description: "Uninstall a plugin" },
+    ];
+    if (suggesterActive) {
+      items.push({ id: "suggester", description: "Next-prompt suggestions and project seed" });
+    }
+    for (const plugin of remotePlugins) {
+      for (const command of plugin.slashCommands ?? []) {
+        if (!items.some((item) => item.id === command.id)) items.push(command);
+      }
+    }
+    return items;
+  }, [remotePlugins, suggesterActive]);
+
+  const handleCommand = useCallback(
+    (cmd: string, reply: (text: string) => void) => {
+      const pluginCommand = parsePluginCommand(cmd);
+      if (pluginCommand) {
+        if (pluginCommand.action === "list") {
+          reply(formatList());
+          return true;
+        }
+        if (pluginCommand.action === "uninstall") {
+          if (!pluginCommand.id) {
+            reply(pluginUsageText());
+            return true;
+          }
+          reply(uninstall(pluginCommand.id));
+          return true;
+        }
+
+        const spec = parsePluginSpec(pluginCommand.id);
+        if (spec.kind === "bundled") {
+          reply(installBundled(spec.id));
+          return true;
+        }
+        if (spec.kind === "github") {
+          reply(`Installing ${spec.owner}/${spec.repo}${spec.ref ? `@${spec.ref}` : ""}...`);
+          void installGitHubPlugin(spec).then(async (result) => {
+            if (result.ok) await reloadRemote();
+            reply(result.message);
+          });
+          return true;
+        }
+        reply(
+          spec.reason === "missing" ? pluginUsageText() : `Unknown plugin "${pluginCommand.id}".\n\n${formatList()}`,
+        );
+        return true;
+      }
+
+      for (const plugin of remotePlugins) {
+        if (plugin.handleCommand?.(cmd, { reply })) return true;
+      }
+
+      if (!suggesterActive) return false;
+      return handleSuggesterCommand(cmd, suggester, reply);
+    },
+    [formatList, installBundled, reloadRemote, remotePlugins, suggester, suggesterActive, uninstall],
+  );
+
+  const requestAfterTurn = useCallback(
+    (entries: ChatEntry[], status: PluginTurnStatus, abortNote?: string) => {
+      for (const plugin of remotePlugins) {
+        plugin.requestAfterTurn?.(entries, status, abortNote);
+      }
+      if (!suggesterActive) return;
+      suggester.requestAfterTurn(entries, status, abortNote);
+    },
+    [remotePlugins, suggester, suggesterActive],
+  );
+
+  const recordSubmit = useCallback(
+    (userPrompt: string) => {
+      for (const plugin of remotePlugins) {
+        plugin.recordSubmit?.(userPrompt);
+      }
+      if (!suggesterActive) return;
+      suggester.recordSubmit(userPrompt);
+    },
+    [remotePlugins, suggester, suggesterActive],
+  );
+
+  const ensureSeed = useCallback(() => {
+    for (const plugin of remotePlugins) {
+      plugin.ensureSeed?.();
+    }
+    if (!suggesterActive) return;
+    suggester.ensureSeed();
+  }, [remotePlugins, suggester, suggesterActive]);
+
+  const cancel = useCallback(() => {
+    for (const plugin of remotePlugins) {
+      plugin.cancel?.();
+    }
+    suggester.cancel();
+  }, [remotePlugins, suggester]);
+
+  const dismiss = useCallback(() => {
+    for (const plugin of remotePlugins) {
+      plugin.dismiss?.();
+    }
+    suggester.dismiss();
+  }, [remotePlugins, suggester]);
+
+  const handleKey = useCallback(
+    (key: KeyEvent, blocked: boolean) => {
+      for (const plugin of remotePlugins) {
+        if (plugin.handleKey?.(key, blocked)) return true;
+      }
+      if (!suggesterActive) return false;
+      return suggester.handleKey(key, blocked);
+    },
+    [remotePlugins, suggester, suggesterActive],
+  );
+
+  const remoteGhost = remotePlugins.find((plugin) => plugin.ghostVisible && plugin.ghostSuggestion);
+
+  return {
+    installed,
+    slashCommands,
+    ghostSuggestion: remoteGhost?.ghostSuggestion ?? (suggesterActive ? suggester.suggestion : null),
+    ghostVisible: Boolean(remoteGhost?.ghostVisible || (suggesterActive && suggester.visible)),
+    handleCommand,
+    requestAfterTurn,
+    recordSubmit,
+    ensureSeed,
+    cancel,
+    dismiss,
+    handleKey,
+    install: installBundled,
+    uninstall,
+    formatList,
+  };
+}

--- a/src/ui/hooks/usePromptSuggester.ts
+++ b/src/ui/hooks/usePromptSuggester.ts
@@ -1,0 +1,399 @@
+import type { KeyEvent, TextareaRenderable } from "@opentui/core";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createProvider } from "../../grok/client.js";
+import { buildSuggestionContext } from "../../suggester/context.js";
+import { fastPathContinueResult, finalizeSuggestionResult, shouldFastPathContinue } from "../../suggester/engine.js";
+import { generatePromptSuggestion } from "../../suggester/generate.js";
+import { formatSuggesterStatus, loadSuggesterSettings, saveSuggesterSettings } from "../../suggester/index.js";
+import { isGhostAcceptKey } from "../../suggester/keys.js";
+import { renderSuggestionPrompt } from "../../suggester/prompt.js";
+import { compactSeedForPrompt, loadSeed, type ReseedTrigger } from "../../suggester/seed.js";
+import { generateProjectSeed } from "../../suggester/seeder.js";
+import { checkSeedStaleness } from "../../suggester/staleness.js";
+import {
+  appendSteeringEvent,
+  classifySteering,
+  isRepeatedRejected,
+  recentChangedExamples,
+} from "../../suggester/steering.js";
+import {
+  addUsage,
+  emptySessionState,
+  loadSuggesterSessionState,
+  saveSuggesterSessionState,
+} from "../../suggester/store.js";
+import type { ResolvedSuggesterSettings, SuggesterSessionState, TurnStatus } from "../../suggester/types.js";
+import type { ChatEntry } from "../../types/index.js";
+import { getApiKey } from "../../utils/settings.js";
+
+export interface PromptSuggesterState {
+  suggestion: string | null;
+  visible: boolean;
+  enabled: boolean;
+  requestAfterTurn: (entries: ChatEntry[], status: TurnStatus, abortNote?: string) => void;
+  recordSubmit: (userPrompt: string) => void;
+  ensureSeed: () => void;
+  requestReseed: () => void;
+  cancel: () => void;
+  accept: () => boolean;
+  dismiss: () => void;
+  setEnabled: (enabled: boolean) => void;
+  setAutoAccept: (autoAccept: boolean) => void;
+  setCustomInstruction: (instruction: string) => void;
+  setSuggesterModel: (model: string) => void;
+  setSeederModel: (model: string) => void;
+  formatStatus: () => string;
+  handleKey: (key: KeyEvent, blocked: boolean) => boolean;
+}
+
+export function usePromptSuggester(
+  inputRef: React.RefObject<TextareaRenderable | null>,
+  cwd: string,
+  sessionId: string | null,
+  baseURL: string,
+): PromptSuggesterState {
+  const [settings, setSettings] = useState<ResolvedSuggesterSettings>(() => loadSuggesterSettings());
+  const [suggestion, setSuggestion] = useState<string | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+  const [editorEmpty, setEditorEmpty] = useState(true);
+  const [sessionState, setSessionState] = useState<SuggesterSessionState>(() => emptySessionState());
+
+  const settingsRef = useRef(settings);
+  settingsRef.current = settings;
+  const suggestionRef = useRef(suggestion);
+  suggestionRef.current = suggestion;
+  const dismissedRef = useRef(dismissed);
+  dismissedRef.current = dismissed;
+  const sessionStateRef = useRef(sessionState);
+  sessionStateRef.current = sessionState;
+  const epochRef = useRef(0);
+  const abortRef = useRef<AbortController | null>(null);
+  const seedRunningRef = useRef(false);
+  const seedPendingRef = useRef<ReseedTrigger | null>(null);
+  const seedAbortRef = useRef<AbortController | null>(null);
+
+  const persistState = useCallback(
+    (next: SuggesterSessionState) => {
+      sessionStateRef.current = next;
+      setSessionState(next);
+      if (sessionId) saveSuggesterSessionState(cwd, sessionId, next);
+    },
+    [cwd, sessionId],
+  );
+
+  useEffect(() => {
+    if (!sessionId) {
+      const empty = emptySessionState();
+      sessionStateRef.current = empty;
+      setSessionState(empty);
+      return;
+    }
+    const loaded = loadSuggesterSessionState(cwd, sessionId);
+    sessionStateRef.current = loaded;
+    setSessionState(loaded);
+  }, [cwd, sessionId]);
+
+  useEffect(() => {
+    const poll = () => {
+      const empty = !(inputRef.current?.plainText ?? "");
+      setEditorEmpty(empty);
+    };
+    poll();
+    const id = setInterval(poll, 100);
+    return () => clearInterval(id);
+  }, [inputRef]);
+
+  const cancel = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    seedAbortRef.current?.abort();
+    seedAbortRef.current = null;
+    seedPendingRef.current = null;
+    epochRef.current += 1;
+    setSuggestion(null);
+    suggestionRef.current = null;
+  }, []);
+
+  const dismiss = useCallback(() => {
+    setDismissed(true);
+  }, []);
+
+  const insertSuggestion = useCallback(
+    (text: string, requireEmpty: boolean): boolean => {
+      const ta = inputRef.current;
+      if (!ta) return false;
+      if (requireEmpty && ta.plainText) return false;
+      ta.setText(text);
+      ta.cursorOffset = text.length;
+      return true;
+    },
+    [inputRef],
+  );
+
+  const accept = useCallback(() => {
+    const text = suggestionRef.current;
+    if (!text) return false;
+    if (!insertSuggestion(text, true)) return false;
+    setDismissed(true);
+    dismissedRef.current = true;
+    return true;
+  }, [insertSuggestion]);
+
+  const runReseed = useCallback(
+    async (trigger: ReseedTrigger) => {
+      if (seedRunningRef.current) {
+        seedPendingRef.current = trigger;
+        return;
+      }
+      const current = settingsRef.current;
+      if (!current.enabled || !current.reseedEnabled) return;
+      const apiKey = getApiKey();
+      if (!apiKey) return;
+
+      seedRunningRef.current = true;
+      const ac = new AbortController();
+      seedAbortRef.current = ac;
+      try {
+        const result = await generateProjectSeed(
+          createProvider(apiKey, baseURL),
+          cwd,
+          trigger,
+          loadSeed(cwd),
+          current.seederModel,
+          ac.signal,
+        );
+        if (result.usage) {
+          persistState({
+            ...sessionStateRef.current,
+            seederUsage: addUsage(sessionStateRef.current.seederUsage, result.usage, result.modelId),
+          });
+        }
+      } catch {
+        /* seeder failures stay silent */
+      } finally {
+        seedRunningRef.current = false;
+        seedAbortRef.current = null;
+        const pending = seedPendingRef.current;
+        seedPendingRef.current = null;
+        if (pending) void runReseed(pending);
+      }
+    },
+    [baseURL, cwd, persistState],
+  );
+
+  const ensureSeed = useCallback(() => {
+    const stale = checkSeedStaleness(cwd);
+    if (stale.stale && stale.trigger) void runReseed(stale.trigger);
+  }, [cwd, runReseed]);
+
+  const requestReseed = useCallback(() => {
+    void runReseed({ reason: "manual", changedFiles: [] });
+  }, [runReseed]);
+
+  const recordSubmit = useCallback(
+    (userPrompt: string) => {
+      const last = sessionStateRef.current.lastSuggestion;
+      if (!last?.text || !userPrompt.trim()) return;
+      const classified = classifySteering(last.text, userPrompt);
+      persistState({
+        ...sessionStateRef.current,
+        steeringHistory: appendSteeringEvent(sessionStateRef.current.steeringHistory, {
+          ...classified,
+          suggestedPrompt: last.text,
+          actualUserPrompt: userPrompt.trim(),
+          at: new Date().toISOString(),
+        }),
+      });
+    },
+    [persistState],
+  );
+
+  const requestAfterTurn = useCallback(
+    (entries: ChatEntry[], status: TurnStatus, abortNote?: string) => {
+      const current = settingsRef.current;
+      if (!current.enabled) return;
+
+      const epoch = ++epochRef.current;
+      abortRef.current?.abort();
+      const ac = new AbortController();
+      abortRef.current = ac;
+      setDismissed(false);
+      dismissedRef.current = false;
+
+      let turnsSince = sessionStateRef.current.turnsSinceLastStalenessCheck + 1;
+      if (current.reseedEnabled && turnsSince >= current.reseedTurnInterval) {
+        const stale = checkSeedStaleness(cwd);
+        if (stale.stale && stale.trigger) void runReseed(stale.trigger);
+        turnsSince = 0;
+      }
+
+      const applyResult = (
+        text: string | null,
+        result?: { usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number }; modelId?: string },
+      ) => {
+        if (epoch !== epochRef.current) return;
+        const nextText = text && isRepeatedRejected(text, sessionStateRef.current.steeringHistory) ? null : text;
+        setSuggestion(nextText);
+        suggestionRef.current = nextText;
+        if (nextText && current.autoAccept) {
+          insertSuggestion(nextText, true);
+        }
+
+        const nextUsage = result?.usage
+          ? addUsage(sessionStateRef.current.suggestionUsage, result.usage, result.modelId ?? current.model)
+          : sessionStateRef.current.suggestionUsage;
+        persistState({
+          ...sessionStateRef.current,
+          lastSuggestion: nextText
+            ? { text: nextText, shownAt: new Date().toISOString(), turnStatus: status }
+            : sessionStateRef.current.lastSuggestion,
+          lastUsage: result?.usage
+            ? {
+                inputTokens: result.usage.inputTokens,
+                outputTokens: result.usage.outputTokens,
+                totalTokens: result.usage.totalTokens,
+                modelId: result.modelId ?? current.model,
+              }
+            : sessionStateRef.current.lastUsage,
+          suggestionUsage: nextUsage,
+          turnsSinceLastStalenessCheck: turnsSince,
+        });
+      };
+
+      if (shouldFastPathContinue(status, current.fastPathContinueOnError)) {
+        applyResult(fastPathContinueResult().text);
+        return;
+      }
+
+      const apiKey = getApiKey();
+      if (!apiKey) {
+        applyResult(null);
+        return;
+      }
+
+      const context = buildSuggestionContext(entries, status, {
+        abortNote,
+        maxSuggestionChars: current.maxSuggestionChars,
+        customInstruction: current.customInstruction,
+        intentSeed: compactSeedForPrompt(loadSeed(cwd)),
+        recentChanged: recentChangedExamples(sessionStateRef.current.steeringHistory),
+      });
+
+      void generatePromptSuggestion(
+        createProvider(apiKey, baseURL),
+        renderSuggestionPrompt(context),
+        current.model,
+        current.maxSuggestionChars,
+        ac.signal,
+      )
+        .then((raw) => {
+          if (epoch !== epochRef.current) return;
+          const finalized = finalizeSuggestionResult(raw, current.maxSuggestionChars);
+          applyResult(finalized.kind === "suggestion" ? finalized.text : null, {
+            usage: finalized.usage,
+            modelId: finalized.modelId,
+          });
+        })
+        .catch(() => {
+          if (epoch !== epochRef.current) return;
+          applyResult(null);
+        });
+    },
+    [baseURL, cwd, insertSuggestion, persistState, runReseed],
+  );
+
+  const setEnabled = useCallback(
+    (enabled: boolean) => {
+      const next = saveSuggesterSettings({ enabled });
+      setSettings(next);
+      if (!enabled) {
+        cancel();
+        setSuggestion(null);
+        suggestionRef.current = null;
+        setDismissed(true);
+      }
+    },
+    [cancel],
+  );
+
+  const setAutoAccept = useCallback((autoAccept: boolean) => {
+    setSettings(saveSuggesterSettings({ autoAccept }));
+  }, []);
+
+  const setCustomInstruction = useCallback((customInstruction: string) => {
+    setSettings(saveSuggesterSettings({ customInstruction }));
+  }, []);
+
+  const setSuggesterModel = useCallback((model: string) => {
+    setSettings(saveSuggesterSettings({ model }));
+  }, []);
+
+  const setSeederModel = useCallback((seederModel: string) => {
+    setSettings(saveSuggesterSettings({ seederModel }));
+  }, []);
+
+  const formatStatus = useCallback(
+    () => formatSuggesterStatus(settingsRef.current, sessionStateRef.current, loadSeed(cwd)),
+    [cwd],
+  );
+
+  const handleKey = useCallback(
+    (key: KeyEvent, blocked: boolean) => {
+      if (blocked || !settingsRef.current.enabled) return false;
+      const editorText = inputRef.current?.plainText ?? "";
+      const text = suggestionRef.current;
+      if (!text || dismissedRef.current) return false;
+
+      const isEscape =
+        key.name === "escape" || key.sequence === "\u001b" || (key as KeyEvent & { raw?: string }).raw === "\u001b";
+      if (isEscape && editorText === text) {
+        key.preventDefault();
+        key.stopPropagation();
+        inputRef.current?.clear();
+        dismiss();
+        return true;
+      }
+
+      if (editorText) return false;
+
+      if (isGhostAcceptKey(key, settingsRef.current.ghostAcceptKeys)) {
+        key.preventDefault();
+        key.stopPropagation();
+        accept();
+        return true;
+      }
+
+      if (isEscape) {
+        key.preventDefault();
+        key.stopPropagation();
+        dismiss();
+        return true;
+      }
+
+      return false;
+    },
+    [accept, dismiss, inputRef],
+  );
+
+  const visible = Boolean(settings.enabled && suggestion && editorEmpty && !dismissed);
+
+  return {
+    suggestion,
+    visible,
+    enabled: settings.enabled,
+    requestAfterTurn,
+    recordSubmit,
+    ensureSeed,
+    requestReseed,
+    cancel,
+    accept,
+    dismiss,
+    setEnabled,
+    setAutoAccept,
+    setCustomInstruction,
+    setSuggesterModel,
+    setSeederModel,
+    formatStatus,
+    handleKey,
+  };
+}

--- a/src/ui/hooks/usePromptSuggester.ts
+++ b/src/ui/hooks/usePromptSuggester.ts
@@ -51,6 +51,7 @@ export function usePromptSuggester(
   cwd: string,
   sessionId: string | null,
   baseURL: string,
+  active = true,
 ): PromptSuggesterState {
   const [settings, setSettings] = useState<ResolvedSuggesterSettings>(() => loadSuggesterSettings());
   const [suggestion, setSuggestion] = useState<string | null>(null);
@@ -92,6 +93,19 @@ export function usePromptSuggester(
     sessionStateRef.current = loaded;
     setSessionState(loaded);
   }, [cwd, sessionId]);
+
+  useEffect(() => {
+    if (active) return;
+    abortRef.current?.abort();
+    abortRef.current = null;
+    seedAbortRef.current?.abort();
+    seedAbortRef.current = null;
+    seedPendingRef.current = null;
+    epochRef.current += 1;
+    setSuggestion(null);
+    suggestionRef.current = null;
+    setDismissed(true);
+  }, [active]);
 
   useEffect(() => {
     const poll = () => {
@@ -182,9 +196,10 @@ export function usePromptSuggester(
   );
 
   const ensureSeed = useCallback(() => {
+    if (!active) return;
     const stale = checkSeedStaleness(cwd);
     if (stale.stale && stale.trigger) void runReseed(stale.trigger);
-  }, [cwd, runReseed]);
+  }, [active, cwd, runReseed]);
 
   const requestReseed = useCallback(() => {
     void runReseed({ reason: "manual", changedFiles: [] });
@@ -211,7 +226,7 @@ export function usePromptSuggester(
   const requestAfterTurn = useCallback(
     (entries: ChatEntry[], status: TurnStatus, abortNote?: string) => {
       const current = settingsRef.current;
-      if (!current.enabled) return;
+      if (!active || !current.enabled) return;
 
       const epoch = ++epochRef.current;
       abortRef.current?.abort();
@@ -299,7 +314,7 @@ export function usePromptSuggester(
           applyResult(null);
         });
     },
-    [baseURL, cwd, insertSuggestion, persistState, runReseed],
+    [active, baseURL, cwd, insertSuggestion, persistState, runReseed],
   );
 
   const setEnabled = useCallback(
@@ -339,7 +354,7 @@ export function usePromptSuggester(
 
   const handleKey = useCallback(
     (key: KeyEvent, blocked: boolean) => {
-      if (blocked || !settingsRef.current.enabled) return false;
+      if (!active || blocked || !settingsRef.current.enabled) return false;
       const editorText = inputRef.current?.plainText ?? "";
       const text = suggestionRef.current;
       if (!text || dismissedRef.current) return false;
@@ -372,10 +387,10 @@ export function usePromptSuggester(
 
       return false;
     },
-    [accept, dismiss, inputRef],
+    [accept, active, dismiss, inputRef],
   );
 
-  const visible = Boolean(settings.enabled && suggestion && editorEmpty && !dismissed);
+  const visible = Boolean(active && settings.enabled && suggestion && editorEmpty && !dismissed);
 
   return {
     suggestion,

--- a/src/ui/session-modal.test.ts
+++ b/src/ui/session-modal.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import type { SessionInfo } from "../types/index";
+import { buildSessionBrowseRows, formatSessionRowTitle, formatSessionUpdatedAt } from "./session-modal";
+
+function session(partial: Partial<SessionInfo> & Pick<SessionInfo, "id">): SessionInfo {
+  return {
+    workspaceId: "ws",
+    title: null,
+    recap: null,
+    model: "grok-4.3",
+    mode: "agent",
+    cwdAtStart: "/tmp",
+    cwdLast: "/tmp",
+    status: "active",
+    createdAt: new Date("2026-04-22T15:00:00.000Z"),
+    updatedAt: new Date("2026-04-22T15:00:00.000Z"),
+    ...partial,
+  };
+}
+
+describe("session picker rows", () => {
+  it("filters by title, id, recap, model, and mode", () => {
+    const sessions = [
+      session({ id: "aaa111", title: "Billing recap", mode: "plan" }),
+      session({
+        id: "bbb222",
+        title: "Sandbox work",
+        recap: { text: "Need to restore the sandbox flags", model: null, updatedAt: null },
+      }),
+      session({ id: "ccc333", model: "grok-4.20-non-reasoning" }),
+    ];
+
+    expect(buildSessionBrowseRows(sessions, "billing").map((row) => row.session.id)).toEqual(["aaa111"]);
+    expect(buildSessionBrowseRows(sessions, "bbb").map((row) => row.session.id)).toEqual(["bbb222"]);
+    expect(buildSessionBrowseRows(sessions, "sandbox flags").map((row) => row.session.id)).toEqual(["bbb222"]);
+    expect(buildSessionBrowseRows(sessions, "4.20").map((row) => row.session.id)).toEqual(["ccc333"]);
+    expect(buildSessionBrowseRows(sessions, "plan").map((row) => row.session.id)).toEqual(["aaa111"]);
+  });
+
+  it("falls back to Untitled when a session has no title", () => {
+    expect(formatSessionRowTitle(session({ id: "plain" }))).toBe("Untitled");
+  });
+
+  it("formats relative update times", () => {
+    const now = new Date("2026-04-22T16:00:00.000Z");
+    expect(formatSessionUpdatedAt(new Date("2026-04-22T15:59:30.000Z"), now)).toBe("just now");
+    expect(formatSessionUpdatedAt(new Date("2026-04-22T15:10:00.000Z"), now)).toBe("50m ago");
+    expect(formatSessionUpdatedAt(new Date("2026-04-22T13:00:00.000Z"), now)).toBe("3h ago");
+    expect(formatSessionUpdatedAt(new Date("2026-04-20T16:00:00.000Z"), now)).toBe("2d ago");
+  });
+});

--- a/src/ui/session-modal.tsx
+++ b/src/ui/session-modal.tsx
@@ -1,0 +1,157 @@
+import type { ScrollBoxRenderable } from "@opentui/core";
+import { useEffect, useRef } from "react";
+import type { SessionInfo } from "../types/index";
+import type { Theme } from "./theme";
+
+export type SessionBrowseRow = { kind: "session"; session: SessionInfo };
+
+export function buildSessionBrowseRows(sessions: SessionInfo[], query: string): SessionBrowseRow[] {
+  const q = query.trim().toLowerCase();
+  const filtered = q
+    ? sessions.filter((session) => {
+        const title = (session.title ?? "").toLowerCase();
+        const recap = (session.recap?.text ?? "").toLowerCase();
+        return (
+          title.includes(q) ||
+          recap.includes(q) ||
+          session.id.toLowerCase().includes(q) ||
+          session.model.toLowerCase().includes(q) ||
+          session.mode.toLowerCase().includes(q)
+        );
+      })
+    : sessions;
+
+  return filtered.map((session) => ({ kind: "session" as const, session }));
+}
+
+export function formatSessionUpdatedAt(updatedAt: Date, now = new Date()): string {
+  const deltaMs = Math.max(0, now.getTime() - updatedAt.getTime());
+  const minutes = Math.floor(deltaMs / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return updatedAt.toISOString().slice(0, 10);
+}
+
+export function formatSessionRowTitle(session: SessionInfo): string {
+  const title = session.title?.trim();
+  return title || "Untitled";
+}
+
+export function formatSessionRowMeta(session: SessionInfo): string {
+  return `${session.id} · ${session.mode} · ${session.model}`;
+}
+
+function bottomAlignedModalTop(height: number, panelHeight: number): number {
+  return Math.max(2, Math.floor((height - panelHeight) / 2));
+}
+
+export function SessionBrowserModal({
+  t,
+  width,
+  height,
+  selectedIndex,
+  searchQuery,
+  rows,
+  currentSessionId,
+}: {
+  t: Theme;
+  width: number;
+  height: number;
+  selectedIndex: number;
+  searchQuery: string;
+  rows: SessionBrowseRow[];
+  currentSessionId: string | null;
+}) {
+  const listRef = useRef<ScrollBoxRenderable>(null);
+
+  useEffect(() => {
+    const selected = rows[selectedIndex];
+    if (!selected) return;
+    listRef.current?.scrollChildIntoView(`session-${selected.session.id}`);
+  }, [rows, selectedIndex]);
+
+  const itemCount = Math.max(rows.length, 1);
+  const contentHeight = itemCount * 2 + 10;
+  const panelHeight = Math.min(contentHeight, Math.floor(height * 0.6));
+  const panelWidth = Math.min(72, width - 6);
+  const overlayBg = "#000000cc" as string;
+
+  return (
+    <box
+      position="absolute"
+      left={0}
+      top={0}
+      width={width}
+      height={height}
+      alignItems="center"
+      paddingTop={bottomAlignedModalTop(height, panelHeight)}
+      backgroundColor={overlayBg}
+    >
+      <box
+        width={panelWidth}
+        height={panelHeight}
+        backgroundColor={t.backgroundPanel}
+        paddingTop={1}
+        paddingBottom={1}
+        flexDirection="column"
+      >
+        <box flexShrink={0} flexDirection="row" justifyContent="space-between" paddingLeft={2} paddingRight={2}>
+          <text fg={t.primary}>
+            <b>{"Resume session"}</b>
+          </text>
+          <text fg={t.textMuted}>{"esc"}</text>
+        </box>
+        <box flexShrink={0} paddingLeft={2} paddingRight={2} paddingTop={1} paddingBottom={1}>
+          <text fg={t.text}>
+            {searchQuery || <span style={{ fg: t.textMuted }}>{"Search by title, id, recap..."}</span>}
+          </text>
+        </box>
+        <scrollbox ref={listRef} flexGrow={1} minHeight={0}>
+          {rows.map((row, idx) => {
+            const selected = idx === selectedIndex;
+            const session = row.session;
+            const current = session.id === currentSessionId;
+            const recap = session.recap?.text?.replace(/\s+/g, " ").trim();
+            return (
+              <box
+                key={`session-${session.id}`}
+                id={`session-${session.id}`}
+                width="100%"
+                backgroundColor={selected ? t.selectedBg : undefined}
+                paddingLeft={2}
+                paddingRight={2}
+              >
+                <box width="100%" flexDirection="row" justifyContent="space-between">
+                  <text fg={current ? t.accent : selected ? t.selected : t.text}>
+                    <b>{formatSessionRowTitle(session)}</b>
+                    {current ? " (current)" : ""}
+                  </text>
+                  <text fg={selected ? t.primary : t.textMuted}>{formatSessionUpdatedAt(session.updatedAt)}</text>
+                </box>
+                <text fg={t.textMuted}>{formatSessionRowMeta(session)}</text>
+                {recap ? <text fg={t.textDim}>{recap}</text> : null}
+              </box>
+            );
+          })}
+          {rows.length === 0 ? (
+            <box paddingLeft={2} paddingRight={2}>
+              <text fg={t.textMuted}>{"No saved sessions yet"}</text>
+            </box>
+          ) : null}
+        </scrollbox>
+        <box flexShrink={0} paddingLeft={2} paddingRight={2} paddingTop={2} paddingBottom={1}>
+          <text>
+            <span style={{ fg: t.primary }}>{"enter "}</span>
+            <span style={{ fg: t.textMuted }}>{"resume · "}</span>
+            <span style={{ fg: t.primary }}>{"esc "}</span>
+            <span style={{ fg: t.textMuted }}>{"close"}</span>
+          </text>
+        </box>
+      </box>
+    </box>
+  );
+}

--- a/src/ui/slash-menu.test.ts
+++ b/src/ui/slash-menu.test.ts
@@ -21,4 +21,9 @@ describe("filterSlashMenuItems", () => {
   it("finds the recaps command from singular aliases", () => {
     expect(filterSlashMenuItems(SLASH_MENU_ITEMS, "recap")[0]?.id).toBe("recaps");
   });
+
+  it("finds the suggester command", () => {
+    expect(filterSlashMenuItems(SLASH_MENU_ITEMS, "/suggester")[0]?.id).toBe("suggester");
+    expect(filterSlashMenuItems(SLASH_MENU_ITEMS, "suggest")[0]?.id).toBe("suggester");
+  });
 });

--- a/src/ui/slash-menu.test.ts
+++ b/src/ui/slash-menu.test.ts
@@ -22,8 +22,19 @@ describe("filterSlashMenuItems", () => {
     expect(filterSlashMenuItems(SLASH_MENU_ITEMS, "recap")[0]?.id).toBe("recaps");
   });
 
-  it("finds the suggester command", () => {
-    expect(filterSlashMenuItems(SLASH_MENU_ITEMS, "/suggester")[0]?.id).toBe("suggester");
-    expect(filterSlashMenuItems(SLASH_MENU_ITEMS, "suggest")[0]?.id).toBe("suggester");
+  it("finds the install command", () => {
+    expect(filterSlashMenuItems(SLASH_MENU_ITEMS, "/install")[0]?.id).toBe("install");
+    expect(filterSlashMenuItems(SLASH_MENU_ITEMS, "plugin")[0]?.id).toBe("plugins");
+  });
+
+  it("finds the resume command from session aliases", () => {
+    expect(filterSlashMenuItems(SLASH_MENU_ITEMS, "/resume")[0]?.id).toBe("resume");
+    expect(filterSlashMenuItems(SLASH_MENU_ITEMS, "sessions")[0]?.id).toBe("resume");
+    expect(filterSlashMenuItems(SLASH_MENU_ITEMS, "session")[0]?.id).toBe("resume");
+  });
+
+  it("ranks resume ahead of new session for the session alias", () => {
+    const ids = filterSlashMenuItems(SLASH_MENU_ITEMS, "session").map((item) => item.id);
+    expect(ids.indexOf("resume")).toBeLessThan(ids.indexOf("new"));
   });
 });

--- a/src/ui/slash-menu.ts
+++ b/src/ui/slash-menu.ts
@@ -16,6 +16,7 @@ export const SLASH_MENU_ITEMS: SlashMenuItem[] = [
   { id: "wallet", label: "wallet", description: "Wallet and payment settings" },
   { id: "models", label: "models", description: "Select a model", aliases: ["model", "mode"] },
   { id: "recaps", label: "recaps", description: "Turn session recaps on/off", aliases: ["recap", "summary"] },
+  { id: "resume", label: "resume", description: "Resume a saved session", aliases: ["sessions", "session"] },
   { id: "new", label: "new session", description: "Start a new session" },
   { id: "commit-push", label: "commit & push", description: "Commit and push" },
   { id: "commit-pr", label: "commit & pr", description: "Commit and open PR" },
@@ -23,8 +24,9 @@ export const SLASH_MENU_ITEMS: SlashMenuItem[] = [
   { id: "verify", label: "verify", description: "Run local verification" },
   { id: "skills", label: "skills", description: "Manage skills" },
   { id: "btw", label: "btw", description: "Ask a side question without interrupting" },
-  { id: "suggester", label: "suggester", description: "Next-prompt suggestions and project seed" },
-  { id: "update", label: "update", description: "Update grok to the latest version" },
+  { id: "plugins", label: "plugins", description: "List installed plugins", aliases: ["plugin"] },
+  { id: "install", label: "install", description: "Install a bundled or GitHub plugin" },
+  { id: "update", label: "update", description: "Update from upstream (ctrl+u)" },
 ];
 
 export function filterSlashMenuItems(items: SlashMenuItem[], query: string): SlashMenuItem[] {

--- a/src/ui/slash-menu.ts
+++ b/src/ui/slash-menu.ts
@@ -23,6 +23,7 @@ export const SLASH_MENU_ITEMS: SlashMenuItem[] = [
   { id: "verify", label: "verify", description: "Run local verification" },
   { id: "skills", label: "skills", description: "Manage skills" },
   { id: "btw", label: "btw", description: "Ask a side question without interrupting" },
+  { id: "suggester", label: "suggester", description: "Next-prompt suggestions and project seed" },
   { id: "update", label: "update", description: "Update grok to the latest version" },
 ];
 

--- a/src/ui/update-hotkey.test.ts
+++ b/src/ui/update-hotkey.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { isCtrlU } from "./update-hotkey";
+
+describe("isCtrlU", () => {
+  it("matches control+u", () => {
+    expect(isCtrlU({ name: "u", ctrl: true })).toBe(true);
+  });
+
+  it("ignores plain u, meta, and super", () => {
+    expect(isCtrlU({ name: "u" })).toBe(false);
+    expect(isCtrlU({ name: "u", ctrl: true, meta: true })).toBe(false);
+    expect(isCtrlU({ name: "u", ctrl: true, super: true })).toBe(false);
+  });
+});

--- a/src/ui/update-hotkey.ts
+++ b/src/ui/update-hotkey.ts
@@ -1,0 +1,3 @@
+export function isCtrlU(key: { name?: string; ctrl?: boolean; meta?: boolean; super?: boolean }): boolean {
+  return key.name === "u" && !!key.ctrl && !key.meta && !key.super;
+}

--- a/src/utils/dev-rebuild.test.ts
+++ b/src/utils/dev-rebuild.test.ts
@@ -1,0 +1,154 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ensureBuilt, findLocalTsc, isSourceCheckout, shouldRebuild } from "../../bin/ensure-built.js";
+
+let tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs) fs.rmSync(dir, { recursive: true, force: true });
+  tempDirs = [];
+});
+
+function createTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeFile(filePath: string, contents: string, mtimeMs: number): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, contents);
+  fs.utimesSync(filePath, mtimeMs / 1000, mtimeMs / 1000);
+}
+
+function createCheckout(options?: { withDist?: boolean; withTsc?: boolean }): string {
+  const root = createTempDir("grok-rebuild-");
+  const now = Date.UTC(2026, 3, 1, 12, 0, 0);
+  writeFile(path.join(root, "package.json"), '{"name":"grok-kev"}', now);
+  writeFile(path.join(root, "tsconfig.json"), "{}", now);
+  writeFile(path.join(root, "src", "index.ts"), "export const ready = true;\n", now);
+  if (options?.withDist) {
+    writeFile(path.join(root, "dist", "index.js"), "export {};\n", now + 60_000);
+  }
+  if (options?.withTsc) {
+    writeFile(path.join(root, "node_modules", "typescript", "bin", "tsc"), "#!/usr/bin/env node\n", now);
+  }
+  return root;
+}
+
+describe("isSourceCheckout", () => {
+  it("is true only when both src/index.ts and tsconfig.json exist", () => {
+    const root = createCheckout();
+    expect(isSourceCheckout(root)).toBe(true);
+
+    fs.rmSync(path.join(root, "src", "index.ts"));
+    expect(isSourceCheckout(root)).toBe(false);
+  });
+
+  it("is false for an installed package without sources", () => {
+    const root = createTempDir("grok-pkg-");
+    writeFile(path.join(root, "package.json"), "{}", Date.now());
+    writeFile(path.join(root, "dist", "index.js"), "export {};\n", Date.now());
+    expect(isSourceCheckout(root)).toBe(false);
+  });
+});
+
+describe("shouldRebuild", () => {
+  it("does not rebuild published installs", () => {
+    const root = createTempDir("grok-published-");
+    writeFile(path.join(root, "package.json"), "{}", Date.now());
+    writeFile(path.join(root, "dist", "index.js"), "export {};\n", Date.now());
+    expect(shouldRebuild(root)).toEqual({ needed: false, reason: "not a source checkout" });
+  });
+
+  it("rebuilds when dist/index.js is missing", () => {
+    const root = createCheckout();
+    expect(shouldRebuild(root)).toEqual({ needed: true, reason: "dist/index.js is missing" });
+  });
+
+  it("rebuilds when a source file is newer than dist", () => {
+    const root = createCheckout({ withDist: true });
+    const newer = Date.UTC(2026, 3, 1, 13, 0, 0);
+    writeFile(path.join(root, "src", "utils", "session-auth.ts"), "export {};\n", newer);
+
+    expect(shouldRebuild(root)).toEqual({ needed: true, reason: "src/utils/session-auth.ts is newer than dist" });
+  });
+
+  it("does not rebuild when dist is newer than sources", () => {
+    const root = createCheckout({ withDist: true });
+    expect(shouldRebuild(root)).toEqual({ needed: false, reason: "dist is up to date" });
+  });
+
+  it("ignores newer test files", () => {
+    const root = createCheckout({ withDist: true });
+    writeFile(path.join(root, "src", "utils", "session-auth.test.ts"), "export {};\n", Date.UTC(2026, 3, 1, 14, 0, 0));
+    expect(shouldRebuild(root)).toEqual({ needed: false, reason: "dist is up to date" });
+  });
+
+  it("rebuilds when package.json is newer than dist", () => {
+    const root = createCheckout({ withDist: true });
+    writeFile(path.join(root, "package.json"), '{"name":"grok-kev","version":"9.9.9"}', Date.UTC(2026, 3, 1, 15, 0, 0));
+    expect(shouldRebuild(root)).toEqual({ needed: true, reason: "package.json is newer than dist" });
+  });
+
+  it("skips rebuild when GROK_SKIP_REBUILD is set", () => {
+    const root = createCheckout();
+    expect(shouldRebuild(root, { env: { GROK_SKIP_REBUILD: "1" } })).toEqual({
+      needed: false,
+      reason: "GROK_SKIP_REBUILD is set",
+    });
+  });
+});
+
+describe("findLocalTsc", () => {
+  it("returns the checkout typescript binary when present", () => {
+    const root = createCheckout({ withTsc: true });
+    expect(findLocalTsc(root)).toBe(path.join(root, "node_modules", "typescript", "bin", "tsc"));
+  });
+
+  it("returns null when typescript is not installed", () => {
+    expect(findLocalTsc(createCheckout())).toBeNull();
+  });
+});
+
+describe("ensureBuilt", () => {
+  it("does not invoke the builder when dist is current", () => {
+    const root = createCheckout({ withDist: true });
+    const calls: string[] = [];
+    const result = ensureBuilt(root, {
+      runBuild: () => {
+        calls.push("build");
+        return { status: 0 };
+      },
+    });
+    expect(result).toEqual({ rebuilt: false, reason: "dist is up to date", status: 0 });
+    expect(calls).toEqual([]);
+  });
+
+  it("invokes the builder when sources are newer", () => {
+    const root = createCheckout();
+    const result = ensureBuilt(root, {
+      runBuild: () => ({ status: 0 }),
+    });
+    expect(result).toEqual({ rebuilt: true, reason: "dist/index.js is missing", status: 0 });
+  });
+
+  it("hard-fails when compilation fails and dist is missing", () => {
+    const root = createCheckout();
+    const result = ensureBuilt(root, {
+      runBuild: () => ({ status: 2 }),
+    });
+    expect(result).toEqual({ rebuilt: false, reason: "dist/index.js is missing", status: 2 });
+  });
+
+  it("keeps the last good dist when compilation fails", () => {
+    const root = createCheckout({ withDist: true });
+    writeFile(path.join(root, "src", "index.ts"), "export const ready = false;\n", Date.UTC(2026, 3, 1, 16, 0, 0));
+    const result = ensureBuilt(root, {
+      runBuild: () => ({ status: 2 }),
+    });
+    expect(result).toEqual({ rebuilt: false, reason: "src/index.ts is newer than dist", status: 0 });
+  });
+});

--- a/src/utils/session-auth.test.ts
+++ b/src/utils/session-auth.test.ts
@@ -1,0 +1,74 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { afterEach, describe, expect, it } from "vitest";
+import { parseOfficialSessionKey, readOfficialSessionKey } from "./session-auth";
+
+const tmpFiles: string[] = [];
+
+afterEach(() => {
+  for (const file of tmpFiles.splice(0)) {
+    fs.rmSync(file, { force: true });
+  }
+});
+
+function writeTempAuth(data: unknown): string {
+  const file = path.join(os.tmpdir(), `grok-auth-test-${Date.now()}-${Math.random().toString(16).slice(2)}.json`);
+  fs.writeFileSync(file, JSON.stringify(data), { mode: 0o600 });
+  tmpFiles.push(file);
+  return file;
+}
+
+describe("parseOfficialSessionKey", () => {
+  it("returns undefined for missing or invalid payloads", () => {
+    expect(parseOfficialSessionKey(undefined)).toBeUndefined();
+    expect(parseOfficialSessionKey(null)).toBeUndefined();
+    expect(parseOfficialSessionKey([])).toBeUndefined();
+    expect(parseOfficialSessionKey({ foo: { email: "a@b.c" } })).toBeUndefined();
+  });
+
+  it("reads the official Grok Build session key", () => {
+    expect(
+      parseOfficialSessionKey({
+        "https://auth.x.ai::client": {
+          auth_mode: "oidc",
+          key: "session-token-1",
+          expires_at: "2099-01-01T00:00:00.000Z",
+        },
+      }),
+    ).toBe("session-token-1");
+  });
+
+  it("prefers a still-valid session over an expired one", () => {
+    expect(
+      parseOfficialSessionKey({
+        expired: { key: "old-token", expires_at: "2000-01-01T00:00:00.000Z" },
+        live: { key: "live-token", expires_at: "2099-01-01T00:00:00.000Z" },
+      }),
+    ).toBe("live-token");
+  });
+
+  it("falls back to an expired key when nothing else is available", () => {
+    expect(
+      parseOfficialSessionKey({
+        expired: { key: "  stale-token  ", expires_at: "2000-01-01T00:00:00.000Z" },
+      }),
+    ).toBe("stale-token");
+  });
+});
+
+describe("readOfficialSessionKey", () => {
+  it("returns undefined when the file is missing or unreadable", () => {
+    expect(readOfficialSessionKey(path.join(os.tmpdir(), "grok-auth-missing.json"))).toBeUndefined();
+    const bad = writeTempAuth("not-json");
+    fs.writeFileSync(bad, "{");
+    expect(readOfficialSessionKey(bad)).toBeUndefined();
+  });
+
+  it("reads a session key from disk", () => {
+    const file = writeTempAuth({
+      "https://auth.x.ai::client": { key: "disk-token", expires_at: "2099-01-01T00:00:00.000Z" },
+    });
+    expect(readOfficialSessionKey(file)).toBe("disk-token");
+  });
+});

--- a/src/utils/session-auth.ts
+++ b/src/utils/session-auth.ts
@@ -1,0 +1,45 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+const AUTH_JSON_PATH = path.join(os.homedir(), ".grok", "auth.json");
+
+/**
+ * Read the official Grok Build session token from ~/.grok/auth.json.
+ * grok-kev can use this as a Bearer token against api.x.ai, so a console
+ * API key is not required when the official CLI is already signed in.
+ */
+export function parseOfficialSessionKey(data: unknown): string | undefined {
+  if (!data || typeof data !== "object" || Array.isArray(data)) return undefined;
+
+  const now = Date.now();
+  let fallback: string | undefined;
+  let bestLive: { key: string; expiresAt: number } | undefined;
+
+  for (const value of Object.values(data as Record<string, unknown>)) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) continue;
+
+    const entry = value as Record<string, unknown>;
+    const key = typeof entry.key === "string" ? entry.key.trim() : "";
+    if (!key) continue;
+
+    fallback ??= key;
+
+    const expiresAt = typeof entry.expires_at === "string" ? Date.parse(entry.expires_at) : Number.NaN;
+    if (!Number.isFinite(expiresAt) || expiresAt <= now) continue;
+    if (!bestLive || expiresAt >= bestLive.expiresAt) {
+      bestLive = { key, expiresAt };
+    }
+  }
+
+  return bestLive?.key ?? fallback;
+}
+
+export function readOfficialSessionKey(filePath = AUTH_JSON_PATH): string | undefined {
+  try {
+    if (!fs.existsSync(filePath)) return undefined;
+    return parseOfficialSessionKey(JSON.parse(fs.readFileSync(filePath, "utf-8")));
+  } catch {
+    return undefined;
+  }
+}

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -10,8 +10,10 @@ import type {
   LspSettings,
   NormalizedLspSettings,
 } from "../lsp/types";
+import { normalizeInstalledPlugins } from "../plugins/installed";
 import type { SuggesterSettings } from "../suggester/types";
 import type { AgentMode, ReasoningEffort } from "../types/index";
+import { readOfficialSessionKey } from "./session-auth";
 
 export type TelegramStreamingMode = "off" | "partial";
 export type SandboxMode = "off" | "shuru";
@@ -175,6 +177,7 @@ export interface UserSettings {
   payments?: PaymentSettings;
   modeModels?: Partial<Record<AgentMode, string>>;
   suggester?: SuggesterSettings;
+  plugins?: string[];
 }
 
 export interface ProjectSettings {
@@ -291,6 +294,7 @@ export function saveUserSettings(partial: Partial<UserSettings>): void {
           },
         }
       : {}),
+    ...(partial.plugins !== undefined ? { plugins: normalizeInstalledPlugins(partial.plugins) } : {}),
   };
 
   writeJson(USER_SETTINGS_PATH, next);
@@ -320,8 +324,18 @@ export function saveProjectSettings(partial: Partial<ProjectSettings>): void {
   });
 }
 
+export function loadInstalledPlugins(): string[] {
+  return normalizeInstalledPlugins(loadUserSettings().plugins);
+}
+
+export function saveInstalledPlugins(plugins: string[]): string[] {
+  const next = normalizeInstalledPlugins(plugins);
+  saveUserSettings({ plugins: next });
+  return next;
+}
+
 export function getApiKey(): string | undefined {
-  return process.env.GROK_API_KEY || loadUserSettings().apiKey;
+  return process.env.GROK_API_KEY || loadUserSettings().apiKey || readOfficialSessionKey();
 }
 
 export function getBaseURL(): string {

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -10,6 +10,7 @@ import type {
   LspSettings,
   NormalizedLspSettings,
 } from "../lsp/types";
+import type { SuggesterSettings } from "../suggester/types";
 import type { AgentMode, ReasoningEffort } from "../types/index";
 
 export type TelegramStreamingMode = "off" | "partial";
@@ -173,6 +174,7 @@ export interface UserSettings {
   hooks?: HooksConfig;
   payments?: PaymentSettings;
   modeModels?: Partial<Record<AgentMode, string>>;
+  suggester?: SuggesterSettings;
 }
 
 export interface ProjectSettings {
@@ -277,6 +279,15 @@ export function saveUserSettings(partial: Partial<UserSettings>): void {
               ...current.payments?.approval,
               ...partial.payments?.approval,
             },
+          },
+        }
+      : {}),
+    ...(partial.suggester !== undefined
+      ? {
+          suggester: {
+            ...current.suggester,
+            ...partial.suggester,
+            ...(partial.suggester.model !== undefined ? { model: normalizeModelId(partial.suggester.model) } : {}),
           },
         }
       : {}),


### PR DESCRIPTION
## Summary

Adds a first-class next-prompt suggester to the interactive TUI, ported from [pi-prompt-suggester](https://github.com/guwidoe/pi-prompt-suggester) by **Guido Witt-Dörring** (MIT).

This is a Grok CLI / OpenTUI rewrite, not a drop-in of the Pi extension. After each interactive turn it predicts the user's likely next prompt (auto-inserts by default), keeps a background project-intent seed, and records whether the user accepted or rewrote the guess.

Credit and license text for the original work are in `NOTICE.md`, `LICENSE`, `src/suggester/README.md`, and file headers.

## Attribution

- Original: https://github.com/guwidoe/pi-prompt-suggester
- Author: Guido Witt-Dörring
- License: MIT (Copyright 2026)

## Usage

- Runs automatically after each interactive turn (`/suggester` is status/settings only)
- `/suggester reseed`, `/suggester instruction set …`, `/suggester auto|ghost`
- Never auto-sends
- Headless `--prompt` is unchanged

## Test plan

- [x] `bun run typecheck`
- [x] `bunx vitest run src/suggester src/ui/slash-menu.test.ts`
- [ ] Interactive: finish a turn, confirm next prompt is filled
- [ ] `/suggester` shows seed/status
- [ ] `/suggester off` stops extra calls

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds background Grok API calls on every interactive turn (plus seeder runs) and new TUI input/key paths in the main prompt loop; failures are mostly silent but increase cost and surface area in `app.tsx`.
> 
> **Overview**
> Adds a **next-prompt suggester** to the interactive TUI: after each local turn it predicts a likely follow-up user message, optionally **auto-inserts** it into the empty editor (default), or shows it as a dim ghost with **Space/right** to accept and **Esc** to dismiss—never auto-sends.
> 
> The feature is a Grok CLI rewrite of **pi-prompt-suggester** (MIT attribution in `NOTICE.md`, `LICENSE`, and module headers). New `src/suggester/` implements a **two-stage pipeline**: a background **seeder** (read-only repo exploration via ls/find/grep/read, persisted `seed.json` under `~/.grok/prompt-suggester/`) and a per-turn **suggester** call (`grok-3-mini` by default) using turn context, intent seed, and **steering** when the user accepts or rewrites suggestions.
> 
> **`/suggester`** commands, slash-menu entry, and optional `suggester` block in `user-settings.json` control on/off, auto vs ghost, reseed, models, and custom instructions. `usePromptSuggester` wires turn completion, submit recording, and key handling into `app.tsx`. Headless `--prompt` mode is unchanged. `package.json` adds a `grok-dev` bin alias.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bff96b5df3e6ac71d107271afe6123ad055f350e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->